### PR TITLE
feat: shared navigation + auth flow polish

### DIFF
--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -1,7 +1,9 @@
 import { createServerClient } from '@supabase/ssr';
 import { NextResponse, type NextRequest } from 'next/server';
 
-const publicPaths = ['/', '/auth/signin', '/auth/signup', '/auth/callback'];
+const publicPaths = ['/', '/auth/callback'];
+const authPaths = ['/auth/signin', '/auth/signup'];
+const protectedPrefixes = ['/dashboard', '/onboarding', '/api/launch', '/api/assistant'];
 
 export async function middleware(request: NextRequest) {
   let supabaseResponse = NextResponse.next({ request });
@@ -33,11 +35,33 @@ export async function middleware(request: NextRequest) {
 
   const { pathname } = request.nextUrl;
 
-  if (publicPaths.some((p) => pathname === p || pathname.startsWith('/auth/'))) {
+  // Public paths — always accessible
+  if (publicPaths.some((p) => pathname === p)) {
     return supabaseResponse;
   }
 
-  if (!user) {
+  // Auth pages — redirect to dashboard if already logged in
+  if (authPaths.some((p) => pathname === p || pathname.startsWith(p))) {
+    if (user) {
+      const url = request.nextUrl.clone();
+      url.pathname = '/dashboard';
+      url.search = '';
+      return NextResponse.redirect(url);
+    }
+    return supabaseResponse;
+  }
+
+  // Protected routes — require auth
+  const isProtected = protectedPrefixes.some((p) => pathname === p || pathname.startsWith(p + '/'));
+  if (isProtected && !user) {
+    const url = request.nextUrl.clone();
+    url.pathname = '/auth/signin';
+    url.searchParams.set('redirect', pathname);
+    return NextResponse.redirect(url);
+  }
+
+  // Everything else that isn't explicitly public — require auth
+  if (!user && !pathname.startsWith('/auth/')) {
     const url = request.nextUrl.clone();
     url.pathname = '/auth/signin';
     url.searchParams.set('redirect', pathname);

--- a/apps/web/src/app/dashboard/layout.tsx
+++ b/apps/web/src/app/dashboard/layout.tsx
@@ -1,0 +1,24 @@
+import { redirect } from 'next/navigation';
+import { createClient } from '@/lib/supabase/server';
+import { DashboardNav } from '@/components/nav/dashboard-nav';
+
+export default async function DashboardLayout({ children }: { children: React.ReactNode }) {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect('/auth/signin?redirect=/dashboard');
+  }
+
+  const userName = user.user_metadata?.name ?? user.email?.split('@')[0] ?? 'User';
+  const plan = user.user_metadata?.plan ?? 'Free';
+
+  return (
+    <div className="min-h-screen bg-slate-950 flex flex-col lg:flex-row">
+      <DashboardNav userName={userName} plan={plan} />
+      <main className="flex-1 p-4 sm:p-6 lg:p-8">
+        {children}
+      </main>
+    </div>
+  );
+}

--- a/apps/web/src/app/dashboard/settings/page.tsx
+++ b/apps/web/src/app/dashboard/settings/page.tsx
@@ -1,0 +1,144 @@
+'use client';
+
+import { createClient } from '@/lib/supabase/client';
+import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+
+const TIMEZONES = [
+  'America/New_York', 'America/Chicago', 'America/Denver', 'America/Phoenix',
+  'America/Los_Angeles', 'America/Anchorage', 'Pacific/Honolulu',
+  'Europe/London', 'Europe/Paris', 'Europe/Berlin', 'Europe/Moscow',
+  'Asia/Tokyo', 'Asia/Shanghai', 'Asia/Kolkata', 'Asia/Dubai',
+  'Australia/Sydney', 'Pacific/Auckland',
+];
+
+export default function SettingsPage() {
+  const supabase = createClient();
+  const router = useRouter();
+
+  const [email, setEmail] = useState('');
+  const [name, setName] = useState('');
+  const [timezone, setTimezone] = useState('America/New_York');
+  const [plan, setPlan] = useState('Free');
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [showDelete, setShowDelete] = useState(false);
+  const [deleteConfirm, setDeleteConfirm] = useState('');
+
+  useEffect(() => {
+    supabase.auth.getUser().then(({ data: { user } }) => {
+      if (!user) return;
+      setEmail(user.email ?? '');
+      setName(user.user_metadata?.name ?? '');
+      setTimezone(user.user_metadata?.timezone ?? 'America/New_York');
+      setPlan(user.user_metadata?.plan ?? 'Free');
+    });
+  }, [supabase]);
+
+  async function handleSave() {
+    setSaving(true);
+    await supabase.auth.updateUser({
+      data: { name, timezone },
+    });
+    setSaving(false);
+    setSaved(true);
+    setTimeout(() => setSaved(false), 2000);
+  }
+
+  async function handleDelete() {
+    if (deleteConfirm !== 'DELETE') return;
+    // In production this would call an API route that deletes the user
+    await supabase.auth.signOut();
+    router.push('/');
+  }
+
+  const inputClass = 'w-full rounded-lg border border-slate-700 bg-slate-800 px-4 py-2.5 text-sm text-white placeholder-slate-500 focus:border-violet-500 focus:outline-none';
+
+  return (
+    <div className="max-w-2xl space-y-8">
+      <h1 className="text-2xl font-bold text-white">Settings</h1>
+
+      {/* Profile */}
+      <section className="space-y-4 rounded-xl border border-slate-800 bg-slate-900/50 p-6">
+        <h2 className="text-lg font-semibold text-white">Profile</h2>
+
+        <div>
+          <label className="block text-sm text-slate-400 mb-1">Display Name</label>
+          <input value={name} onChange={(e) => setName(e.target.value)} className={inputClass} />
+        </div>
+
+        <div>
+          <label className="block text-sm text-slate-400 mb-1">Email</label>
+          <input value={email} readOnly className={`${inputClass} opacity-60 cursor-not-allowed`} />
+        </div>
+
+        <div>
+          <label className="block text-sm text-slate-400 mb-1">Timezone</label>
+          <select
+            value={timezone}
+            onChange={(e) => setTimezone(e.target.value)}
+            className={inputClass}
+          >
+            {TIMEZONES.map((tz) => (
+              <option key={tz} value={tz}>{tz.replace(/_/g, ' ')}</option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label className="block text-sm text-slate-400 mb-1">Current Plan</label>
+          <p className="text-sm text-white">{plan}</p>
+        </div>
+
+        <button
+          onClick={handleSave}
+          disabled={saving}
+          className="rounded-lg bg-violet-600 px-5 py-2 text-sm font-medium text-white hover:bg-violet-500 disabled:opacity-50 transition"
+        >
+          {saving ? 'Saving…' : saved ? 'Saved ✓' : 'Save Changes'}
+        </button>
+      </section>
+
+      {/* Danger Zone */}
+      <section className="rounded-xl border border-red-900/50 bg-red-950/20 p-6 space-y-4">
+        <h2 className="text-lg font-semibold text-red-400">Danger Zone</h2>
+        <p className="text-sm text-slate-400">
+          Permanently delete your account and all associated data. This action cannot be undone.
+        </p>
+        {!showDelete ? (
+          <button
+            onClick={() => setShowDelete(true)}
+            className="rounded-lg border border-red-800 px-4 py-2 text-sm text-red-400 hover:bg-red-900/30 transition"
+          >
+            Delete my account
+          </button>
+        ) : (
+          <div className="space-y-3">
+            <p className="text-sm text-red-300">Type <strong>DELETE</strong> to confirm:</p>
+            <input
+              value={deleteConfirm}
+              onChange={(e) => setDeleteConfirm(e.target.value)}
+              placeholder="DELETE"
+              className="w-full max-w-xs rounded-lg border border-red-800 bg-slate-900 px-4 py-2 text-sm text-white focus:outline-none"
+            />
+            <div className="flex gap-3">
+              <button
+                onClick={handleDelete}
+                disabled={deleteConfirm !== 'DELETE'}
+                className="rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-500 disabled:opacity-50 transition"
+              >
+                Permanently Delete
+              </button>
+              <button
+                onClick={() => { setShowDelete(false); setDeleteConfirm(''); }}
+                className="rounded-lg border border-slate-700 px-4 py-2 text-sm text-slate-300 hover:bg-slate-800 transition"
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/apps/web/src/components/nav/dashboard-nav.tsx
+++ b/apps/web/src/components/nav/dashboard-nav.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { useState } from 'react';
+
+const links = [
+  { href: '/dashboard', label: 'Overview' },
+  { href: '/dashboard/skills', label: 'Skills' },
+  { href: '/dashboard/settings', label: 'Settings' },
+  { href: '/dashboard/billing', label: 'Billing' },
+];
+
+interface DashboardNavProps {
+  userName?: string;
+  plan?: string;
+}
+
+export function DashboardNav({ userName = 'User', plan = 'Free' }: DashboardNavProps) {
+  const pathname = usePathname();
+  const [open, setOpen] = useState(false);
+
+  const isActive = (href: string) =>
+    href === '/dashboard' ? pathname === '/dashboard' : pathname.startsWith(href);
+
+  const planColor = plan === 'Pro' ? 'bg-violet-600' : plan === 'Starter' ? 'bg-blue-600' : 'bg-slate-700';
+
+  return (
+    <>
+      {/* Mobile top bar */}
+      <div className="lg:hidden flex items-center justify-between bg-slate-900 border-b border-slate-800 px-4 py-3">
+        <span className="text-white font-semibold">HandsOff</span>
+        <button onClick={() => setOpen(!open)} className="text-slate-300 hover:text-white" aria-label="Toggle nav">
+          <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            {open ? (
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+            ) : (
+              <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+            )}
+          </svg>
+        </button>
+      </div>
+
+      {/* Sidebar */}
+      <aside className={`
+        fixed inset-y-0 left-0 z-40 w-64 bg-slate-900 border-r border-slate-800 flex flex-col
+        transform transition-transform lg:translate-x-0 lg:static lg:z-auto
+        ${open ? 'translate-x-0' : '-translate-x-full'}
+      `}>
+        <div className="hidden lg:flex items-center gap-2 px-6 py-5 border-b border-slate-800">
+          <Link href="/" className="text-lg font-bold text-white">HandsOff</Link>
+        </div>
+
+        <div className="px-4 py-4 border-b border-slate-800">
+          <p className="text-sm text-white font-medium truncate">{userName}</p>
+          <span className={`inline-block mt-1 text-xs px-2 py-0.5 rounded-full text-white ${planColor}`}>
+            {plan}
+          </span>
+        </div>
+
+        <nav className="flex-1 px-3 py-4 space-y-1">
+          {links.map(({ href, label }) => (
+            <Link
+              key={href}
+              href={href}
+              onClick={() => setOpen(false)}
+              className={`block rounded-lg px-3 py-2 text-sm transition ${
+                isActive(href)
+                  ? 'bg-violet-600/20 text-violet-300 font-medium'
+                  : 'text-slate-400 hover:text-white hover:bg-slate-800'
+              }`}
+            >
+              {label}
+            </Link>
+          ))}
+        </nav>
+      </aside>
+
+      {/* Mobile overlay */}
+      {open && (
+        <div className="fixed inset-0 z-30 bg-black/50 lg:hidden" onClick={() => setOpen(false)} />
+      )}
+    </>
+  );
+}

--- a/apps/web/src/components/nav/main-nav.tsx
+++ b/apps/web/src/components/nav/main-nav.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+import { createClient } from '@/lib/supabase/client';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import type { User } from '@supabase/supabase-js';
+
+export function MainNav() {
+  const supabase = createClient();
+  const router = useRouter();
+  const [user, setUser] = useState<User | null>(null);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    supabase.auth.getUser().then(({ data }) => {
+      setUser(data.user);
+      setLoaded(true);
+    });
+    const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, session) => {
+      setUser(session?.user ?? null);
+    });
+    return () => subscription.unsubscribe();
+  }, [supabase]);
+
+  async function handleSignOut() {
+    await supabase.auth.signOut();
+    router.push('/');
+  }
+
+  const initial = user?.user_metadata?.name?.[0]?.toUpperCase()
+    ?? user?.email?.[0]?.toUpperCase()
+    ?? '?';
+
+  return (
+    <nav className="sticky top-0 z-50 bg-slate-900/95 backdrop-blur border-b border-slate-800">
+      <div className="mx-auto flex max-w-6xl items-center justify-between px-4 py-3 sm:px-6">
+        <Link href="/" className="text-lg sm:text-xl font-bold text-white">
+          HandsOff
+        </Link>
+
+        {/* Desktop */}
+        <div className="hidden sm:flex items-center gap-4">
+          {loaded && user ? (
+            <>
+              <Link href="/dashboard" className="text-sm text-slate-300 hover:text-white transition">
+                Dashboard
+              </Link>
+              <button
+                onClick={handleSignOut}
+                className="text-sm text-slate-400 hover:text-white transition"
+              >
+                Sign Out
+              </button>
+              <div className="flex items-center justify-center w-8 h-8 rounded-full bg-violet-600 text-white text-sm font-medium">
+                {initial}
+              </div>
+            </>
+          ) : loaded ? (
+            <>
+              <Link href="/auth/signin" className="text-sm text-slate-300 hover:text-white transition">
+                Sign In
+              </Link>
+              <Link
+                href="/auth/signup"
+                className="rounded-full bg-violet-600 px-4 py-2 text-sm font-medium text-white hover:bg-violet-500 transition"
+              >
+                Get Started Free
+              </Link>
+            </>
+          ) : null}
+        </div>
+
+        {/* Mobile hamburger */}
+        <button
+          className="sm:hidden text-slate-300 hover:text-white"
+          onClick={() => setMenuOpen(!menuOpen)}
+          aria-label="Toggle menu"
+        >
+          <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            {menuOpen ? (
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+            ) : (
+              <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+            )}
+          </svg>
+        </button>
+      </div>
+
+      {/* Mobile menu */}
+      {menuOpen && (
+        <div className="sm:hidden border-t border-slate-800 bg-slate-900 px-4 py-4 space-y-3">
+          {loaded && user ? (
+            <>
+              <Link href="/dashboard" className="block text-sm text-slate-300 hover:text-white" onClick={() => setMenuOpen(false)}>
+                Dashboard
+              </Link>
+              <button onClick={handleSignOut} className="block text-sm text-slate-400 hover:text-white">
+                Sign Out
+              </button>
+            </>
+          ) : loaded ? (
+            <>
+              <Link href="/auth/signin" className="block text-sm text-slate-300 hover:text-white" onClick={() => setMenuOpen(false)}>
+                Sign In
+              </Link>
+              <Link href="/auth/signup" className="block text-sm text-violet-400 hover:text-violet-300" onClick={() => setMenuOpen(false)}>
+                Get Started Free
+              </Link>
+            </>
+          ) : null}
+        </div>
+      )}
+    </nav>
+  );
+}


### PR DESCRIPTION
## What

Shared navigation components, dashboard layout, settings page, and improved auth middleware.

### New files
- **`components/nav/main-nav.tsx`** — Sticky top nav (client component). Shows logo, auth-aware buttons (Sign In / Get Started when logged out; Dashboard / avatar / Sign Out when logged in). Mobile hamburger menu. Dark slate-900 theme.
- **`components/nav/dashboard-nav.tsx`** — Dashboard sidebar. Links: Overview, Skills, Settings, Billing. Active state highlighting, user name + plan badge, mobile collapsible with overlay.
- **`app/dashboard/layout.tsx`** — Server-side auth check (redirects to sign-in if unauthenticated). Wraps children with DashboardNav sidebar.
- **`app/dashboard/settings/page.tsx`** — Display name edit, timezone dropdown, read-only email, current plan display, delete account danger zone with DELETE confirmation.

### Updated
- **`middleware.ts`** — Protected routes: `/dashboard/*`, `/onboarding/*`, `/api/launch`, `/api/assistant/*` require auth. Auth pages (`/auth/*`) redirect to `/dashboard` if already logged in.