### PR TITLE
feat: DigitalOcean OAuth — users connect their own DO account

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,11 @@ DATABASE_URL=
 # Hetzner Cloud — used by Claw4All to provision VMs
 # Get your token at https://console.hetzner.cloud → Project → Security → API Tokens
 HETZNER_API_TOKEN=
+
+# DigitalOcean OAuth — users connect their own DO account
+DO_CLIENT_ID=
+DO_CLIENT_SECRET=
+DO_REDIRECT_URI=
+
+# Encryption key for storing provider OAuth tokens
+TOKEN_ENCRYPTION_KEY=

--- a/apps/web/src/app/api/auth/digitalocean/callback/route.ts
+++ b/apps/web/src/app/api/auth/digitalocean/callback/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { saveProviderToken } from '@/lib/providers/token-store';
+
+export async function GET(request: NextRequest) {
+  const code = request.nextUrl.searchParams.get('code');
+  if (!code) {
+    return NextResponse.redirect(new URL('/onboarding/connect?error=missing_code', request.url));
+  }
+
+  // Exchange code for tokens
+  const tokenRes = await fetch('https://cloud.digitalocean.com/v1/oauth/token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      grant_type: 'authorization_code',
+      code,
+      client_id: process.env.DO_CLIENT_ID!,
+      client_secret: process.env.DO_CLIENT_SECRET!,
+      redirect_uri: process.env.DO_REDIRECT_URI!,
+    }),
+  });
+
+  if (!tokenRes.ok) {
+    return NextResponse.redirect(new URL('/onboarding/connect?error=token_exchange', request.url));
+  }
+
+  const tokenData = await tokenRes.json();
+
+  // Get current user
+  const supabase: any = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.redirect(new URL('/auth/signin', request.url));
+  }
+
+  // Store encrypted tokens
+  const expiresAt = tokenData.expires_in
+    ? new Date(Date.now() + tokenData.expires_in * 1000)
+    : null;
+
+  await saveProviderToken(
+    user.id,
+    'digitalocean',
+    tokenData.access_token,
+    tokenData.refresh_token,
+    expiresAt,
+  );
+
+  return NextResponse.redirect(new URL('/onboarding/connect?connected=digitalocean', request.url));
+}

--- a/apps/web/src/app/api/auth/digitalocean/route.ts
+++ b/apps/web/src/app/api/auth/digitalocean/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  const clientId = process.env.DO_CLIENT_ID;
+  const redirectUri = process.env.DO_REDIRECT_URI;
+
+  if (!clientId || !redirectUri) {
+    return NextResponse.json({ error: 'DigitalOcean OAuth not configured' }, { status: 500 });
+  }
+
+  const params = new URLSearchParams({
+    client_id: clientId,
+    redirect_uri: redirectUri,
+    response_type: 'code',
+    scope: 'read write',
+  });
+
+  return NextResponse.redirect(
+    `https://cloud.digitalocean.com/v1/oauth/authorize?${params.toString()}`,
+  );
+}

--- a/apps/web/src/app/onboarding/connect/page.tsx
+++ b/apps/web/src/app/onboarding/connect/page.tsx
@@ -1,5 +1,6 @@
 import { redirect } from 'next/navigation';
 import { createClient } from '@/lib/supabase/server';
