### PR TITLE
feat: Hetzner Cloud provider + cloud-init for Claw4All (T10/T11)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# openclaw-saas environment variables
+
+# Database
+DATABASE_URL=
+
+# Hetzner Cloud — used by Claw4All to provision VMs
+# Get your token at https://console.hetzner.cloud → Project → Security → API Tokens
+HETZNER_API_TOKEN=

--- a/apps/web/src/lib/providers/cloud-init.ts
+++ b/apps/web/src/lib/providers/cloud-init.ts
@@ -1,0 +1,97 @@
+/**
+ * Generate cloud-init user data for a Claw4All instance.
+ */
+
+export interface CloudInitOptions {
+  /** Auth token the sidecar uses to talk to the portal. */
+  sidecarToken: string;
+  /** Portal URL the instance phones home to on completion. */
+  portalUrl: string;
+  /** Instance ID for phone-home identification. */
+  instanceId: string;
+  /** Non-root username to create. Default: "claw" */
+  username?: string;
+  /** OpenClaw version/tag to install. Default: "latest" */
+  openclawVersion?: string;
+  /** Node.js major version. Default: 22 */
+  nodeVersion?: number;
+}
+
+export function generateCloudInit(opts: CloudInitOptions): string {
+  const user = opts.username ?? "claw";
+  const nodeVersion = opts.nodeVersion ?? 22;
+  const ocVersion = opts.openclawVersion ?? "latest";
+
+  return `#cloud-config
+# Claw4All instance provisioning — managed, do not edit
+
+users:
+  - name: ${user}
+    groups: sudo
+    shell: /bin/bash
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    ssh_authorized_keys: []
+
+package_update: true
+package_upgrade: true
+
+packages:
+  - ufw
+  - curl
+  - git
+  - unzip
+
+write_files:
+  - path: /etc/claw4all/sidecar.env
+    permissions: "0600"
+    content: |
+      SIDECAR_TOKEN=${opts.sidecarToken}
+      PORTAL_URL=${opts.portalUrl}
+      INSTANCE_ID=${opts.instanceId}
+
+runcmd:
+  # Firewall — allow only SSH + HTTPS + OpenClaw gateway
+  - ufw default deny incoming
+  - ufw default allow outgoing
+  - ufw allow 22/tcp
+  - ufw allow 443/tcp
+  - ufw allow 3000/tcp
+  - ufw --force enable
+
+  # Node.js via NodeSource
+  - curl -fsSL https://deb.nodesource.com/setup_${nodeVersion}.x | bash -
+  - apt-get install -y nodejs
+
+  # OpenClaw
+  - npm install -g openclaw@${ocVersion}
+
+  # Sidecar agent
+  - |
+    cat > /etc/systemd/system/openclaw-sidecar.service <<'EOF'
+    [Unit]
+    Description=OpenClaw Sidecar Agent
+    After=network-online.target
+    Wants=network-online.target
+
+    [Service]
+    Type=simple
+    User=${user}
+    EnvironmentFile=/etc/claw4all/sidecar.env
+    ExecStart=/usr/bin/openclaw gateway start
+    Restart=always
+    RestartSec=5
+
+    [Install]
+    WantedBy=multi-user.target
+    EOF
+  - systemctl daemon-reload
+  - systemctl enable --now openclaw-sidecar
+
+  # Phone home
+  - |
+    curl -sf -X POST "${opts.portalUrl}/api/instances/${opts.instanceId}/phone-home" \\
+      -H "Authorization: Bearer ${opts.sidecarToken}" \\
+      -H "Content-Type: application/json" \\
+      -d '{"status":"ready"}'
+`;
+}

