### PR TITLE
feat: Sidecar agent for user VMs (T13+T14)

### DIFF
--- a/apps/sidecar/package.json
+++ b/apps/sidecar/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@handsoff/sidecar",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Lightweight sidecar agent for OpenClaw user VMs",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "dev": "tsx src/index.ts"
+  },
+  "dependencies": {
+    "express": "^4.21.0"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "@types/node": "^20.11.0",
+    "tsx": "^4.7.0",
+    "typescript": "^5.3.3"
+  }
+}

--- a/apps/sidecar/src/index.ts
+++ b/apps/sidecar/src/index.ts
@@ -1,0 +1,24 @@
+import express from 'express';
+import { authMiddleware } from './middleware/auth';
+import healthRouter from './routes/health';
+import openclawRouter from './routes/openclaw';
+import heartbeatRouter from './routes/heartbeat';
+
+const app = express();
+const PORT = parseInt(process.env.PORT || '8787', 10);
+
+app.use(express.json());
+
+// Auth on all routes
+app.use(authMiddleware);
+
+// Routes
+app.use(healthRouter);
+app.use(openclawRouter);
+app.use(heartbeatRouter);
+
+app.listen(PORT, '0.0.0.0', () => {
+  console.log(`[sidecar] listening on port ${PORT}`);
+});
+
+export default app;

--- a/apps/sidecar/src/middleware/auth.ts
+++ b/apps/sidecar/src/middleware/auth.ts
@@ -1,0 +1,17 @@
+import { Request, Response, NextFunction } from 'express';
+
+export function authMiddleware(req: Request, res: Response, next: NextFunction): void {
+  const token = process.env.SIDECAR_TOKEN;
+  if (!token) {
+    res.status(500).json({ error: 'SIDECAR_TOKEN not configured' });
+    return;
+  }
+
+  const auth = req.headers.authorization;
+  if (!auth || !auth.startsWith('Bearer ') || auth.slice(7) !== token) {
+    res.status(401).json({ error: 'Unauthorized' });
+    return;
+  }
+
+  next();
+}

