### PR TITLE
feat(sidecar): skill management, messaging config, usage metering

### DIFF
--- a/apps/sidecar/src/index.ts
+++ b/apps/sidecar/src/index.ts
@@ -3,6 +3,9 @@ import { authMiddleware } from './middleware/auth';
 import healthRouter from './routes/health';
 import openclawRouter from './routes/openclaw';
 import heartbeatRouter from './routes/heartbeat';
+import skillsRouter from './routes/skills';
+import messagingRouter from './routes/messaging';
+import usageRouter from './routes/usage';
 
 const app = express();
 const PORT = parseInt(process.env.PORT || '8787', 10);
@@ -16,6 +19,9 @@ app.use(authMiddleware);
 app.use(healthRouter);
 app.use(openclawRouter);
 app.use(heartbeatRouter);
+app.use(skillsRouter);
+app.use(messagingRouter);
+app.use(usageRouter);
 
 app.listen(PORT, '0.0.0.0', () => {
   console.log(`[sidecar] listening on port ${PORT}`);

--- a/apps/sidecar/src/routes/heartbeat.ts
+++ b/apps/sidecar/src/routes/heartbeat.ts
@@ -1,4 +1,5 @@
 import { Router, Request, Response } from 'express';
+import { getTodayUsageSummary } from './usage';
 
 const router = Router();
 
@@ -39,10 +40,12 @@ async function sendHeartbeat() {
 
   try {
     const health = await collectHealthData();
+    let usage = { messages_sent: 0, hours_active: 0, api_tokens_used: 0 };
+    try { usage = await getTodayUsageSummary(); } catch {}
     await fetch(`${portalUrl}/api/heartbeat`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ vmId, ...health }),
+      body: JSON.stringify({ vmId, ...health, usage }),
     });
   } catch (err) {
     console.error('[heartbeat] Failed to phone home:', (err as Error).message);

--- a/apps/sidecar/src/routes/messaging.ts
+++ b/apps/sidecar/src/routes/messaging.ts
@@ -1,0 +1,150 @@
+import { Router, Request, Response } from 'express';
+import { exec } from 'child_process';
+import { promisify } from 'util';
+import { readFile, writeFile, mkdir } from 'fs/promises';
+import { join } from 'path';
+
+const execAsync = promisify(exec);
+const router = Router();
+
+type Platform = 'whatsapp' | 'telegram' | 'signal' | 'discord' | 'slack';
+const VALID_PLATFORMS: Platform[] = ['whatsapp', 'telegram', 'signal', 'discord', 'slack'];
+
+const OPENCLAW_CONFIG_PATH = join(process.env.HOME || '/root', '.openclaw/openclaw.json');
+
+async function readOpenclawConfig(): Promise<Record<string, any>> {
+  try {
+    const raw = await readFile(OPENCLAW_CONFIG_PATH, 'utf-8');
+    return JSON.parse(raw);
+  } catch {
+    return {};
+  }
+}
+
+async function writeOpenclawConfig(config: Record<string, any>): Promise<void> {
+  const dir = join(process.env.HOME || '/root', '.openclaw');
+  await mkdir(dir, { recursive: true });
+  await writeFile(OPENCLAW_CONFIG_PATH, JSON.stringify(config, null, 2), 'utf-8');
+}
+
+async function setupTelegram(config: { botToken: string }): Promise<{ status: string }> {
+  if (!config.botToken || typeof config.botToken !== 'string') {
+    throw new Error('Missing botToken for Telegram setup');
+  }
+
+  const clawConfig = await readOpenclawConfig();
+  if (!clawConfig.plugins) clawConfig.plugins = {};
+  if (!clawConfig.plugins.entries) clawConfig.plugins.entries = {};
+  clawConfig.plugins.entries.telegram = {
+    enabled: true,
+    config: { botToken: config.botToken },
+  };
+  await writeOpenclawConfig(clawConfig);
+
+  // Restart openclaw to pick up new config
+  try {
+    await execAsync('systemctl restart openclaw');
+  } catch {
+    try { await execAsync('openclaw gateway restart'); } catch {}
+  }
+
+  return { status: 'configured' };
+}
+
+async function setupWhatsApp(_config: Record<string, any>): Promise<{ status: string; qr?: string }> {
+  // WhatsApp pairing typically goes through openclaw's device-pair flow
+  try {
+    const { stdout } = await execAsync('openclaw whatsapp status 2>/dev/null', { timeout: 10_000 });
+    if (stdout.includes('connected')) {
+      return { status: 'connected' };
+    }
+  } catch {}
+
+  // Trigger QR generation
+  try {
+    const { stdout } = await execAsync('openclaw whatsapp pair 2>/dev/null', { timeout: 15_000 });
+    return { status: 'pairing', qr: stdout.trim() };
+  } catch {
+    return { status: 'pending', qr: undefined };
+  }
+}
+
+async function setupGeneric(platform: string, config: Record<string, any>): Promise<{ status: string }> {
+  const clawConfig = await readOpenclawConfig();
+  if (!clawConfig.plugins) clawConfig.plugins = {};
+  if (!clawConfig.plugins.entries) clawConfig.plugins.entries = {};
+  clawConfig.plugins.entries[platform] = {
+    enabled: true,
+    config,
+  };
+  await writeOpenclawConfig(clawConfig);
+
+  try {
+    await execAsync('systemctl restart openclaw');
+  } catch {
+    try { await execAsync('openclaw gateway restart'); } catch {}
+  }
+
+  return { status: 'configured' };
+}
+
+router.post('/messaging/setup', async (req: Request, res: Response) => {
+  const { platform, config } = req.body;
+
+  if (!platform || !VALID_PLATFORMS.includes(platform)) {
+    res.status(400).json({ error: `Invalid platform. Must be one of: ${VALID_PLATFORMS.join(', ')}` });
+    return;
+  }
+
+  if (!config || typeof config !== 'object') {
+    res.status(400).json({ error: 'Missing config object' });
+    return;
+  }
+
+  try {
+    let result: { status: string; qr?: string };
+
+    switch (platform) {
+      case 'telegram':
+        result = await setupTelegram(config);
+        break;
+      case 'whatsapp':
+        result = await setupWhatsApp(config);
+        break;
+      default:
+        result = await setupGeneric(platform, config);
+        break;
+    }
+
+    res.json({ platform, ...result });
+  } catch (err: any) {
+    res.status(500).json({ error: `Failed to setup ${platform}`, details: err.message });
+  }
+});
+
+router.get('/messaging/status', async (_req: Request, res: Response) => {
+  try {
+    const config = await readOpenclawConfig();
+    const entries = config?.plugins?.entries || {};
+    const platforms: Record<string, { enabled: boolean; connected: boolean }> = {};
+
+    for (const p of VALID_PLATFORMS) {
+      const entry = entries[p];
+      if (entry) {
+        let connected = false;
+        try {
+          const { stdout } = await execAsync(`openclaw ${p} status 2>/dev/null`, { timeout: 5_000 });
+          connected = stdout.toLowerCase().includes('connected') || stdout.toLowerCase().includes('active');
+        } catch {}
+
+        platforms[p] = { enabled: !!entry.enabled, connected };
+      }
+    }
+
+    res.json({ platforms });
+  } catch (err: any) {
+    res.status(500).json({ error: 'Failed to get messaging status', details: err.message });
+  }
+});
+
+export default router;

--- a/apps/sidecar/src/routes/skills.ts
+++ b/apps/sidecar/src/routes/skills.ts
@@ -1,0 +1,95 @@
+import { Router, Request, Response } from 'express';
+import { exec } from 'child_process';
+import { promisify } from 'util';
+import { readdir } from 'fs/promises';
+import { join } from 'path';
+
+const execAsync = promisify(exec);
+const router = Router();
+
+const SKILLS_DIRS = [
+  '/usr/local/lib/node_modules/openclaw/skills',
+  join(process.env.HOME || '/root', '.openclaw/workspace/skills'),
+  join(process.env.HOME || '/root', '.agents/skills'),
+];
+
+router.get('/skills', async (_req: Request, res: Response) => {
+  try {
+    // Try CLI first
+    try {
+      const { stdout } = await execAsync('openclaw skill list --json 2>/dev/null || openclaw skill list 2>/dev/null');
+      if (stdout.trim()) {
+        try {
+          const skills = JSON.parse(stdout.trim());
+          res.json({ skills });
+          return;
+        } catch {
+          // CLI returned non-JSON, parse as text
+          const skills = stdout.trim().split('\n').filter(Boolean).map((name: string) => ({ name: name.trim() }));
+          res.json({ skills });
+          return;
+        }
+      }
+    } catch {}
+
+    // Fallback: read from filesystem
+    const skills: Array<{ name: string; path: string }> = [];
+    for (const dir of SKILLS_DIRS) {
+      try {
+        const entries = await readdir(dir, { withFileTypes: true });
+        for (const entry of entries) {
+          if (entry.isDirectory()) {
+            skills.push({ name: entry.name, path: join(dir, entry.name) });
+          }
+        }
+      } catch {}
+    }
+
+    res.json({ skills });
+  } catch (err: any) {
+    res.status(500).json({ error: 'Failed to list skills', details: err.message });
+  }
+});
+
+router.post('/skills/install', async (req: Request, res: Response) => {
+  const { name } = req.body;
+  if (!name || typeof name !== 'string') {
+    res.status(400).json({ error: 'Missing or invalid skill name' });
+    return;
+  }
+
+  // Sanitize: only allow alphanumeric, hyphens, underscores
+  if (!/^[a-zA-Z0-9_-]+$/.test(name)) {
+    res.status(400).json({ error: 'Invalid skill name format' });
+    return;
+  }
+
+  try {
+    const { stdout, stderr } = await execAsync(`openclaw skill install ${name}`, { timeout: 60_000 });
+    res.json({ status: 'installed', name, output: stdout.trim() || stderr.trim() });
+  } catch (err: any) {
+    res.status(500).json({ error: 'Failed to install skill', details: err.stderr || err.message });
+  }
+});
+
+router.post('/skills/remove', async (req: Request, res: Response) => {
+  const { name } = req.body;
+  if (!name || typeof name !== 'string') {
+    res.status(400).json({ error: 'Missing or invalid skill name' });
+    return;
+  }
+
+  if (!/^[a-zA-Z0-9_-]+$/.test(name)) {
+    res.status(400).json({ error: 'Invalid skill name format' });
+    return;
+  }
+
+  try {
+    const { stdout, stderr } = await execAsync(`openclaw skill remove ${name}`, { timeout: 30_000 });
+    res.json({ status: 'removed', name, output: stdout.trim() || stderr.trim() });
+  } catch (err: any) {
+    res.status(500).json({ error: 'Failed to remove skill', details: err.stderr || err.message });
+  }
+});
+
+export default router;

--- a/apps/sidecar/src/routes/usage.ts
+++ b/apps/sidecar/src/routes/usage.ts
@@ -1,0 +1,117 @@
+import { Router, Request, Response } from 'express';
+import { readFile, writeFile, mkdir } from 'fs/promises';
+import { dirname } from 'path';
+
+const router = Router();
+
+const USAGE_FILE = process.env.USAGE_FILE || '/var/lib/handsoff/usage.json';
+
+interface DailyUsage {
+  date: string;
+  messages_sent: number;
+  active_minutes: number;
+  api_tokens_used: number;
+  last_activity: string;
+}
+
+interface UsageStore {
+  [date: string]: DailyUsage;
+}
+
+function todayKey(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+async function readUsageStore(): Promise<UsageStore> {
+  try {
+    const raw = await readFile(USAGE_FILE, 'utf-8');
+    return JSON.parse(raw);
+  } catch {
+    return {};
+  }
+}
+
+async function writeUsageStore(store: UsageStore): Promise<void> {
+  await mkdir(dirname(USAGE_FILE), { recursive: true });
+  await writeFile(USAGE_FILE, JSON.stringify(store, null, 2), 'utf-8');
+}
+
+function getOrCreateToday(store: UsageStore): DailyUsage {
+  const key = todayKey();
+  if (!store[key]) {
+    store[key] = {
+      date: key,
+      messages_sent: 0,
+      active_minutes: 0,
+      api_tokens_used: 0,
+      last_activity: new Date().toISOString(),
+    };
+  }
+  return store[key];
+}
+
+router.post('/usage/increment', async (req: Request, res: Response) => {
+  const { messages = 1, tokens = 0 } = req.body || {};
+
+  try {
+    const store = await readUsageStore();
+    const today = getOrCreateToday(store);
+
+    today.messages_sent += typeof messages === 'number' ? messages : 1;
+    today.api_tokens_used += typeof tokens === 'number' ? tokens : 0;
+
+    // Track active time: if last activity was within 5 min, add the gap
+    const now = new Date();
+    const lastActivity = new Date(today.last_activity);
+    const gapMinutes = (now.getTime() - lastActivity.getTime()) / 60_000;
+    if (gapMinutes > 0 && gapMinutes <= 5) {
+      today.active_minutes += gapMinutes;
+    } else if (gapMinutes > 5) {
+      // New activity session, count 1 minute
+      today.active_minutes += 1;
+    }
+    today.last_activity = now.toISOString();
+
+    await writeUsageStore(store);
+
+    res.json({ status: 'ok', today });
+  } catch (err: any) {
+    res.status(500).json({ error: 'Failed to increment usage', details: err.message });
+  }
+});
+
+router.get('/usage/today', async (_req: Request, res: Response) => {
+  try {
+    const store = await readUsageStore();
+    const key = todayKey();
+    const today = store[key] || {
+      date: key,
+      messages_sent: 0,
+      active_minutes: 0,
+      api_tokens_used: 0,
+      last_activity: null,
+    };
+
+    res.json({
+      messages_sent: today.messages_sent,
+      hours_active: Math.round((today.active_minutes / 60) * 100) / 100,
+      api_tokens_used: today.api_tokens_used,
+    });
+  } catch (err: any) {
+    res.status(500).json({ error: 'Failed to read usage', details: err.message });
+  }
+});
+
+/** Exported for heartbeat to include usage data when phoning home */
+export async function getTodayUsageSummary(): Promise<{ messages_sent: number; hours_active: number; api_tokens_used: number }> {
+  const store = await readUsageStore();
+  const today = store[todayKey()];
+  if (!today) return { messages_sent: 0, hours_active: 0, api_tokens_used: 0 };
+  return {
+    messages_sent: today.messages_sent,
+    hours_active: Math.round((today.active_minutes / 60) * 100) / 100,
+    api_tokens_used: today.api_tokens_used,
+  };
+}
+
+export default router;


### PR DESCRIPTION
## Sidecar Extensions (T43–T46)

### Skills Management (T43)
- `GET /skills` — list installed skills (CLI with filesystem fallback)
- `POST /skills/install` — install a skill by name
- `POST /skills/remove` — remove a skill by name
- Input sanitization on skill names

### Messaging Configuration (T44)
- `POST /messaging/setup` — configure WhatsApp, Telegram, Signal, Discord, or Slack
- Telegram: writes bot token to openclaw config and restarts
- WhatsApp: triggers QR pairing flow
- Others: generic config write to openclaw.json
- `GET /messaging/status` — returns enabled/connected status per platform

### Usage Metering (T45)
- `POST /usage/increment` — increment message count and track active time
- `GET /usage/today` — returns daily summary (messages, hours active, API tokens)
- Stores counters in `/var/lib/handsoff/usage.json`
- Active time tracked via 5-minute session windows

### Heartbeat Integration (T46)
- Heartbeat now includes usage summary when phoning home to portal

All routes use existing auth middleware.