--- a/apps/web/src/lib/providers/hetzner.ts
+++ b/apps/web/src/lib/providers/hetzner.ts
@@ -1,0 +1,101 @@
+import type {
+  CloudProvider,
+  CreateServerOptions,
+  ServerInfo,
+} from "./types";
+
+const API_BASE = "https://api.hetzner.cloud/v1";
+const DEFAULT_SERVER_TYPE = "cx22"; // 2 vCPU, 4 GB RAM, ~€3.99/mo
+const DEFAULT_REGION = "nbg1"; // Nuremberg
+
+function getToken(): string {
+  const token = process.env.HETZNER_API_TOKEN;
+  if (!token) throw new Error("HETZNER_API_TOKEN environment variable is not set");
+  return token;
+}
+
+async function hetznerFetch<T = unknown>(
+  path: string,
+  init?: RequestInit,
+): Promise<T> {
+  const res = await fetch(`${API_BASE}${path}`, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${getToken()}`,
+      "Content-Type": "application/json",
+      ...init?.headers,
+    },
+  });
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`Hetzner API ${res.status}: ${body}`);
+  }
+
+  if (res.status === 204) return undefined as T;
+  return res.json() as Promise<T>;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function toServerInfo(s: any): ServerInfo {
+  return {
+    id: String(s.id),
+    name: s.name,
+    status: s.status,
+    publicIpv4: s.public_net?.ipv4?.ip ?? null,
+    publicIpv6: s.public_net?.ipv6?.ip ?? null,
+    region: s.datacenter?.name ?? "",
+    serverType: s.server_type?.name ?? "",
+    createdAt: s.created,
+    labels: s.labels ?? {},
+  };
+}
+
+export class HetznerProvider implements CloudProvider {
+  async createServer(options: CreateServerOptions): Promise<ServerInfo> {
+    const data = await hetznerFetch<{ server: unknown }>("/servers", {
+      method: "POST",
+      body: JSON.stringify({
+        name: options.name,
+        server_type: options.serverType ?? DEFAULT_SERVER_TYPE,
+        location: options.region ?? DEFAULT_REGION,
+        image: "ubuntu-24.04",
+        user_data: options.cloudInit ?? undefined,
+        labels: options.labels ?? { managed_by: "claw4all" },
+        start_after_create: true,
+      }),
+    });
+    return toServerInfo(data.server);
+  }
+
+  async destroyServer(serverId: string): Promise<void> {
+    await hetznerFetch(`/servers/${serverId}`, { method: "DELETE" });
+  }
+
+  async getServer(serverId: string): Promise<ServerInfo> {
+    const data = await hetznerFetch<{ server: unknown }>(`/servers/${serverId}`);
+    return toServerInfo(data.server);
+  }
+
+  async listServers(labelSelector?: string): Promise<ServerInfo[]> {
+    const params = new URLSearchParams();
+    if (labelSelector) params.set("label_selector", labelSelector);
+    const qs = params.toString();
+    const data = await hetznerFetch<{ servers: unknown[] }>(
+      `/servers${qs ? `?${qs}` : ""}`,
+    );
+    return data.servers.map(toServerInfo);
+  }
+
+  async powerOn(serverId: string): Promise<void> {
+    await hetznerFetch(`/servers/${serverId}/actions/poweron`, {
+      method: "POST",
+    });
+  }
+
+  async powerOff(serverId: string): Promise<void> {
+    await hetznerFetch(`/servers/${serverId}/actions/poweroff`, {
+      method: "POST",
+    });
+  }
+}

--- a/apps/web/src/lib/providers/index.ts
+++ b/apps/web/src/lib/providers/index.ts
@@ -1,0 +1,4 @@
+export { HetznerProvider } from "./hetzner";
+export { generateCloudInit } from "./cloud-init";
+export type { CloudProvider, ServerInfo, CreateServerOptions } from "./types";
+export type { CloudInitOptions } from "./cloud-init";

--- a/apps/web/src/lib/providers/types.ts
+++ b/apps/web/src/lib/providers/types.ts
@@ -1,0 +1,33 @@
+/**
+ * Cloud provider abstraction for Claw4All.
+ * Implement this interface to add DigitalOcean, Vultr, etc.
+ */
+
+export interface ServerInfo {
+  id: string;
+  name: string;
+  status: string;
+  publicIpv4: string | null;
+  publicIpv6: string | null;
+  region: string;
+  serverType: string;
+  createdAt: string;
+  labels: Record<string, string>;
+}
+
+export interface CreateServerOptions {
+  name: string;
+  region?: string;
+  serverType?: string;
+  cloudInit?: string;
+  labels?: Record<string, string>;
+}
+
+export interface CloudProvider {
+  createServer(options: CreateServerOptions): Promise<ServerInfo>;
+  destroyServer(serverId: string): Promise<void>;
+  getServer(serverId: string): Promise<ServerInfo>;
+  listServers(labelSelector?: string): Promise<ServerInfo[]>;
+  powerOn(serverId: string): Promise<void>;
+  powerOff(serverId: string): Promise<void>;
+}


### PR DESCRIPTION
## What

Adds the Hetzner Cloud API client and cloud-init provisioning for Claw4All managed VMs.

### Files added

- **`apps/web/src/lib/providers/types.ts`** — `CloudProvider` interface + `ServerInfo`/`CreateServerOptions` types. Provider-agnostic so we can add DO/Vultr later.
- **`apps/web/src/lib/providers/hetzner.ts`** — `HetznerProvider` implementing all 6 methods (create/destroy/get/list/powerOn/powerOff) via Hetzner Cloud API v1. Uses native fetch, no deps.
- **`apps/web/src/lib/providers/cloud-init.ts`** — Generates cloud-init YAML that provisions a VM with: Node.js, OpenClaw, sidecar agent (systemd), UFW firewall (22/443/3000), non-root user, and phone-home callback.
- **`apps/web/src/lib/providers/index.ts`** — Barrel export.
- **`.env.example`** — Added `HETZNER_API_TOKEN`.

### Defaults
- Server type: `cx22` (2 vCPU, 4 GB RAM, ~€3.99/mo)
- Region: `nbg1` (Nuremberg), configurable

### Tasks
- T10: Hetzner API client ✅
- T11: Cloud-init template ✅