--- a/apps/sidecar/src/routes/health.ts
+++ b/apps/sidecar/src/routes/health.ts
@@ -1,0 +1,77 @@
+import { Router, Request, Response } from 'express';
+import os from 'os';
+import { exec } from 'child_process';
+import { promisify } from 'util';
+
+const execAsync = promisify(exec);
+const router = Router();
+
+async function getDiskUsage(): Promise<{ total: string; used: string; available: string; usePercent: string }> {
+  try {
+    const { stdout } = await execAsync("df -h / | tail -1 | awk '{print $2,$3,$4,$5}'");
+    const [total, used, available, usePercent] = stdout.trim().split(/\s+/);
+    return { total, used, available, usePercent };
+  } catch {
+    return { total: 'unknown', used: 'unknown', available: 'unknown', usePercent: 'unknown' };
+  }
+}
+
+async function getOpenclawVersion(): Promise<string> {
+  try {
+    const { stdout } = await execAsync('openclaw --version');
+    return stdout.trim();
+  } catch {
+    return 'unknown';
+  }
+}
+
+async function isOpenclawRunning(): Promise<boolean> {
+  try {
+    await execAsync('pgrep -f openclaw');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function getCpuUsage(): { model: string; cores: number; loadAvg: number[] } {
+  const cpus = os.cpus();
+  return {
+    model: cpus[0]?.model || 'unknown',
+    cores: cpus.length,
+    loadAvg: os.loadavg(),
+  };
+}
+
+function getMemoryUsage(): { totalMB: number; freeMB: number; usedPercent: number } {
+  const total = os.totalmem();
+  const free = os.freemem();
+  const used = total - free;
+  return {
+    totalMB: Math.round(total / 1024 / 1024),
+    freeMB: Math.round(free / 1024 / 1024),
+    usedPercent: Math.round((used / total) * 100),
+  };
+}
+
+router.get('/health', async (_req: Request, res: Response) => {
+  const [disk, openclawVersion, openclawRunning] = await Promise.all([
+    getDiskUsage(),
+    getOpenclawVersion(),
+    isOpenclawRunning(),
+  ]);
+
+  res.json({
+    status: 'ok',
+    uptime: process.uptime(),
+    cpu: getCpuUsage(),
+    memory: getMemoryUsage(),
+    disk,
+    openclaw: {
+      version: openclawVersion,
+      running: openclawRunning,
+    },
+  });
+});
+
+export default router;

--- a/apps/sidecar/src/routes/heartbeat.ts
+++ b/apps/sidecar/src/routes/heartbeat.ts
@@ -1,0 +1,73 @@
+import { Router, Request, Response } from 'express';
+
+const router = Router();
+
+let heartbeatInterval: NodeJS.Timeout | null = null;
+let portalUrl: string | null = null;
+let vmId: string | null = null;
+
+async function collectHealthData() {
+  const os = await import('os');
+  const { exec } = await import('child_process');
+  const { promisify } = await import('util');
+  const execAsync = promisify(exec);
+
+  let openclawRunning = false;
+  try {
+    await execAsync('pgrep -f openclaw');
+    openclawRunning = true;
+  } catch {}
+
+  const total = os.totalmem();
+  const free = os.freemem();
+
+  return {
+    uptime: process.uptime(),
+    cpu: { cores: os.cpus().length, loadAvg: os.loadavg() },
+    memory: {
+      totalMB: Math.round(total / 1024 / 1024),
+      freeMB: Math.round(free / 1024 / 1024),
+      usedPercent: Math.round(((total - free) / total) * 100),
+    },
+    openclaw: { running: openclawRunning },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+async function sendHeartbeat() {
+  if (!portalUrl || !vmId) return;
+
+  try {
+    const health = await collectHealthData();
+    await fetch(`${portalUrl}/api/heartbeat`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ vmId, ...health }),
+    });
+  } catch (err) {
+    console.error('[heartbeat] Failed to phone home:', (err as Error).message);
+  }
+}
+
+router.post('/heartbeat/register', (req: Request, res: Response) => {
+  const { url, id } = req.body;
+
+  if (!url || !id) {
+    res.status(400).json({ error: 'Missing url or id in body' });
+    return;
+  }
+
+  portalUrl = url;
+  vmId = id;
+
+  // Clear existing interval if re-registering
+  if (heartbeatInterval) clearInterval(heartbeatInterval);
+
+  // Send immediately, then every 60s
+  sendHeartbeat();
+  heartbeatInterval = setInterval(sendHeartbeat, 60_000);
+
+  res.json({ status: 'registered', portalUrl, vmId, intervalMs: 60_000 });
+});
+
+export default router;

--- a/apps/sidecar/src/routes/openclaw.ts
+++ b/apps/sidecar/src/routes/openclaw.ts
@@ -1,0 +1,64 @@
+import { Router, Request, Response } from 'express';
+import { exec } from 'child_process';
+import { promisify } from 'util';
+
+const execAsync = promisify(exec);
+const router = Router();
+
+async function getOpenclawStatus(): Promise<{ running: boolean; version: string; uptime: string }> {
+  let running = false;
+  let version = 'unknown';
+  let uptime = 'unknown';
+
+  try {
+    const { stdout } = await execAsync('openclaw --version');
+    version = stdout.trim();
+  } catch {}
+
+  try {
+    await execAsync('systemctl is-active openclaw');
+    running = true;
+  } catch {
+    // Also try pgrep as fallback
+    try {
+      await execAsync('pgrep -f openclaw');
+      running = true;
+    } catch {}
+  }
+
+  if (running) {
+    try {
+      const { stdout } = await execAsync("systemctl show openclaw --property=ActiveEnterTimestamp --value");
+      uptime = stdout.trim() || 'unknown';
+    } catch {}
+  }
+
+  return { running, version, uptime };
+}
+
+router.get('/openclaw/status', async (_req: Request, res: Response) => {
+  const status = await getOpenclawStatus();
+  res.json(status);
+});
+
+router.post('/openclaw/restart', async (_req: Request, res: Response) => {
+  try {
+    await execAsync('systemctl restart openclaw');
+    res.json({ status: 'restarted' });
+  } catch (err: any) {
+    res.status(500).json({ error: 'Failed to restart openclaw', details: err.message });
+  }
+});
+
+router.post('/openclaw/update', async (_req: Request, res: Response) => {
+  try {
+    await execAsync('npm install -g openclaw@latest');
+    await execAsync('systemctl restart openclaw');
+    const { stdout } = await execAsync('openclaw --version');
+    res.json({ status: 'updated', version: stdout.trim() });
+  } catch (err: any) {
+    res.status(500).json({ error: 'Failed to update openclaw', details: err.message });
+  }
+});
+
+export default router;

--- a/apps/sidecar/tsconfig.json
+++ b/apps/sidecar/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "lib": ["ES2022"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Sidecar Agent

Lightweight Express/TypeScript HTTP service that runs on each user's VM (port 8787).

### Endpoints
| Method | Path | Description |
|--------|------|-------------|
| GET | /health | System metrics (cpu, memory, disk, openclaw status, uptime) |
| GET | /openclaw/status | OpenClaw running state, version, uptime |
| POST | /openclaw/restart | Restart openclaw systemd service |
| POST | /openclaw/update | Update openclaw to latest + restart |
| POST | /heartbeat/register | Register portal URL; starts 60s periodic heartbeat |

### Auth
All routes require `Authorization: Bearer <SIDECAR_TOKEN>` header.

### Structure
```
apps/sidecar/
├── package.json
├── tsconfig.json
└── src/
    ├── index.ts
    ├── middleware/auth.ts
    └── routes/
        ├── health.ts
        ├── heartbeat.ts
        └── openclaw.ts
```

### Run
```bash
cd apps/sidecar
npm install
SIDECAR_TOKEN=secret npm run dev
```