+import { getProviderToken } from '@/lib/providers/token-store';
 import Link from 'next/link';
 
 const APPS = [
@@ -10,22 +11,73 @@ const APPS = [
   { name: 'Slack', icon: '💼', description: 'Chat on Slack' },
 ];
 
-export default async function ConnectPage() {
-  const supabase = await createClient();
+export default async function ConnectPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ connected?: string; error?: string }>;
+}) {
+  const supabase: any = await createClient();
   const { data: { user } } = await supabase.auth.getUser();
 
   if (!user) {
     redirect('/auth/signin');
   }
 
+  const params = await searchParams;
+  const doToken = await getProviderToken(user.id, 'digitalocean');
+  const isConnected = !!doToken || params.connected === 'digitalocean';
+
   return (
     <div className="min-h-screen bg-slate-950 flex items-center justify-center px-4">
       <div className="max-w-lg w-full space-y-8">
+        {/* Step 1: Connect Cloud */}
         <div className="text-center space-y-3">
           <h1 className="text-3xl font-bold text-white">
-            Connect a chat app
+            Connect your cloud
           </h1>
           <p className="text-slate-400">
+            We&apos;ll set up your assistant on your own DigitalOcean account. You pay them directly (~$6/mo).
+          </p>
+        </div>
+
+        <div className="space-y-3">
+          <div className="flex items-center justify-between p-4 bg-slate-900 rounded-xl border border-slate-800">
+            <div className="flex items-center gap-3">
+              <span className="text-2xl">🌊</span>
+              <div>
+                <p className="text-white font-medium">DigitalOcean</p>
+                <p className="text-slate-500 text-sm">
+                  {isConnected ? 'Account connected' : 'Connect your cloud account'}
+                </p>
+              </div>
+            </div>
+            {isConnected ? (
+              <span className="px-4 py-2 bg-green-900/50 text-green-400 text-sm rounded-lg">
+                ✓ Connected
+              </span>
+            ) : (
+              <a
+                href="/api/auth/digitalocean"
+                className="px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white text-sm rounded-lg transition-colors"
+              >
+                Connect DigitalOcean
+              </a>
+            )}
+          </div>
+
+          {params.error && (
+            <p className="text-red-400 text-sm text-center">
+              Failed to connect. Please try again.
+            </p>
+          )}
+        </div>
+
+        {/* Step 2: Connect Chat App */}
+        <div className="text-center space-y-3 pt-4">
+          <h2 className="text-xl font-semibold text-white">
+            Connect a chat app
+          </h2>
+          <p className="text-slate-400 text-sm">
             Pick your favorite way to talk to your assistant.
           </p>
         </div>

--- a/apps/web/src/lib/providers/digitalocean.ts
+++ b/apps/web/src/lib/providers/digitalocean.ts
@@ -1,0 +1,102 @@
+const API = 'https://api.digitalocean.com/v2';
+const TAG = 'handsoff';
+
+interface DropletOptions {
+  name: string;
+  cloudInit?: string;
+  size?: string;
+  region?: string;
+  image?: string;
+}
+
+interface Droplet {
+  id: number;
+  name: string;
+  status: string;
+  networks: {
+    v4: Array<{ ip_address: string; type: string }>;
+  };
+  region: { slug: string };
+}
+
+async function doFetch(token: string, path: string, init: RequestInit = {}) {
+  const res = await fetch(`${API}${path}`, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      ...init.headers,
+    },
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    throw new Error(`DigitalOcean API error ${res.status}: ${body}`);
+  }
+  if (res.status === 204) return null;
+  return res.json();
+}
+
+export async function createDroplet(token: string, options: DropletOptions) {
+  const body = {
+    name: options.name,
+    region: options.region ?? 'nyc1',
+    size: options.size ?? 's-1vcpu-1gb',
+    image: options.image ?? 'ubuntu-24-04-x64',
+    tags: [TAG],
+    user_data: options.cloudInit,
+  };
+  const data = await doFetch(token, '/droplets', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+  const droplet: Droplet = data.droplet;
+  const publicIp = droplet.networks?.v4?.find((n: any) => n.type === 'public')?.ip_address ?? null;
+  return {
+    id: droplet.id,
+    name: droplet.name,
+    status: droplet.status,
+    publicIpv4: publicIp,
+    region: droplet.region.slug,
+  };
+}
+
+export async function destroyDroplet(token: string, dropletId: number) {
+  await doFetch(token, `/droplets/${dropletId}`, { method: 'DELETE' });
+}
+
+export async function getDroplet(token: string, dropletId: number) {
+  const data = await doFetch(token, `/droplets/${dropletId}`);
+  const d: Droplet = data.droplet;
+  return {
+    id: d.id,
+    name: d.name,
+    status: d.status,
+    publicIpv4: d.networks?.v4?.find((n: any) => n.type === 'public')?.ip_address ?? null,
+    region: d.region.slug,
+  };
+}
+
+export async function listDroplets(token: string) {
+  const data = await doFetch(token, `/droplets?tag_name=${TAG}`);
+  return (data.droplets as Droplet[]).map((d) => ({
+    id: d.id,
+    name: d.name,
+    status: d.status,
+    publicIpv4: d.networks?.v4?.find((n: any) => n.type === 'public')?.ip_address ?? null,
+    region: d.region.slug,
+  }));
+}
+
+export async function powerOn(token: string, dropletId: number) {
+  await doFetch(token, `/droplets/${dropletId}/actions`, {
+    method: 'POST',
+    body: JSON.stringify({ type: 'power_on' }),
+  });
+}
+
+export async function powerOff(token: string, dropletId: number) {
+  await doFetch(token, `/droplets/${dropletId}/actions`, {
+    method: 'POST',
+    body: JSON.stringify({ type: 'power_off' }),
+  });
+}

--- a/apps/web/src/lib/providers/token-store.ts
+++ b/apps/web/src/lib/providers/token-store.ts
@@ -1,0 +1,99 @@
+import crypto from 'crypto';
+import { createClient } from '../supabase/server';
+
+const ALGORITHM = 'aes-256-gcm';
+
+function getKey(): Buffer {
+  const key = process.env.TOKEN_ENCRYPTION_KEY;
+  if (!key) throw new Error('TOKEN_ENCRYPTION_KEY is not set');
+  return crypto.createHash('sha256').update(key).digest();
+}
+
+function encrypt(text: string): string {
+  const key = getKey();
+  const iv = crypto.randomBytes(12);
+  const cipher = crypto.createCipheriv(ALGORITHM, key, iv);
+  let encrypted = cipher.update(text, 'utf8', 'hex');
+  encrypted += cipher.final('hex');
+  const tag = cipher.getAuthTag().toString('hex');
+  return `${iv.toString('hex')}:${tag}:${encrypted}`;
+}
+
+function decrypt(data: string): string {
+  const key = getKey();
+  const [ivHex, tagHex, encrypted] = data.split(':');
+  const decipher = crypto.createDecipheriv(ALGORITHM, key, Buffer.from(ivHex, 'hex'));
+  decipher.setAuthTag(Buffer.from(tagHex, 'hex'));
+  let decrypted = decipher.update(encrypted, 'hex', 'utf8');
+  decrypted += decipher.final('utf8');
+  return decrypted;
+}
+
+export async function saveProviderToken(
+  userId: string,
+  provider: string,
+  accessToken: string,
+  refreshToken: string | null,
+  expiresAt: Date | null,
+) {
+  const supabase: any = await createClient();
+  const { error } = await supabase
+    .from('provider_tokens')
+    .upsert(
+      {
+        user_id: userId,
+        provider,
+        access_token_encrypted: encrypt(accessToken),
+        refresh_token_encrypted: refreshToken ? encrypt(refreshToken) : null,
+        expires_at: expiresAt?.toISOString() ?? null,
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: 'user_id,provider' },
+    );
+  if (error) throw new Error(`Failed to save token: ${error.message}`);
+}
+
+export async function getProviderToken(
+  userId: string,
+  provider: string,
+): Promise<{ accessToken: string; refreshToken: string | null; expiresAt: Date | null } | null> {
+  const supabase: any = await createClient();
+  const { data, error } = await supabase
+    .from('provider_tokens')
+    .select()
+    .eq('user_id', userId)
+    .eq('provider', provider)
+    .single();
+
+  if (error || !data) return null;
+
+  return {
+    accessToken: decrypt(data.access_token_encrypted),
+    refreshToken: data.refresh_token_encrypted ? decrypt(data.refresh_token_encrypted) : null,
+    expiresAt: data.expires_at ? new Date(data.expires_at) : null,
+  };
+}
+
+export async function refreshProviderToken(userId: string, provider: string) {
+  const existing = await getProviderToken(userId, provider);
+  if (!existing?.refreshToken) throw new Error('No refresh token available');
+
+  const res = await fetch('https://cloud.digitalocean.com/v1/oauth/token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      grant_type: 'refresh_token',
+      refresh_token: existing.refreshToken,
+      client_id: process.env.DO_CLIENT_ID!,
+      client_secret: process.env.DO_CLIENT_SECRET!,
+    }),
+  });
+
+  if (!res.ok) throw new Error(`Token refresh failed: ${res.status}`);
+  const data = await res.json();
+
+  const expiresAt = data.expires_in ? new Date(Date.now() + data.expires_in * 1000) : null;
+  await saveProviderToken(userId, provider, data.access_token, data.refresh_token, expiresAt);
+
+  return data.access_token as string;
+}

