### PR TITLE
feat: Pricing pivot — BYOC model (Free/Plus/Pro)

### DIFF
--- a/apps/web/src/app/dashboard/components/plan-card.tsx
+++ b/apps/web/src/app/dashboard/components/plan-card.tsx
@@ -2,9 +2,9 @@ import Link from "next/link";
 import { PLANS, type PlanKey } from "@/lib/stripe/config";
 
 const planLimits: Record<PlanKey, string[]> = {
-  free: ["100 messages / day", "Daytime hours only", "Shared infrastructure"],
-  starter: ["Unlimited messages", "24/7 access", "Dedicated assistant"],
-  pro: ["Unlimited messages", "24/7 access", "Priority support", "Custom integrations"],
+  free: ["100 messages / day", "1 cloud account", "Basic skills", "Community support"],
+  plus: ["Unlimited messages", "2 cloud accounts", "All skills", "Priority support"],
+  pro: ["Unlimited messages", "5 cloud accounts", "Custom skills + API access", "White-glove setup"],
 };
 
 export function PlanCard({ plan }: { plan: PlanKey }) {
@@ -31,10 +31,14 @@ export function PlanCard({ plan }: { plan: PlanKey }) {
         ))}
       </ul>
 
+      <p className="text-xs text-slate-500 mb-4">
+        Cloud hosting billed separately by your provider (~$6-12/mo).
+      </p>
+
       {plan === "free" && (
         <div className="pt-2 border-t border-slate-800">
           <p className="text-sm text-slate-400 mb-3">
-            Upgrade to get 24/7 access and unlimited messages
+            Upgrade for unlimited messages and more cloud accounts
           </p>
           <Link
             href="/api/stripe/checkout"

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -33,19 +33,18 @@ export default function Home() {
       {/* Hero */}
       <section className="mx-auto max-w-4xl px-6 pt-24 pb-16 text-center">
         <div className="inline-block rounded-full bg-violet-500/10 border border-violet-500/20 px-4 py-1.5 text-sm text-violet-300 mb-8">
-          No setup. No installs. Just chat.
+          Runs on your own cloud. You stay in control.
         </div>
         <h1 className="text-5xl font-bold leading-tight sm:text-6xl lg:text-7xl">
-          Your own AI assistant
+          Your personal AI assistant
           <br />
           <span className="bg-gradient-to-r from-violet-400 to-fuchsia-400 bg-clip-text text-transparent">
-            in 60 seconds
+            Runs on your cloud
           </span>
         </h1>
         <p className="mx-auto mt-6 max-w-2xl text-lg text-slate-400 leading-relaxed">
-          An AI assistant that actually <em>does things</em> — reads your email,
-          manages your calendar, browses the web, and runs 24/7.
-          Connect WhatsApp or Telegram and start talking.
+          Your personal AI assistant. Runs on your cloud. Does the work so you don&apos;t have to.
+          Connect your own DigitalOcean account, link WhatsApp or Telegram, and start talking.
         </p>
         <div className="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4">
           <a
@@ -224,48 +223,46 @@ export default function Home() {
             {
               name: "Free",
               price: "$0",
-              period: "forever",
-              desc: "Try it out, no commitment",
+              period: "",
+              desc: "Free forever — no credit card required",
               features: [
-                "Assistant available 8 hours/day",
+                "1 assistant",
                 "100 messages per day",
-                "Web search & general Q&A",
-                "One chat platform",
+                "Basic skills",
+                "1 cloud account",
                 "Community support",
               ],
-              cta: "Get Started Free",
+              cta: "Get Started",
               highlight: false,
             },
             {
-              name: "Starter",
-              price: "$12",
+              name: "Plus",
+              price: "$9",
               period: "/month",
-              desc: "Your full-time assistant",
+              desc: "Unlimited power for your assistant",
               features: [
-                "24/7 availability",
                 "Unlimited messages",
-                "Email + calendar integration",
-                "Web browsing & research",
+                "All skills included",
+                "2 cloud accounts",
                 "Multiple chat platforms",
-                "Email support",
+                "Priority support",
               ],
-              cta: "Start Free Trial",
+              cta: "Start Free, Upgrade Later",
               highlight: true,
             },
             {
               name: "Pro",
-              price: "$25",
+              price: "$19",
               period: "/month",
-              desc: "Maximum capability",
+              desc: "For power users and teams",
               features: [
-                "Everything in Starter",
-                "Smart home control",
-                "Social media management",
-                "Custom workflows",
-                "Priority support (4h)",
+                "Everything in Plus",
+                "Custom skills",
                 "API access",
+                "5 cloud accounts",
+                "White-glove setup",
               ],
-              cta: "Start Free Trial",
+              cta: "Go Pro",
               highlight: false,
             },
           ].map((p) => (
@@ -303,6 +300,9 @@ export default function Home() {
             </div>
           ))}
         </div>
+        <p className="text-center text-sm text-slate-500 mt-8">
+          Plus your cloud hosting (~$6/mo on DigitalOcean). You pay them directly — we never touch your server bill.
+        </p>
       </section>
 
       {/* FAQ */}

--- a/apps/web/src/lib/billing/plan-enforcement.ts
+++ b/apps/web/src/lib/billing/plan-enforcement.ts
@@ -3,16 +3,19 @@ import type { PlanKey } from "@/lib/stripe/config";
 
 /**
  * Plan limits by tier.
+ *
+ * Users pay their own cloud provider for the VM — no reason to restrict hours.
+ * Free tier is limited by messages per day and cloud accounts.
  */
-export const FREE_LIMITS = { messagesPerDay: 100, hoursPerDay: 8, platforms: 1 } as const;
-export const STARTER_LIMITS = { messagesPerDay: Infinity, hoursPerDay: 24, platforms: 3 } as const;
-export const PRO_LIMITS = { messagesPerDay: Infinity, hoursPerDay: 24, platforms: Infinity } as const;
+export const FREE_LIMITS = { messagesPerDay: 100, hoursPerDay: 24, platforms: 1, cloudAccounts: 1 } as const;
+export const PLUS_LIMITS = { messagesPerDay: Infinity, hoursPerDay: 24, platforms: 3, cloudAccounts: 2 } as const;
+export const PRO_LIMITS = { messagesPerDay: Infinity, hoursPerDay: 24, platforms: Infinity, cloudAccounts: 5 } as const;
 
-export type PlanLimits = { messagesPerDay: number; hoursPerDay: number; platforms: number };
+export type PlanLimits = { messagesPerDay: number; hoursPerDay: number; platforms: number; cloudAccounts: number };
 
 const LIMITS_BY_PLAN: Record<string, PlanLimits> = {
   free: FREE_LIMITS,
-  starter: STARTER_LIMITS,
+  plus: PLUS_LIMITS,
   pro: PRO_LIMITS,
 };
 
@@ -95,6 +98,37 @@ export async function checkPlatformLimit(
     allowed: used < limits.platforms,
     used,
     limit: limits.platforms,
+  };
+}
+
+/**
+ * Check whether a user can connect more cloud accounts.
+ */
+export async function checkCloudAccountLimit(
+  userId: string,
+): Promise<{ allowed: boolean; used: number; limit: number }> {
+  const supabase: any = await createClient();
+
+  const { data: sub } = await supabase
+    .from("subscriptions")
+    .select("plan")
+    .eq("user_id", userId)
+    .single();
+
+  const plan = sub?.plan ?? "free";
+  const limits = getLimitsForPlan(plan);
+
+  const { count } = await supabase
+    .from("cloud_accounts")
+    .select("*", { count: "exact", head: true })
+    .eq("user_id", userId);
+
+  const used = count ?? 0;
+
+  return {
+    allowed: used < limits.cloudAccounts,
+    used,
+    limit: limits.cloudAccounts,
   };
 }
 

--- a/apps/web/src/lib/stripe/config.ts
+++ b/apps/web/src/lib/stripe/config.ts
@@ -1,5 +1,9 @@
 /**
- * Stripe product and price configuration for Claw4All tiers.
+ * Stripe product and price configuration for HandsOff tiers.
+ *
+ * PRICING MODEL: HandsOff charges for the software/service layer only.
+ * Users pay their cloud provider separately (~$6-12/mo for the VM).
+ * Users connect their own cloud account (DigitalOcean, later Azure).
  *
  * Set these environment variables to match the IDs created in your Stripe
  * dashboard (or via the setup instructions in docs/stripe-setup.md).
@@ -11,14 +15,14 @@ export const PLANS = {
     priceMonthly: 0,
     stripePriceId: null,
   },
-  starter: {
-    name: "Starter",
-    priceMonthly: 1200, // $12.00 in cents
-    stripePriceId: process.env.STRIPE_PRICE_STARTER || "price_starter_placeholder",
+  plus: {
+    name: "Plus",
+    priceMonthly: 900, // $9.00 in cents
+    stripePriceId: process.env.STRIPE_PRICE_PLUS || "price_plus_placeholder",
   },
   pro: {
     name: "Pro",
-    priceMonthly: 2500, // $25.00 in cents
+    priceMonthly: 1900, // $19.00 in cents
     stripePriceId: process.env.STRIPE_PRICE_PRO || "price_pro_placeholder",
   },
 } as const;
@@ -27,7 +31,7 @@ export type PlanKey = keyof typeof PLANS;
 
 /** Map a Stripe price ID back to a plan key. */
 export function planKeyFromPriceId(priceId: string): PlanKey | null {
-  if (priceId === PLANS.starter.stripePriceId) return "starter";
+  if (priceId === PLANS.plus.stripePriceId) return "plus";
   if (priceId === PLANS.pro.stripePriceId) return "pro";
   return null;
 }


### PR DESCRIPTION
## Pricing Pivot

HandsOff no longer hosts VMs. Users connect their own cloud account (DigitalOcean, later Azure) and pay the cloud provider directly. HandsOff charges for the **software/service layer only**.

### New Tiers
| Tier | Price | Key Limits |
|------|-------|------------|
| Free | $0 | 1 assistant, 100 msg/day, 1 cloud account |
| Plus | $9/mo | Unlimited messages, all skills, 2 cloud accounts |
| Pro | $19/mo | Custom skills, API access, 5 cloud accounts |

### Changes
- **`stripe/config.ts`** — Renamed Starter→Plus, updated prices ($9/$19), updated price ID mappings
- **`page.tsx`** — Hero reflects BYOC model, pricing cards updated with new tiers/features/CTAs, added cloud hosting note
- **`plan-enforcement.ts`** — Removed 8h/day limit (users pay for their own VM), added `cloudAccounts` to all limits, added `checkCloudAccountLimit()`
- **`plan-card.tsx`** — Updated plan names, features, and added cloud hosting cost note