### PR TITLE
feat: SEO — meta tags, OpenGraph, sitemap, robots.txt

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,14 +1,29 @@
 import type { Metadata } from "next";
 import "./globals.css";
 
+const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://handsoff.app";
+
 export const metadata: Metadata = {
-  title: "OpenClaw — Your Personal AI Assistant, Set Up in Minutes",
+  title: "HandsOff — Your Personal AI Assistant That Actually Does Things",
   description:
-    "Get a private AI assistant that manages your email, calendar, and messages. No coding required. Set up in under 5 minutes.",
+    "Not a chatbot. A doer. HandsOff gives you a personal AI assistant that handles your email, calendar, research, and more — all through the messaging app you already use.",
+  metadataBase: new URL(siteUrl),
+  icons: { icon: "/favicon.ico" },
+  themeColor: "#020617", // slate-950
   openGraph: {
-    title: "OpenClaw — Your Personal AI Assistant",
-    description: "Set up in minutes. No coding required.",
+    title: "HandsOff — Your Personal AI Assistant That Actually Does Things",
+    description:
+      "Not a chatbot. A doer. HandsOff gives you a personal AI assistant that handles your email, calendar, research, and more — all through the messaging app you already use.",
     type: "website",
+    url: siteUrl,
+    images: [{ url: "/opengraph-image", width: 1200, height: 630, alt: "HandsOff" }],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "HandsOff — Your Personal AI Assistant That Actually Does Things",
+    description:
+      "Not a chatbot. A doer. HandsOff gives you a personal AI assistant that handles your email, calendar, research, and more.",
+    images: ["/opengraph-image"],
   },
 };
 

--- a/apps/web/src/app/manifest.ts
+++ b/apps/web/src/app/manifest.ts
@@ -1,0 +1,17 @@
+import type { MetadataRoute } from "next";
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: "HandsOff",
+    short_name: "HandsOff",
+    description:
+      "Your personal AI assistant that handles email, calendar, research, and more.",
+    start_url: "/",
+    display: "standalone",
+    theme_color: "#020617", // slate-950
+    background_color: "#020617",
+    icons: [
+      { src: "/favicon.ico", sizes: "any", type: "image/x-icon" },
+    ],
+  };
+}

--- a/apps/web/src/app/opengraph-image.tsx
+++ b/apps/web/src/app/opengraph-image.tsx
@@ -1,0 +1,47 @@
+import { ImageResponse } from "next/og";
+
+export const runtime = "edge";
+export const alt = "HandsOff — Your Personal AI Assistant";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export default function OgImage() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          background: "linear-gradient(135deg, #020617 0%, #0f172a 50%, #020617 100%)",
+          fontFamily: "sans-serif",
+        }}
+      >
+        <div
+          style={{
+            fontSize: 72,
+            fontWeight: 800,
+            color: "#f8fafc",
+            letterSpacing: "-0.02em",
+          }}
+        >
+          HandsOff
+        </div>
+        <div
+          style={{
+            fontSize: 32,
+            fontWeight: 400,
+            color: "#94a3b8",
+            marginTop: 16,
+          }}
+        >
+          Your Personal AI Assistant
+        </div>
+      </div>
+    ),
+    { ...size }
+  );
+}

--- a/apps/web/src/app/robots.ts
+++ b/apps/web/src/app/robots.ts
@@ -1,0 +1,16 @@
+import type { MetadataRoute } from "next";
+
+const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://handsoff.app";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+        disallow: ["/dashboard", "/onboarding", "/api"],
+      },
+    ],
+    sitemap: `${siteUrl}/sitemap.xml`,
+  };
+}

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -1,0 +1,26 @@
+import type { MetadataRoute } from "next";
+
+const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://handsoff.app";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [
+    {
+      url: siteUrl,
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 1.0,
+    },
+    {
+      url: `${siteUrl}/auth/signin`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.5,
+    },
+    {
+      url: `${siteUrl}/auth/signup`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.7,
+    },
+  ];
+}


### PR DESCRIPTION
## T49: SEO Meta Tags & Discovery

### Changes
- **layout.tsx** — Comprehensive metadata: title, description, OpenGraph, Twitter card, theme color (slate-950), favicon
- **sitemap.ts** — Next.js sitemap for /, /auth/signin, /auth/signup with priority & changeFrequency
- **robots.ts** — Allow public pages, disallow /dashboard, /onboarding, /api
- **manifest.ts** — PWA manifest (HandsOff, standalone, dark theme)
- **opengraph-image.tsx** — Dynamic 1200×630 OG image with dark gradient, bold title, subtitle

### Notes
- Uses `NEXT_PUBLIC_SITE_URL` env var (defaults to https://handsoff.app)
- OG image runs on edge runtime