--- a/apps/web/src/lib/vm/lifecycle.ts
+++ b/apps/web/src/lib/vm/lifecycle.ts
@@ -1,10 +1,9 @@
 import { createClient } from '../supabase/server';
-import { HetznerProvider } from '../providers/hetzner';
+import { createDroplet, destroyDroplet, powerOn, powerOff } from '../providers/digitalocean';
+import { getProviderToken, refreshProviderToken } from '../providers/token-store';
 import { generateCloudInit } from '../providers/cloud-init';
 import type { Assistant, AssistantStatus } from '../supabase/types';
 import { randomUUID } from 'crypto';
-
-const hetzner = new HetznerProvider();
 
 const PORTAL_URL = process.env.NEXT_PUBLIC_APP_URL ?? 'https://app.claw4all.com';
 
@@ -44,10 +43,26 @@ async function updateAssistantStatus(
 }
 
 /**
- * Launch a new assistant VM for the given user.
+ * Get a valid DO access token for the user, refreshing if expired.
+ */
+async function getUserDOToken(userId: string): Promise<string> {
+  const tokenData = await getProviderToken(userId, 'digitalocean');
+  if (!tokenData) throw new Error('DigitalOcean account not connected. Please connect via Settings.');
+
+  // Refresh if expired or expiring within 5 minutes
+  if (tokenData.expiresAt && tokenData.expiresAt.getTime() < Date.now() + 5 * 60 * 1000) {
+    return await refreshProviderToken(userId, 'digitalocean');
+  }
+
+  return tokenData.accessToken;
+}
+
+/**
+ * Launch a new assistant VM on the user's DigitalOcean account.
  */
 export async function launchAssistant(userId: string): Promise<Assistant> {
   const supabase: any = await createClient();
+  const token = await getUserDOToken(userId);
 
   const assistantId = randomUUID();
   const sidecarToken = randomUUID();
@@ -64,7 +79,7 @@ export async function launchAssistant(userId: string): Promise<Assistant> {
     .insert({
       id: assistantId,
       user_id: userId,
-      provider: 'hetzner',
+      provider: 'digitalocean',
       status: 'provisioning' as AssistantStatus,
       sidecar_token: sidecarToken,
     })
@@ -74,27 +89,24 @@ export async function launchAssistant(userId: string): Promise<Assistant> {
   if (insertError) throw new Error(`Failed to create assistant: ${insertError.message}`);
 
   try {
-    const server = await hetzner.createServer({
+    const droplet = await createDroplet(token, {
       name: `claw-${assistantId.slice(0, 8)}`,
       cloudInit,
-      labels: { managed_by: 'claw4all', assistant_id: assistantId },
     });
 
-    // Update with VM info
     return await updateAssistantStatus(assistantId, 'provisioning', {
-      vm_id: server.id,
-      ip_address: server.publicIpv4,
-      region: server.region,
+      vm_id: String(droplet.id),
+      ip_address: droplet.publicIpv4,
+      region: droplet.region,
     });
   } catch (err) {
-    // Mark destroyed on failure
     await updateAssistantStatus(assistantId, 'destroyed').catch(() => {});
     throw err;
   }
 }
 
 /**
- * Suspend (power off) an assistant's VM.
+ * Suspend (power off) an assistant's droplet.
  */
 export async function suspendAssistant(assistantId: string): Promise<Assistant> {
   const supabase: any = await createClient();
@@ -110,12 +122,13 @@ export async function suspendAssistant(assistantId: string): Promise<Assistant> 
   assertTransition(assistant.status, 'suspended');
   if (!assistant.vm_id) throw new Error('No VM associated with assistant');
 
-  await hetzner.powerOff(assistant.vm_id);
+  const token = await getUserDOToken(assistant.user_id);
+  await powerOff(token, Number(assistant.vm_id));
   return await updateAssistantStatus(assistantId, 'suspended');
 }
 
 /**
- * Resume (power on) a suspended assistant's VM.
+ * Resume (power on) a suspended assistant's droplet.
  */
 export async function resumeAssistant(assistantId: string): Promise<Assistant> {
   const supabase: any = await createClient();
@@ -131,12 +144,13 @@ export async function resumeAssistant(assistantId: string): Promise<Assistant> {
   assertTransition(assistant.status, 'active');
   if (!assistant.vm_id) throw new Error('No VM associated with assistant');
 
-  await hetzner.powerOn(assistant.vm_id);
+  const token = await getUserDOToken(assistant.user_id);
+  await powerOn(token, Number(assistant.vm_id));
   return await updateAssistantStatus(assistantId, 'active');
 }
 
 /**
- * Destroy an assistant's VM permanently.
+ * Destroy an assistant's droplet permanently.
  */
 export async function destroyAssistant(assistantId: string): Promise<Assistant> {
   const supabase: any = await createClient();
@@ -154,14 +168,14 @@ export async function destroyAssistant(assistantId: string): Promise<Assistant> 
 
   try {
     if (assistant.vm_id) {
-      await hetzner.destroyServer(assistant.vm_id);
+      const token = await getUserDOToken(assistant.user_id);
+      await destroyDroplet(token, Number(assistant.vm_id));
     }
     return await updateAssistantStatus(assistantId, 'destroyed', {
       vm_id: null,
       ip_address: null,
     });
   } catch (err) {
-    // Still mark destroyed — VM may already be gone
     return await updateAssistantStatus(assistantId, 'destroyed', {
       vm_id: null,
       ip_address: null,

--- a/supabase/migrations/002_provider_tokens.sql
+++ b/supabase/migrations/002_provider_tokens.sql
@@ -1,0 +1,18 @@
+-- Provider OAuth tokens (DigitalOcean, Azure, etc.)
+CREATE TABLE provider_tokens (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE,
+  provider TEXT NOT NULL,
+  access_token_encrypted TEXT NOT NULL,
+  refresh_token_encrypted TEXT,
+  expires_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  updated_at TIMESTAMPTZ DEFAULT now(),
+  UNIQUE(user_id, provider)
+);
+
+ALTER TABLE provider_tokens ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can only access own tokens"
+  ON provider_tokens FOR ALL
+  USING (auth.uid() = user_id);


### PR DESCRIPTION
## Big Pivot

Users now connect their **own** DigitalOcean account via OAuth. We provision droplets on their account — they pay DO directly (~$6/mo).

### What's new

- **`lib/providers/digitalocean.ts`** — DO API v2 client (create/destroy/list/power on/off droplets, tagged `handsoff`)
- **`api/auth/digitalocean/route.ts`** — OAuth initiation (redirects to DO authorize)
- **`api/auth/digitalocean/callback/route.ts`** — OAuth callback (exchanges code, stores encrypted tokens)
- **`lib/providers/token-store.ts`** — AES-256-GCM encrypted token storage with auto-refresh
- **`supabase/migrations/002_provider_tokens.sql`** — New table with RLS
- **`lib/vm/lifecycle.ts`** — Rewired from Hetzner to DO using user's OAuth token
- **`onboarding/connect/page.tsx`** — "Connect DigitalOcean" as first onboarding step

### Env vars needed
```
DO_CLIENT_ID=
DO_CLIENT_SECRET=
DO_REDIRECT_URI=
TOKEN_ENCRYPTION_KEY=
```