### PR TITLE
feat: post-signup onboarding flow (T21, T22, T26)

### DIFF
--- a/apps/web/src/app/onboarding/connect/page.tsx
+++ b/apps/web/src/app/onboarding/connect/page.tsx
@@ -1,0 +1,67 @@
+import { redirect } from 'next/navigation';
+import { createClient } from '@/lib/supabase/server';
+import Link from 'next/link';
+
+const APPS = [
+  { name: 'WhatsApp', icon: '💬', description: 'Chat on WhatsApp' },
+  { name: 'Telegram', icon: '✈️', description: 'Chat on Telegram' },
+  { name: 'Signal', icon: '🔒', description: 'Chat on Signal' },
+  { name: 'Discord', icon: '🎮', description: 'Chat on Discord' },
+  { name: 'Slack', icon: '💼', description: 'Chat on Slack' },
+];
+
+export default async function ConnectPage() {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect('/auth/signin');
+  }
+
+  return (
+    <div className="min-h-screen bg-slate-950 flex items-center justify-center px-4">
+      <div className="max-w-lg w-full space-y-8">
+        <div className="text-center space-y-3">
+          <h1 className="text-3xl font-bold text-white">
+            Connect a chat app
+          </h1>
+          <p className="text-slate-400">
+            Pick your favorite way to talk to your assistant.
+          </p>
+        </div>
+
+        <div className="space-y-3">
+          {APPS.map((app) => (
+            <div
+              key={app.name}
+              className="flex items-center justify-between p-4 bg-slate-900 rounded-xl border border-slate-800"
+            >
+              <div className="flex items-center gap-3">
+                <span className="text-2xl">{app.icon}</span>
+                <div>
+                  <p className="text-white font-medium">{app.name}</p>
+                  <p className="text-slate-500 text-sm">{app.description}</p>
+                </div>
+              </div>
+              <button
+                disabled
+                className="px-4 py-2 bg-slate-800 text-slate-500 text-sm rounded-lg cursor-not-allowed"
+              >
+                Coming soon
+              </button>
+            </div>
+          ))}
+        </div>
+
+        <div className="text-center">
+          <Link
+            href="/dashboard"
+            className="text-slate-400 hover:text-slate-200 transition-colors text-sm"
+          >
+            Skip for now →
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/onboarding/launch-button.tsx
+++ b/apps/web/src/app/onboarding/launch-button.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { useRouter } from 'next/navigation';
+
+const STEPS = [
+  'Creating your private cloud space...',
+  'Installing your AI assistant...',
+  'Almost ready...',
+];
+
+export function LaunchButton() {
+  const router = useRouter();
+  const [state, setState] = useState<'idle' | 'launching' | 'error'>('idle');
+  const [step, setStep] = useState(0);
+  const [errorMsg, setErrorMsg] = useState('');
+
+  const launch = useCallback(async () => {
+    setState('launching');
+    setStep(0);
+    setErrorMsg('');
+
+    try {
+      const res = await fetch('/api/launch', { method: 'POST' });
+      if (!res.ok) throw new Error('Launch failed');
+    } catch {
+      setState('error');
+      setErrorMsg('Something went wrong. Let\u2019s try that again.');
+      return;
+    }
+
+    // Start polling
+    const poll = setInterval(async () => {
+      try {
+        const res = await fetch('/api/assistant/status');
+        if (!res.ok) return;
+        const data = await res.json();
+        if (data.status === 'active') {
+          clearInterval(poll);
+          router.push('/onboarding/ready');
+        }
+      } catch {
+        // keep polling
+      }
+    }, 3000);
+
+    // Animate steps
+    const stepTimer1 = setTimeout(() => setStep(1), 5000);
+    const stepTimer2 = setTimeout(() => setStep(2), 12000);
+
+    // Timeout after 90s
+    const timeout = setTimeout(() => {
+      clearInterval(poll);
+      setState('error');
+      setErrorMsg('This is taking longer than expected. Let\u2019s try again.');
+    }, 90000);
+
+    return () => {
+      clearInterval(poll);
+      clearTimeout(stepTimer1);
+      clearTimeout(stepTimer2);
+      clearTimeout(timeout);
+    };
+  }, [router]);
+
+  if (state === 'idle') {
+    return (
+      <button
+        onClick={launch}
+        className="w-full py-4 px-8 bg-purple-600 hover:bg-purple-500 text-white text-lg font-semibold rounded-xl transition-colors duration-200 shadow-lg shadow-purple-600/20"
+      >
+        Launch my assistant 🚀
+      </button>
+    );
+  }
+
+  if (state === 'error') {
+    return (
+      <div className="space-y-4">
+        <p className="text-red-400">{errorMsg}</p>
+        <button
+          onClick={launch}
+          className="w-full py-4 px-8 bg-purple-600 hover:bg-purple-500 text-white text-lg font-semibold rounded-xl transition-colors duration-200"
+        >
+          Try again
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex justify-center">
+        <div className="h-8 w-8 border-3 border-purple-500 border-t-transparent rounded-full animate-spin" />
+      </div>
+      <p className="text-lg text-white font-medium">
+        Setting up your assistant<span className="animate-pulse">...</span>
+      </p>
+      <div className="space-y-3">
+        {STEPS.map((text, i) => (
+          <div
+            key={i}
+            className={`flex items-center gap-3 transition-opacity duration-500 ${
+              i <= step ? 'opacity-100' : 'opacity-30'
+            }`}
+          >
+            <span className={`text-sm ${
+              i < step ? 'text-green-400' : i === step ? 'text-purple-400' : 'text-slate-500'
+            }`}>
+              {i < step ? '✓' : i === step ? '●' : '○'}
+            </span>
+            <span className={`text-sm ${
+              i <= step ? 'text-slate-200' : 'text-slate-500'
+            }`}>
+              {text}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/onboarding/page.tsx
+++ b/apps/web/src/app/onboarding/page.tsx
@@ -1,0 +1,38 @@
+import { Suspense } from 'react';
+import { redirect } from 'next/navigation';
+import { createClient } from '@/lib/supabase/server';
+import { LaunchButton } from './launch-button';
+
+export default async function OnboardingPage() {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect('/auth/signin');
+  }
+
+  return (
+    <div className="min-h-screen bg-slate-950 flex items-center justify-center px-4">
+      <div className="max-w-lg w-full text-center space-y-8">
+        <div className="space-y-4">
+          <h1 className="text-4xl font-bold text-white">
+            Welcome aboard! 👋
+          </h1>
+          <p className="text-lg text-slate-300">
+            We&apos;re about to set up your personal AI assistant.
+            This takes about 60 seconds.
+          </p>
+          <p className="text-slate-400">
+            Your assistant will live in its own private space — just for you.
+          </p>
+        </div>
+
+        <Suspense fallback={
+          <div className="h-14 bg-slate-800 rounded-xl animate-pulse" />
+        }>
+          <LaunchButton />
+        </Suspense>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/onboarding/ready/page.tsx
+++ b/apps/web/src/app/onboarding/ready/page.tsx
@@ -1,0 +1,41 @@
+import { redirect } from 'next/navigation';
+import { createClient } from '@/lib/supabase/server';
+import Link from 'next/link';
+
+export default async function ReadyPage() {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect('/auth/signin');
+  }
+
+  return (
+    <div className="min-h-screen bg-slate-950 flex items-center justify-center px-4">
+      <div className="max-w-lg w-full text-center space-y-8">
+        <div className="text-6xl">🎉</div>
+        <h1 className="text-4xl font-bold text-white">
+          Your assistant is ready!
+        </h1>
+        <p className="text-lg text-slate-300">
+          Say hi — connect your favorite chat app and start talking to your new assistant.
+        </p>
+
+        <div className="space-y-4">
+          <Link
+            href="/onboarding/connect"
+            className="block w-full py-4 px-8 bg-purple-600 hover:bg-purple-500 text-white text-lg font-semibold rounded-xl transition-colors duration-200 shadow-lg shadow-purple-600/20"
+          >
+            Connect a chat app 💬
+          </Link>
+          <Link
+            href="/dashboard"
+            className="block text-slate-400 hover:text-slate-200 transition-colors text-sm"
+          >
+            Go to dashboard →
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Onboarding Flow

Builds the post-signup onboarding experience:

### Pages
- **`/onboarding`** — Welcome page with "Launch my assistant" button. Auth-protected, redirects to signin if not logged in.
- **`/onboarding/ready`** — Celebration screen after assistant is provisioned. CTA to connect messaging or go to dashboard.
- **`/onboarding/connect`** — Messaging app connection cards (WhatsApp, Telegram, Signal, Discord, Slack). All "Coming soon" for now.

### Launch Button (client component)
- Calls `POST /api/launch` on click
- Shows animated progress steps (Creating cloud space → Installing assistant → Almost ready)
- Polls `GET /api/assistant/status` every 3s
- Redirects to /onboarding/ready when status=active
- Error state with retry button, 90s timeout

### Design
- Dark theme (slate-950/900) matching existing site
- Purple accent buttons
- Warm, friendly copy — zero tech jargon
- CSS-only animations (no extra deps)

Closes T21, T22, T26