### PR TITLE
feat: Skill Library UI (T33 + T34)

### DIFF
--- a/apps/web/src/app/dashboard/skills/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/skills/[id]/page.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { useParams } from "next/navigation";
+import { getSkillById, TIER_LABELS, type SkillTier } from "@/lib/skills/catalog";
+
+const TIER_COLORS: Record<SkillTier, string> = {
+  free: "bg-emerald-500/20 text-emerald-400 border-emerald-500/30",
+  starter: "bg-blue-500/20 text-blue-400 border-blue-500/30",
+  pro: "bg-purple-500/20 text-purple-400 border-purple-500/30",
+};
+
+export default function SkillDetailPage() {
+  const params = useParams();
+  const skill = getSkillById(params.id as string);
+  const [enabled, setEnabled] = useState(false);
+
+  const userTier: SkillTier = "free";
+
+  if (!skill) {
+    return (
+      <div className="min-h-screen bg-gray-950 text-gray-100 flex items-center justify-center">
+        <div className="text-center">
+          <p className="text-2xl mb-4">🤷</p>
+          <p className="text-gray-400 mb-4">Skill not found</p>
+          <Link href="/dashboard/skills" className="text-blue-400 hover:text-blue-300">
+            ← Back to Skill Library
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  const locked = skill.tier !== "free" && userTier === "free";
+
+  return (
+    <div className="min-h-screen bg-gray-950 text-gray-100 px-4 py-8 sm:px-6 lg:px-8 max-w-3xl mx-auto">
+      {/* Back link */}
+      <Link
+        href="/dashboard/skills"
+        className="text-sm text-gray-500 hover:text-gray-300 mb-6 inline-block"
+      >
+        ← Back to Skill Library
+      </Link>
+
+      {/* Header */}
+      <div className="flex items-start gap-4 mb-8">
+        <span className="text-5xl">{skill.icon}</span>
+        <div className="flex-1">
+          <div className="flex items-center gap-3 mb-1">
+            <h1 className="text-2xl font-bold">{skill.name}</h1>
+            <span
+              className={`text-xs font-medium px-2.5 py-0.5 rounded-full border ${TIER_COLORS[skill.tier]}`}
+            >
+              {TIER_LABELS[skill.tier]}
+            </span>
+            {skill.popular && <span className="text-xs text-amber-400">⭐ Popular</span>}
+          </div>
+          <p className="text-gray-400">{skill.description}</p>
+        </div>
+      </div>
+
+      {/* Toggle / Upgrade */}
+      <div className="bg-gray-900 border border-gray-800 rounded-xl p-5 mb-8">
+        {locked ? (
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="font-medium mb-1">
+                This skill requires the {TIER_LABELS[skill.tier]} plan
+              </p>
+              <p className="text-sm text-gray-400">
+                Upgrade your plan to enable this skill.
+              </p>
+            </div>
+            <Link
+              href="/dashboard/billing"
+              className="px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white text-sm font-medium rounded-lg transition-colors"
+            >
+              Upgrade
+            </Link>
+          </div>
+        ) : (
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="font-medium mb-1">
+                {enabled ? "This skill is active" : "Enable this skill"}
+              </p>
+              <p className="text-sm text-gray-400">
+                {enabled
+                  ? "Your assistant can now use this skill."
+                  : "Turn it on to let your assistant use it."}
+              </p>
+            </div>
+            <button
+              onClick={() => setEnabled(!enabled)}
+              className="flex items-center gap-2"
+              aria-label={`Toggle ${skill.name}`}
+            >
+              <div
+                className={`w-12 h-6 rounded-full relative transition-colors ${
+                  enabled ? "bg-blue-600" : "bg-gray-700"
+                }`}
+              >
+                <div
+                  className={`absolute top-0.5 w-5 h-5 rounded-full bg-white transition-transform ${
+                    enabled ? "translate-x-6" : "translate-x-0.5"
+                  }`}
+                />
+              </div>
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* Capabilities */}
+      <div className="mb-8">
+        <h2 className="text-lg font-semibold mb-3">What it can do</h2>
+        <ul className="space-y-2">
+          {skill.capabilities.map((cap, i) => (
+            <li key={i} className="flex items-start gap-2 text-gray-300">
+              <span className="text-emerald-400 mt-0.5">✓</span>
+              <span>{cap}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      {/* Examples */}
+      <div>
+        <h2 className="text-lg font-semibold mb-3">Try saying</h2>
+        <div className="space-y-2">
+          {skill.examples.map((ex, i) => (
+            <div
+              key={i}
+              className="bg-gray-900 border border-gray-800 rounded-lg px-4 py-3 text-sm text-gray-300 italic"
+            >
+              &ldquo;{ex}&rdquo;
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/dashboard/skills/page.tsx
+++ b/apps/web/src/app/dashboard/skills/page.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import Link from "next/link";
+import { SKILLS, CATEGORIES, TIER_LABELS, type SkillCategory, type SkillTier } from "@/lib/skills/catalog";
+
+const TIER_COLORS: Record<SkillTier, string> = {
+  free: "bg-emerald-500/20 text-emerald-400 border-emerald-500/30",
+  starter: "bg-blue-500/20 text-blue-400 border-blue-500/30",
+  pro: "bg-purple-500/20 text-purple-400 border-purple-500/30",
+};
+
+export default function SkillsPage() {
+  const [search, setSearch] = useState("");
+  const [category, setCategory] = useState<SkillCategory | "All">("All");
+  const [enabled, setEnabled] = useState<Set<string>>(() => new Set());
+
+  // Simulate free-tier user
+  const userTier: SkillTier = "free";
+
+  const filtered = useMemo(() => {
+    return SKILLS.filter((s) => {
+      if (category !== "All" && s.category !== category) return false;
+      if (search) {
+        const q = search.toLowerCase();
+        return s.name.toLowerCase().includes(q) || s.description.toLowerCase().includes(q);
+      }
+      return true;
+    });
+  }, [search, category]);
+
+  function toggle(id: string, tier: SkillTier) {
+    if (tier !== "free" && userTier === "free") return;
+    setEnabled((prev) => {
+      const next = new Set(prev);
+      next.has(id) ? next.delete(id) : next.add(id);
+      return next;
+    });
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-950 text-gray-100 px-4 py-8 sm:px-6 lg:px-8 max-w-6xl mx-auto">
+      {/* Header */}
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold mb-2">Skill Library</h1>
+        <p className="text-gray-400">
+          Browse and enable skills to teach your assistant new tricks.
+        </p>
+      </div>
+
+      {/* Search */}
+      <div className="mb-6">
+        <input
+          type="text"
+          placeholder="Search skills..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="w-full sm:w-96 rounded-lg bg-gray-900 border border-gray-700 px-4 py-2.5 text-sm text-gray-100 placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+        />
+      </div>
+
+      {/* Category pills */}
+      <div className="flex flex-wrap gap-2 mb-8">
+        {["All", ...CATEGORIES].map((cat) => (
+          <button
+            key={cat}
+            onClick={() => setCategory(cat as SkillCategory | "All")}
+            className={`px-4 py-1.5 rounded-full text-sm font-medium transition-colors ${
+              category === cat
+                ? "bg-blue-600 text-white"
+                : "bg-gray-800 text-gray-400 hover:bg-gray-700 hover:text-gray-200"
+            }`}
+          >
+            {cat}
+          </button>
+        ))}
+      </div>
+
+      {/* Grid */}
+      {filtered.length === 0 ? (
+        <p className="text-gray-500 text-center py-12">No skills match your search.</p>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {filtered.map((skill) => {
+            const locked = skill.tier !== "free" && userTier === "free";
+            const isOn = enabled.has(skill.id);
+
+            return (
+              <div
+                key={skill.id}
+                className="relative bg-gray-900 border border-gray-800 rounded-xl p-5 flex flex-col gap-3 hover:border-gray-700 transition-colors"
+              >
+                {/* Top row: icon + badge + toggle */}
+                <div className="flex items-start justify-between">
+                  <div className="flex items-center gap-3">
+                    <span className="text-3xl">{skill.icon}</span>
+                    <div>
+                      <Link
+                        href={`/dashboard/skills/${skill.id}`}
+                        className="font-semibold text-gray-100 hover:text-blue-400 transition-colors"
+                      >
+                        {skill.name}
+                      </Link>
+                      {skill.popular && (
+                        <span className="ml-2 text-xs text-amber-400">⭐ Popular</span>
+                      )}
+                    </div>
+                  </div>
+                  <span
+                    className={`text-xs font-medium px-2 py-0.5 rounded-full border ${TIER_COLORS[skill.tier]}`}
+                  >
+                    {TIER_LABELS[skill.tier]}
+                  </span>
+                </div>
+
+                {/* Description */}
+                <p className="text-sm text-gray-400 leading-relaxed">{skill.description}</p>
+
+                {/* Toggle / Upgrade */}
+                <div className="mt-auto pt-2">
+                  {locked ? (
+                    <Link
+                      href="/dashboard/billing"
+                      className="inline-block text-sm text-blue-400 hover:text-blue-300 font-medium"
+                    >
+                      Upgrade to unlock →
+                    </Link>
+                  ) : (
+                    <button
+                      onClick={() => toggle(skill.id, skill.tier)}
+                      className="flex items-center gap-2 text-sm"
+                      aria-label={`Toggle ${skill.name}`}
+                    >
+                      <div
+                        className={`w-10 h-5 rounded-full relative transition-colors ${
+                          isOn ? "bg-blue-600" : "bg-gray-700"
+                        }`}
+                      >
+                        <div
+                          className={`absolute top-0.5 w-4 h-4 rounded-full bg-white transition-transform ${
+                            isOn ? "translate-x-5" : "translate-x-0.5"
+                          }`}
+                        />
+                      </div>
+                      <span className="text-gray-400">{isOn ? "Enabled" : "Disabled"}</span>
+                    </button>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/lib/skills/catalog.ts
+++ b/apps/web/src/lib/skills/catalog.ts
@@ -1,0 +1,339 @@
+export type SkillTier = "free" | "starter" | "pro";
+export type SkillCategory = "Productivity" | "Communication" | "Research" | "Home & Life" | "Creative";
+
+export interface Skill {
+  id: string;
+  name: string;
+  description: string;
+  icon: string;
+  category: SkillCategory;
+  tier: SkillTier;
+  popular: boolean;
+  capabilities: string[];
+  examples: string[];
+}
+
+export const CATEGORIES: SkillCategory[] = [
+  "Productivity",
+  "Communication",
+  "Research",
+  "Home & Life",
+  "Creative",
+];
+
+export const TIER_LABELS: Record<SkillTier, string> = {
+  free: "Free",
+  starter: "Starter",
+  pro: "Pro",
+};
+
+export const SKILLS: Skill[] = [
+  {
+    id: "email-management",
+    name: "Email Management",
+    description: "Checks your email and tells you what's important so you never miss a thing.",
+    icon: "📧",
+    category: "Communication",
+    tier: "free",
+    popular: true,
+    capabilities: [
+      "Scans your inbox and highlights urgent messages",
+      "Summarizes long email threads in plain English",
+      "Drafts replies you can review before sending",
+      "Flags emails that need action by a deadline",
+    ],
+    examples: [
+      "Check my email for anything urgent",
+      "Summarize that long thread from Sarah",
+      "Draft a polite reply saying I'll get back to them Monday",
+    ],
+  },
+  {
+    id: "calendar",
+    name: "Calendar",
+    description: "Keeps track of your schedule and reminds you what's coming up next.",
+    icon: "📅",
+    category: "Productivity",
+    tier: "free",
+    popular: true,
+    capabilities: [
+      "Shows your upcoming events at a glance",
+      "Adds new events from natural language",
+      "Alerts you before meetings so you're never late",
+      "Finds open time slots when you need to schedule something",
+    ],
+    examples: [
+      "What's on my calendar today?",
+      "Schedule a dentist appointment for next Tuesday at 2pm",
+      "When am I free this week for a 1-hour meeting?",
+    ],
+  },
+  {
+    id: "weather",
+    name: "Weather",
+    description: "Gives you the forecast so you know whether to grab an umbrella or sunscreen.",
+    icon: "🌤️",
+    category: "Home & Life",
+    tier: "free",
+    popular: false,
+    capabilities: [
+      "Current conditions for any location",
+      "Hourly and weekly forecasts",
+      "Severe weather alerts",
+      "Packing suggestions for upcoming trips",
+    ],
+    examples: [
+      "What's the weather like today?",
+      "Will it rain this weekend in Seattle?",
+      "What should I wear tomorrow?",
+    ],
+  },
+  {
+    id: "reminders",
+    name: "Reminders",
+    description: "Nudges you at the right time so nothing slips through the cracks.",
+    icon: "⏰",
+    category: "Productivity",
+    tier: "free",
+    popular: true,
+    capabilities: [
+      "One-time and recurring reminders",
+      "Natural language scheduling — just say when",
+      "Nags you until you acknowledge it",
+      "Works across all your connected channels",
+    ],
+    examples: [
+      "Remind me to call Mom at 5pm",
+      "Every Monday morning, remind me to submit my timesheet",
+      "In 20 minutes, tell me to check the oven",
+    ],
+  },
+  {
+    id: "web-search",
+    name: "Web Search",
+    description: "Looks things up on the internet and gives you a clear, simple answer.",
+    icon: "🔍",
+    category: "Research",
+    tier: "free",
+    popular: false,
+    capabilities: [
+      "Searches the web and summarizes what it finds",
+      "Compares products, prices, and reviews",
+      "Answers factual questions with sources",
+      "Finds local businesses and services",
+    ],
+    examples: [
+      "What are the best-rated air fryers under $100?",
+      "Find me a good Italian restaurant nearby",
+      "How long does it take to drive from Phoenix to LA?",
+    ],
+  },
+  {
+    id: "social-media",
+    name: "Social Media Posting",
+    description: "Helps you write and schedule posts across your social accounts.",
+    icon: "📱",
+    category: "Communication",
+    tier: "starter",
+    popular: true,
+    capabilities: [
+      "Drafts posts tailored to each platform",
+      "Schedules posts for optimal engagement times",
+      "Suggests hashtags and captions",
+      "Keeps your posting consistent without the burnout",
+    ],
+    examples: [
+      "Draft an Instagram caption for this photo of my garden",
+      "Schedule a LinkedIn post for tomorrow morning",
+      "What hashtags should I use for a homeschooling post?",
+    ],
+  },
+  {
+    id: "news-monitoring",
+    name: "News Monitoring",
+    description: "Watches the news for topics you care about and gives you the highlights.",
+    icon: "📰",
+    category: "Research",
+    tier: "starter",
+    popular: false,
+    capabilities: [
+      "Tracks topics and keywords you choose",
+      "Daily or real-time news digests",
+      "Filters out noise so you get signal",
+      "Covers major outlets and niche sources",
+    ],
+    examples: [
+      "What's happening in tech today?",
+      "Any news about homeschooling laws in Arizona?",
+      "Give me a morning news briefing",
+    ],
+  },
+  {
+    id: "file-organization",
+    name: "File Organization",
+    description: "Tidies up your files and helps you find things when you need them.",
+    icon: "📁",
+    category: "Productivity",
+    tier: "starter",
+    popular: false,
+    capabilities: [
+      "Organizes files into logical folders",
+      "Renames files with consistent naming",
+      "Finds documents by describing what's in them",
+      "Cleans up duplicates and clutter",
+    ],
+    examples: [
+      "Organize my Downloads folder",
+      "Find that PDF about insurance from last month",
+      "Clean up duplicate photos",
+    ],
+  },
+  {
+    id: "recipe-finder",
+    name: "Recipe Finder",
+    description: "Suggests recipes based on what you have in the fridge or what you're craving.",
+    icon: "🍳",
+    category: "Home & Life",
+    tier: "starter",
+    popular: true,
+    capabilities: [
+      "Finds recipes from ingredients you have on hand",
+      "Filters by dietary preferences and allergies",
+      "Scales recipes up or down",
+      "Creates shopping lists for missing ingredients",
+    ],
+    examples: [
+      "What can I make with chicken, rice, and broccoli?",
+      "Find me a quick vegetarian dinner",
+      "Make a shopping list for that pasta recipe",
+    ],
+  },
+  {
+    id: "smart-home",
+    name: "Smart Home Control",
+    description: "Manages your smart devices so you can control your home with a message.",
+    icon: "🏠",
+    category: "Home & Life",
+    tier: "pro",
+    popular: false,
+    capabilities: [
+      "Controls lights, thermostats, and locks",
+      "Creates routines and automations",
+      "Monitors security cameras",
+      "Gets alerts when something unusual happens",
+    ],
+    examples: [
+      "Turn off all the lights downstairs",
+      "Set the thermostat to 72 degrees",
+      "Is the front door locked?",
+    ],
+  },
+  {
+    id: "investment-tracking",
+    name: "Investment Tracking",
+    description: "Keeps an eye on your investments and explains what's happening in plain English.",
+    icon: "📈",
+    category: "Productivity",
+    tier: "pro",
+    popular: false,
+    capabilities: [
+      "Tracks your portfolio performance",
+      "Explains market movements simply",
+      "Alerts you to significant changes",
+      "Summarizes earnings reports and financial news",
+    ],
+    examples: [
+      "How's my portfolio doing this week?",
+      "Why did tech stocks drop today?",
+      "Summarize Tesla's latest earnings",
+    ],
+  },
+  {
+    id: "travel-planning",
+    name: "Travel Planning",
+    description: "Plans your trips from flights to hotels to the fun stuff in between.",
+    icon: "✈️",
+    category: "Home & Life",
+    tier: "pro",
+    popular: true,
+    capabilities: [
+      "Finds and compares flights and hotels",
+      "Builds day-by-day itineraries",
+      "Suggests restaurants and activities",
+      "Tracks prices and alerts you to deals",
+    ],
+    examples: [
+      "Plan a 5-day trip to Japan for two",
+      "Find cheap flights to Denver next month",
+      "What are the must-see spots in Lisbon?",
+    ],
+  },
+  {
+    id: "content-creation",
+    name: "Content Creation",
+    description: "Helps you write blog posts, newsletters, and anything else you publish.",
+    icon: "✍️",
+    category: "Creative",
+    tier: "pro",
+    popular: true,
+    capabilities: [
+      "Drafts blog posts and articles from an outline or idea",
+      "Writes newsletters in your voice",
+      "Suggests headlines and hooks that grab attention",
+      "Edits and polishes your drafts",
+    ],
+    examples: [
+      "Write a blog post about our homeschooling routine",
+      "Help me outline a newsletter about snowbird life",
+      "Make this draft sound more conversational",
+    ],
+  },
+  {
+    id: "code-assistant",
+    name: "Code Assistant",
+    description: "Your programming sidekick — writes, explains, and fixes code for you.",
+    icon: "💻",
+    category: "Creative",
+    tier: "pro",
+    popular: false,
+    capabilities: [
+      "Writes code in any popular language",
+      "Explains what existing code does",
+      "Debugs errors and suggests fixes",
+      "Reviews pull requests and suggests improvements",
+    ],
+    examples: [
+      "Write a Python script to rename all my photos by date",
+      "Why is this function returning undefined?",
+      "Review my latest PR",
+    ],
+  },
+  {
+    id: "custom-integrations",
+    name: "Custom Integrations",
+    description: "Connects your favorite apps and services so they all work together.",
+    icon: "🔗",
+    category: "Productivity",
+    tier: "pro",
+    popular: false,
+    capabilities: [
+      "Connects to APIs and third-party services",
+      "Builds custom workflows between apps",
+      "Triggers actions based on events",
+      "No coding required — just describe what you want",
+    ],
+    examples: [
+      "When I get an email from my accountant, add it to my Trello board",
+      "Post my Instagram photos to Pinterest automatically",
+      "Send me a Slack message when my website goes down",
+    ],
+  },
+];
+
+export function getSkillById(id: string): Skill | undefined {
+  return SKILLS.find((s) => s.id === id);
+}
+
+export function getSkillsByCategory(category: SkillCategory): Skill[] {
+  return SKILLS.filter((s) => s.category === category);
+}


### PR DESCRIPTION
## Skill Library

Adds the skill library UI for the dashboard — browse, search, and enable/disable skills like an app store.

### What's included

**`apps/web/src/lib/skills/catalog.ts`** — Skill catalog data
- 15 skills across 5 categories (Productivity, Communication, Research, Home & Life, Creative)
- 3 tiers: Free (5), Starter (4), Pro (6)
- Each skill has plain-English descriptions, capabilities list, and example interactions

**`apps/web/src/app/dashboard/skills/page.tsx`** — Skill library page
- Responsive grid (1/2/3 columns)
- Search bar and category filter pills
- Tier badges and toggle switches
- Free skills toggleable, paid skills show "Upgrade to unlock"

**`apps/web/src/app/dashboard/skills/[id]/page.tsx`** — Skill detail page
- Full description, capabilities, and example phrases
- Enable/disable toggle (or upgrade prompt for locked tiers)
- Back to library navigation

Dark theme, warm and friendly feel. 🎨