### PR TITLE
feat: Admin dashboard and API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,6 @@ DATABASE_URL=
 # Hetzner Cloud — used by Claw4All to provision VMs
 # Get your token at https://console.hetzner.cloud → Project → Security → API Tokens
 HETZNER_API_TOKEN=
+
+# Admin — comma-separated list of admin email addresses
+ADMIN_EMAILS=

--- a/apps/web/src/app/admin/page.tsx
+++ b/apps/web/src/app/admin/page.tsx
@@ -1,0 +1,158 @@
+import { redirect } from 'next/navigation';
+import { createClient } from '@/lib/supabase/server';
+import { isAdmin } from '@/lib/admin/auth';
+
+async function fetchJson(url: string, cookie: string) {
+  const res = await fetch(url, { headers: { cookie }, cache: 'no-store' });
+  if (!res.ok) return null;
+  return res.json();
+}
+
+export default async function AdminDashboard() {
+  const supabase: any = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+
+  if (!user) redirect('/auth/signin?redirect=/admin');
+  if (!isAdmin(user.email)) redirect('/dashboard');
+
+  // Fetch data server-side via Supabase directly
+  const { count: totalUsers } = await supabase
+    .from('profiles')
+    .select('*', { count: 'exact', head: true });
+
+  const { count: activeAssistants } = await supabase
+    .from('assistants')
+    .select('*', { count: 'exact', head: true })
+    .eq('status', 'running');
+
+  const { count: totalVMs } = await supabase
+    .from('assistants')
+    .select('*', { count: 'exact', head: true })
+    .neq('status', 'destroyed');
+
+  const { data: recentUsers } = await supabase
+    .from('profiles')
+    .select('id, email, name, plan, created_at')
+    .order('created_at', { ascending: false })
+    .limit(20);
+
+  const { data: activeVMs } = await supabase
+    .from('assistants')
+    .select('id, user_id, status, ip_address, created_at')
+    .neq('status', 'destroyed')
+    .order('created_at', { ascending: false })
+    .limit(20);
+
+  // Get emails for VMs
+  const userIds = [...new Set((activeVMs ?? []).map((v: any) => v.user_id))];
+  const { data: vmProfiles } = userIds.length
+    ? await supabase.from('profiles').select('id, email').in('id', userIds)
+    : { data: [] };
+  const emailMap: Record<string, string> = {};
+  for (const p of vmProfiles ?? []) emailMap[p.id] = p.email;
+
+  const stats = [
+    { label: 'Total Users', value: totalUsers ?? 0, icon: '👤' },
+    { label: 'Active Assistants', value: activeAssistants ?? 0, icon: '🤖' },
+    { label: 'Revenue', value: '$0', icon: '💰' },
+    { label: 'VMs Running', value: totalVMs ?? 0, icon: '🖥️' },
+  ];
+
+  return (
+    <div className="min-h-screen bg-slate-950 text-slate-100 p-6 lg:p-10">
+      <div className="max-w-7xl mx-auto space-y-8">
+        <div className="flex items-center justify-between">
+          <h1 className="text-3xl font-bold">Admin Dashboard</h1>
+          <a href="/admin/users" className="text-sm text-blue-400 hover:text-blue-300 underline">
+            Manage Users →
+          </a>
+        </div>
+
+        {/* Stats Cards */}
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+          {stats.map((s) => (
+            <div key={s.label} className="bg-slate-900 border border-slate-800 rounded-xl p-5">
+              <div className="text-2xl mb-1">{s.icon}</div>
+              <div className="text-2xl font-bold">{s.value}</div>
+              <div className="text-sm text-slate-400">{s.label}</div>
+            </div>
+          ))}
+        </div>
+
+        {/* Recent Signups */}
+        <section>
+          <h2 className="text-xl font-semibold mb-3">Recent Signups</h2>
+          <div className="overflow-x-auto bg-slate-900 border border-slate-800 rounded-xl">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-slate-800 text-slate-400">
+                  <th className="text-left p-3">Email</th>
+                  <th className="text-left p-3">Name</th>
+                  <th className="text-left p-3">Plan</th>
+                  <th className="text-left p-3">Joined</th>
+                </tr>
+              </thead>
+              <tbody>
+                {(recentUsers ?? []).map((u: any) => (
+                  <tr key={u.id} className="border-b border-slate-800/50 hover:bg-slate-800/30">
+                    <td className="p-3 font-mono text-xs">{u.email}</td>
+                    <td className="p-3">{u.name ?? '—'}</td>
+                    <td className="p-3">
+                      <span className="px-2 py-0.5 rounded-full text-xs bg-slate-800">
+                        {u.plan ?? 'free'}
+                      </span>
+                    </td>
+                    <td className="p-3 text-slate-400">{new Date(u.created_at).toLocaleDateString()}</td>
+                  </tr>
+                ))}
+                {!(recentUsers ?? []).length && (
+                  <tr><td colSpan={4} className="p-6 text-center text-slate-500">No users yet</td></tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        {/* Active VMs */}
+        <section>
+          <h2 className="text-xl font-semibold mb-3">Active VMs</h2>
+          <div className="overflow-x-auto bg-slate-900 border border-slate-800 rounded-xl">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-slate-800 text-slate-400">
+                  <th className="text-left p-3">Assistant ID</th>
+                  <th className="text-left p-3">User</th>
+                  <th className="text-left p-3">Status</th>
+                  <th className="text-left p-3">IP</th>
+                  <th className="text-left p-3">Created</th>
+                </tr>
+              </thead>
+              <tbody>
+                {(activeVMs ?? []).map((v: any) => (
+                  <tr key={v.id} className="border-b border-slate-800/50 hover:bg-slate-800/30">
+                    <td className="p-3 font-mono text-xs">{v.id}</td>
+                    <td className="p-3 font-mono text-xs">{emailMap[v.user_id] ?? v.user_id}</td>
+                    <td className="p-3">
+                      <span className={`px-2 py-0.5 rounded-full text-xs ${
+                        v.status === 'running' ? 'bg-green-900/50 text-green-400' :
+                        v.status === 'suspended' ? 'bg-yellow-900/50 text-yellow-400' :
+                        'bg-slate-800 text-slate-400'
+                      }`}>
+                        {v.status}
+                      </span>
+                    </td>
+                    <td className="p-3 font-mono text-xs">{v.ip_address ?? '—'}</td>
+                    <td className="p-3 text-slate-400">{new Date(v.created_at).toLocaleDateString()}</td>
+                  </tr>
+                ))}
+                {!(activeVMs ?? []).length && (
+                  <tr><td colSpan={5} className="p-6 text-center text-slate-500">No active VMs</td></tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/admin/users/page.tsx
+++ b/apps/web/src/app/admin/users/page.tsx
@@ -1,0 +1,226 @@
+'use client';
+
+import { useEffect, useState, useCallback } from 'react';
+
+interface User {
+  id: string;
+  email: string;
+  name: string | null;
+  plan: string | null;
+  assistant_status: string | null;
+  created_at: string;
+}
+
+export default function AdminUsersPage() {
+  const [users, setUsers] = useState<User[]>([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
+  const [search, setSearch] = useState('');
+  const [searchInput, setSearchInput] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [selectedUser, setSelectedUser] = useState<User | null>(null);
+  const [actionLoading, setActionLoading] = useState(false);
+  const limit = 20;
+
+  const fetchUsers = useCallback(async () => {
+    setLoading(true);
+    const params = new URLSearchParams({ page: String(page), limit: String(limit) });
+    if (search) params.set('search', search);
+    const res = await fetch(`/api/admin/users?${params}`);
+    if (res.ok) {
+      const data = await res.json();
+      setUsers(data.users);
+      setTotal(data.total);
+    }
+    setLoading(false);
+  }, [page, search]);
+
+  useEffect(() => { fetchUsers(); }, [fetchUsers]);
+
+  const totalPages = Math.ceil(total / limit);
+
+  const handleSearch = (e: React.FormEvent) => {
+    e.preventDefault();
+    setPage(1);
+    setSearch(searchInput);
+  };
+
+  const handleAction = async (userId: string, action: string, payload?: any) => {
+    setActionLoading(true);
+    try {
+      // These would call specific admin action endpoints
+      const res = await fetch(`/api/admin/users/${userId}/${action}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload ?? {}),
+      });
+      if (res.ok) {
+        await fetchUsers();
+        setSelectedUser(null);
+      } else {
+        alert(`Action failed: ${(await res.json()).error ?? 'Unknown error'}`);
+      }
+    } catch {
+      alert('Action failed');
+    }
+    setActionLoading(false);
+  };
+
+  return (
+    <div className="min-h-screen bg-slate-950 text-slate-100 p-6 lg:p-10">
+      <div className="max-w-7xl mx-auto space-y-6">
+        <div className="flex items-center justify-between">
+          <h1 className="text-3xl font-bold">User Management</h1>
+          <a href="/admin" className="text-sm text-blue-400 hover:text-blue-300 underline">
+            ← Dashboard
+          </a>
+        </div>
+
+        {/* Search */}
+        <form onSubmit={handleSearch} className="flex gap-2">
+          <input
+            type="text"
+            placeholder="Search by email or name..."
+            value={searchInput}
+            onChange={(e) => setSearchInput(e.target.value)}
+            className="flex-1 bg-slate-900 border border-slate-700 rounded-lg px-4 py-2 text-sm focus:outline-none focus:border-blue-500"
+          />
+          <button type="submit" className="bg-blue-600 hover:bg-blue-500 px-4 py-2 rounded-lg text-sm font-medium">
+            Search
+          </button>
+        </form>
+
+        {/* Table */}
+        <div className="overflow-x-auto bg-slate-900 border border-slate-800 rounded-xl">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-slate-800 text-slate-400">
+                <th className="text-left p-3">Email</th>
+                <th className="text-left p-3">Name</th>
+                <th className="text-left p-3">Plan</th>
+                <th className="text-left p-3">Assistant</th>
+                <th className="text-left p-3">Joined</th>
+              </tr>
+            </thead>
+            <tbody>
+              {loading ? (
+                <tr><td colSpan={5} className="p-6 text-center text-slate-500">Loading...</td></tr>
+              ) : users.length === 0 ? (
+                <tr><td colSpan={5} className="p-6 text-center text-slate-500">No users found</td></tr>
+              ) : users.map((u) => (
+                <tr
+                  key={u.id}
+                  onClick={() => setSelectedUser(u)}
+                  className="border-b border-slate-800/50 hover:bg-slate-800/30 cursor-pointer"
+                >
+                  <td className="p-3 font-mono text-xs">{u.email}</td>
+                  <td className="p-3">{u.name ?? '—'}</td>
+                  <td className="p-3">
+                    <span className="px-2 py-0.5 rounded-full text-xs bg-slate-800">
+                      {u.plan ?? 'free'}
+                    </span>
+                  </td>
+                  <td className="p-3">
+                    {u.assistant_status ? (
+                      <span className={`px-2 py-0.5 rounded-full text-xs ${
+                        u.assistant_status === 'running' ? 'bg-green-900/50 text-green-400' :
+                        u.assistant_status === 'suspended' ? 'bg-yellow-900/50 text-yellow-400' :
+                        'bg-slate-800 text-slate-400'
+                      }`}>
+                        {u.assistant_status}
+                      </span>
+                    ) : (
+                      <span className="text-slate-500">none</span>
+                    )}
+                  </td>
+                  <td className="p-3 text-slate-400">{new Date(u.created_at).toLocaleDateString()}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        {/* Pagination */}
+        {totalPages > 1 && (
+          <div className="flex items-center justify-between text-sm">
+            <span className="text-slate-400">{total} users total</span>
+            <div className="flex gap-2">
+              <button
+                onClick={() => setPage((p) => Math.max(1, p - 1))}
+                disabled={page <= 1}
+                className="px-3 py-1 bg-slate-800 rounded disabled:opacity-40"
+              >
+                Prev
+              </button>
+              <span className="px-3 py-1 text-slate-400">
+                {page} / {totalPages}
+              </span>
+              <button
+                onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+                disabled={page >= totalPages}
+                className="px-3 py-1 bg-slate-800 rounded disabled:opacity-40"
+              >
+                Next
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* User Detail Modal */}
+        {selectedUser && (
+          <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-4">
+            <div className="bg-slate-900 border border-slate-700 rounded-xl p-6 w-full max-w-lg space-y-4">
+              <div className="flex justify-between items-start">
+                <h2 className="text-xl font-bold">User Details</h2>
+                <button onClick={() => setSelectedUser(null)} className="text-slate-400 hover:text-white text-lg">✕</button>
+              </div>
+
+              <div className="space-y-2 text-sm">
+                <div><span className="text-slate-400">Email:</span> <span className="font-mono">{selectedUser.email}</span></div>
+                <div><span className="text-slate-400">Name:</span> {selectedUser.name ?? '—'}</div>
+                <div><span className="text-slate-400">Plan:</span> {selectedUser.plan ?? 'free'}</div>
+                <div><span className="text-slate-400">Assistant:</span> {selectedUser.assistant_status ?? 'none'}</div>
+                <div><span className="text-slate-400">Joined:</span> {new Date(selectedUser.created_at).toLocaleString()}</div>
+              </div>
+
+              <div className="border-t border-slate-800 pt-4 space-y-2">
+                <h3 className="text-sm font-semibold text-slate-400">Actions</h3>
+                <div className="flex flex-wrap gap-2">
+                  <button
+                    disabled={actionLoading}
+                    onClick={() => handleAction(selectedUser.id, 'change-plan', { plan: selectedUser.plan === 'pro' ? 'free' : 'pro' })}
+                    className="px-3 py-1.5 bg-blue-600 hover:bg-blue-500 rounded text-xs font-medium disabled:opacity-50"
+                  >
+                    {selectedUser.plan === 'pro' ? 'Downgrade to Free' : 'Upgrade to Pro'}
+                  </button>
+                  {selectedUser.assistant_status === 'running' && (
+                    <button
+                      disabled={actionLoading}
+                      onClick={() => handleAction(selectedUser.id, 'suspend-assistant')}
+                      className="px-3 py-1.5 bg-yellow-600 hover:bg-yellow-500 rounded text-xs font-medium disabled:opacity-50"
+                    >
+                      Suspend Assistant
+                    </button>
+                  )}
+                  {selectedUser.assistant_status && selectedUser.assistant_status !== 'destroyed' && (
+                    <button
+                      disabled={actionLoading}
+                      onClick={() => {
+                        if (confirm('Destroy this assistant? This cannot be undone.')) {
+                          handleAction(selectedUser.id, 'destroy-assistant');
+                        }
+                      }}
+                      className="px-3 py-1.5 bg-red-600 hover:bg-red-500 rounded text-xs font-medium disabled:opacity-50"
+                    >
+                      Destroy Assistant
+                    </button>
+                  )}
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/api/admin/assistants/route.ts
+++ b/apps/web/src/app/api/admin/assistants/route.ts
@@ -1,0 +1,60 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { isAdmin } from '@/lib/admin/auth';
+
+export async function GET(request: Request) {
+  try {
+    const supabase: any = await createClient();
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    if (!isAdmin(user.email)) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+
+    const url = new URL(request.url);
+    const status = url.searchParams.get('status');
+
+    let query = supabase
+      .from('assistants')
+      .select('id, user_id, status, ip_address, created_at, server_id, plan')
+      .neq('status', 'destroyed')
+      .order('created_at', { ascending: false });
+
+    if (status) {
+      query = query.eq('status', status);
+    }
+
+    const { data: assistants, error } = await query;
+
+    if (error) {
+      console.error('Admin assistants query error:', error);
+      return NextResponse.json({ error: 'Query failed' }, { status: 500 });
+    }
+
+    // Get user emails for each assistant
+    const userIds = [...new Set((assistants ?? []).map((a: any) => a.user_id))];
+    const { data: profiles } = await supabase
+      .from('profiles')
+      .select('id, email')
+      .in('id', userIds);
+
+    const emailMap: Record<string, string> = {};
+    for (const p of profiles ?? []) {
+      emailMap[p.id] = p.email;
+    }
+
+    const enriched = (assistants ?? []).map((a: any) => ({
+      ...a,
+      user_email: emailMap[a.user_id] ?? 'unknown',
+    }));
+
+    return NextResponse.json({ assistants: enriched });
+  } catch (err) {
+    console.error('Admin assistants error:', err);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/apps/web/src/app/api/admin/stats/route.ts
+++ b/apps/web/src/app/api/admin/stats/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { isAdmin } from '@/lib/admin/auth';
+
+export async function GET(request: Request) {
+  try {
+    const supabase: any = await createClient();
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    if (!isAdmin(user.email)) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+
+    // Total users
+    const { count: totalUsers } = await supabase
+      .from('profiles')
+      .select('*', { count: 'exact', head: true });
+
+    // Active assistants
+    const { count: activeAssistants } = await supabase
+      .from('assistants')
+      .select('*', { count: 'exact', head: true })
+      .eq('status', 'running');
+
+    // Total VMs (not destroyed)
+    const { count: totalVMs } = await supabase
+      .from('assistants')
+      .select('*', { count: 'exact', head: true })
+      .neq('status', 'destroyed');
+
+    // Users by plan
+    const { data: planData } = await supabase
+      .from('profiles')
+      .select('plan');
+
+    const usersByPlan: Record<string, number> = {};
+    for (const row of planData ?? []) {
+      const plan = row.plan ?? 'free';
+      usersByPlan[plan] = (usersByPlan[plan] ?? 0) + 1;
+    }
+
+    return NextResponse.json({
+      total_users: totalUsers ?? 0,
+      active_assistants: activeAssistants ?? 0,
+      total_vms: totalVMs ?? 0,
+      users_by_plan: usersByPlan,
+    });
+  } catch (err) {
+    console.error('Admin stats error:', err);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/apps/web/src/app/api/admin/users/route.ts
+++ b/apps/web/src/app/api/admin/users/route.ts
@@ -1,0 +1,69 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { isAdmin } from '@/lib/admin/auth';
+
+export async function GET(request: Request) {
+  try {
+    const supabase: any = await createClient();
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    if (!isAdmin(user.email)) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+
+    const url = new URL(request.url);
+    const page = parseInt(url.searchParams.get('page') ?? '1', 10);
+    const limit = Math.min(parseInt(url.searchParams.get('limit') ?? '20', 10), 100);
+    const search = url.searchParams.get('search') ?? '';
+    const offset = (page - 1) * limit;
+
+    let query = supabase
+      .from('profiles')
+      .select('id, email, name, plan, created_at', { count: 'exact' })
+      .order('created_at', { ascending: false })
+      .range(offset, offset + limit - 1);
+
+    if (search) {
+      query = query.or(`email.ilike.%${search}%,name.ilike.%${search}%`);
+    }
+
+    const { data: users, count, error } = await query;
+
+    if (error) {
+      console.error('Admin users query error:', error);
+      return NextResponse.json({ error: 'Query failed' }, { status: 500 });
+    }
+
+    // Fetch assistant status for these users
+    const userIds = (users ?? []).map((u: any) => u.id);
+    const { data: assistants } = await supabase
+      .from('assistants')
+      .select('user_id, status')
+      .in('user_id', userIds)
+      .neq('status', 'destroyed');
+
+    const assistantMap: Record<string, string> = {};
+    for (const a of assistants ?? []) {
+      assistantMap[a.user_id] = a.status;
+    }
+
+    const enriched = (users ?? []).map((u: any) => ({
+      ...u,
+      assistant_status: assistantMap[u.id] ?? null,
+    }));
+
+    return NextResponse.json({
+      users: enriched,
+      total: count ?? 0,
+      page,
+      limit,
+    });
+  } catch (err) {
+    console.error('Admin users error:', err);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/apps/web/src/lib/admin/auth.ts
+++ b/apps/web/src/lib/admin/auth.ts
@@ -1,0 +1,20 @@
+/**
+ * Admin authorization utilities.
+ *
+ * Set ADMIN_EMAILS as a comma-separated list of email addresses in your
+ * environment to grant admin access.
+ */
+
+export function getAdminEmails(): string[] {
+  const raw = process.env.ADMIN_EMAILS ?? '';
+  return raw
+    .split(',')
+    .map((e) => e.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+export function isAdmin(email: string | undefined | null): boolean {
+  if (!email) return false;
+  const admins = getAdminEmails();
+  return admins.includes(email.toLowerCase());
+}


### PR DESCRIPTION
## Admin Dashboard & API

Adds a complete admin interface for managing the platform.

### New files

| File | Purpose |
|------|---------|
| `src/lib/admin/auth.ts` | `isAdmin()` check against `ADMIN_EMAILS` env var |
| `src/app/admin/page.tsx` | Dashboard with stats cards, recent signups, active VMs |
| `src/app/admin/users/page.tsx` | User management: search, pagination, detail modal, actions |
| `src/app/api/admin/stats/route.ts` | GET stats (total users, assistants, VMs, users by plan) |
| `src/app/api/admin/users/route.ts` | GET paginated users with search + assistant status |
| `src/app/api/admin/assistants/route.ts` | GET active assistants with user info, filterable by status |

### Setup
Add `ADMIN_EMAILS=you@example.com` to `.env` (comma-separated for multiple admins).

### Notes
- All routes require auth + admin check (401/403 on failure)
- Dark theme matches existing dashboard UI
- User detail modal has plan change + suspend/destroy assistant actions (action endpoints are stubbed — will need corresponding backend routes)
- Revenue card is a placeholder