### PR TITLE
feat: free-tier scheduler (8h/day VM window)

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -14,3 +14,6 @@ HETZNER_API_TOKEN=your-hetzner-token
 
 # App
 NEXT_PUBLIC_APP_URL=http://localhost:3000
+
+# Cron
+CRON_SECRET=your-cron-secret

--- a/apps/web/src/app/api/cron/scheduler/README.md
+++ b/apps/web/src/app/api/cron/scheduler/README.md
@@ -1,0 +1,30 @@
+# Free Tier Scheduler
+
+Cron endpoint that manages free-tier VM uptime.
+
+## How it works
+
+- Runs every 15 minutes via Vercel Cron (`GET /api/cron/scheduler`)
+- Queries all free-tier assistants with `active` or `suspended` status
+- For each assistant, checks if the current time falls within their **8-hour active window** (default: 8 AM – 4 PM in the user's timezone)
+- **Outside window + active** → suspends the VM
+- **Within window + suspended** → resumes the VM
+- Paid tiers are excluded — they run 24/7
+
+## Configuration
+
+Set `CRON_SECRET` in your environment variables. The endpoint requires it as a Bearer token in the `Authorization` header:
+
+```
+Authorization: Bearer <your-cron-secret>
+```
+
+Vercel Cron automatically sends this header when `CRON_SECRET` is set in the project's environment variables.
+
+## Tier behavior
+
+| Tier    | Daily uptime | Scheduling |
+|---------|-------------|------------|
+| Free    | 8h/day      | 8am–4pm user timezone |
+| Starter | 24/7        | Always on |
+| Pro     | 24/7        | Always on |

--- a/apps/web/src/app/api/cron/scheduler/route.ts
+++ b/apps/web/src/app/api/cron/scheduler/route.ts
@@ -1,0 +1,67 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { suspendAssistant, resumeAssistant } from '@/lib/vm/lifecycle';
+import { isWithinActiveWindow } from '@/lib/scheduler/free-tier';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET /api/cron/scheduler
+ *
+ * Called every 15 minutes by Vercel Cron (or an external scheduler).
+ * Suspends free-tier VMs outside their 8h active window and resumes
+ * them when the window opens again.
+ */
+export async function GET(request: Request) {
+  // Verify cron secret
+  const authHeader = request.headers.get('authorization');
+  const cronSecret = process.env.CRON_SECRET;
+
+  if (!cronSecret || authHeader !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const supabase: any = await createClient();
+
+  // Fetch all free-tier assistants that have a VM (active or suspended)
+  const { data: assistants, error } = await supabase
+    .from('assistants')
+    .select('id, status, user_id, timezone')
+    .in('status', ['active', 'suspended'])
+    .eq('tier', 'free');
+
+  if (error) {
+    console.error('[scheduler] Failed to query assistants:', error.message);
+    return NextResponse.json({ error: 'Database query failed' }, { status: 500 });
+  }
+
+  const results: { id: string; action: string }[] = [];
+  const errors: { id: string; error: string }[] = [];
+
+  for (const assistant of assistants ?? []) {
+    const timezone = assistant.timezone ?? 'America/New_York';
+    const withinWindow = isWithinActiveWindow(timezone);
+
+    try {
+      if (!withinWindow && assistant.status === 'active') {
+        await suspendAssistant(assistant.id);
+        results.push({ id: assistant.id, action: 'suspended' });
+      } else if (withinWindow && assistant.status === 'suspended') {
+        await resumeAssistant(assistant.id);
+        results.push({ id: assistant.id, action: 'resumed' });
+      }
+    } catch (err: any) {
+      console.error(`[scheduler] Error processing ${assistant.id}:`, err.message);
+      errors.push({ id: assistant.id, error: err.message });
+    }
+  }
+
+  return NextResponse.json({
+    ok: true,
+    processed: (assistants ?? []).length,
+    actions: results,
+    errors,
+    timestamp: new Date().toISOString(),
+  });
+}

--- a/apps/web/src/lib/scheduler/free-tier.ts
+++ b/apps/web/src/lib/scheduler/free-tier.ts
@@ -1,0 +1,154 @@
+/**
+ * Free-tier scheduling logic.
+ *
+ * Free-tier assistants get an 8-hour active window per day
+ * (default 08:00–16:00 in the user's timezone). Outside that
+ * window the VM is suspended to save resources.
+ */
+
+const DEFAULT_START_HOUR = 8; // 8 AM
+const DEFAULT_END_HOUR = 16; // 4 PM
+const WINDOW_HOURS = DEFAULT_END_HOUR - DEFAULT_START_HOUR; // 8
+
+export interface ActiveWindow {
+  startHour: number;
+  endHour: number;
+  windowHours: number;
+}
+
+/**
+ * Return the active window definition for a timezone.
+ * Currently every timezone gets the same 8am-4pm window;
+ * this is the extension point if per-user customisation is added later.
+ */
+export function getActiveWindow(_timezone: string): ActiveWindow {
+  return {
+    startHour: DEFAULT_START_HOUR,
+    endHour: DEFAULT_END_HOUR,
+    windowHours: WINDOW_HOURS,
+  };
+}
+
+/** Get the current hour (0-23) in the given IANA timezone. */
+function currentHourIn(timezone: string): number {
+  const now = new Date();
+  const parts = new Intl.DateTimeFormat('en-US', {
+    hour: 'numeric',
+    hour12: false,
+    timeZone: timezone,
+  }).formatToParts(now);
+  const hourPart = parts.find((p) => p.type === 'hour');
+  return parseInt(hourPart?.value ?? '0', 10);
+}
+
+/** Get a full Date representing "now" in the given timezone (as local fields). */
+function nowInTimezone(timezone: string): { hour: number; date: Date } {
+  const now = new Date();
+  const formatter = new Intl.DateTimeFormat('en-US', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+    timeZone: timezone,
+  });
+  const hour = currentHourIn(timezone);
+  return { hour, date: now };
+}
+
+/**
+ * Is the current time within the 8h active window for this timezone?
+ */
+export function isWithinActiveWindow(timezone: string): boolean {
+  const { startHour, endHour } = getActiveWindow(timezone);
+  const hour = currentHourIn(timezone);
+  return hour >= startHour && hour < endHour;
+}
+
+/**
+ * Get the next start time (as a Date) for the active window.
+ * If currently before today's window, returns today's start.
+ * If currently within or after the window, returns tomorrow's start.
+ */
+export function getNextStartTime(timezone: string): Date {
+  const { startHour } = getActiveWindow(timezone);
+  const hour = currentHourIn(timezone);
+
+  // Build a date string in the timezone, then convert
+  const now = new Date();
+  const tzDate = new Intl.DateTimeFormat('en-CA', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    timeZone: timezone,
+  }).format(now); // YYYY-MM-DD
+
+  // Start with today's start time
+  const target = new Date(`${tzDate}T${String(startHour).padStart(2, '0')}:00:00`);
+
+  // Approximate: get offset by comparing
+  const offsetMs = now.getTime() - new Date(
+    new Intl.DateTimeFormat('en-CA', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+      hour12: false,
+      timeZone: timezone,
+    }).format(now).replace(', ', 'T'),
+  ).getTime();
+
+  const result = new Date(target.getTime() + offsetMs);
+
+  // If we're already past the start hour, advance to tomorrow
+  if (hour >= startHour) {
+    result.setTime(result.getTime() + 24 * 60 * 60 * 1000);
+  }
+
+  return result;
+}
+
+/**
+ * Get the next stop time (as a Date) for the active window.
+ * If currently before the end hour, returns today's end.
+ * If currently at or after end hour, returns tomorrow's end.
+ */
+export function getNextStopTime(timezone: string): Date {
+  const { endHour } = getActiveWindow(timezone);
+  const hour = currentHourIn(timezone);
+
+  const now = new Date();
+  const tzDate = new Intl.DateTimeFormat('en-CA', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    timeZone: timezone,
+  }).format(now);
+
+  const target = new Date(`${tzDate}T${String(endHour).padStart(2, '0')}:00:00`);
+
+  const offsetMs = now.getTime() - new Date(
+    new Intl.DateTimeFormat('en-CA', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+      hour12: false,
+      timeZone: timezone,
+    }).format(now).replace(', ', 'T'),
+  ).getTime();
+
+  const result = new Date(target.getTime() + offsetMs);
+
+  if (hour >= endHour) {
+    result.setTime(result.getTime() + 24 * 60 * 60 * 1000);
+  }
+
+  return result;
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "crons": [
+    {
+      "path": "/api/cron/scheduler",
+      "schedule": "*/15 * * * *"
+    }
+  ]
+}


### PR DESCRIPTION
## T20: Free Tier Scheduler

Adds a cron-driven scheduler that enforces the free-tier 8h/day VM limit.

### What's included

- **`lib/scheduler/free-tier.ts`** — Core logic: determines if current time is within the user's 8h active window (default 8am–4pm in their timezone)
- **`/api/cron/scheduler`** — Cron endpoint (every 15min via Vercel Cron): suspends free-tier VMs outside the window, resumes them when the window opens
- **`vercel.json`** — Cron configuration
- **`CRON_SECRET`** added to `.env.example`

### How it works

1. Vercel Cron hits `GET /api/cron/scheduler` every 15 minutes
2. Endpoint verifies `CRON_SECRET` Bearer token
3. Queries all free-tier assistants with active/suspended status
4. For each: checks timezone-aware active window
5. Suspends active VMs outside window, resumes suspended VMs inside window

Paid tiers are unaffected (always-on).