### PR TITLE
Make DigitalOcean the primary/default provider

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -9,7 +9,7 @@ The target user has never opened a terminal. Every interaction happens through a
 We never host user data or agents. We provision and configure on the user's own VPS account, then hand over the keys. Their server, their data, their control.
 
 ## 3. Provider Agnostic
-Support multiple VPS providers (Hetzner, DigitalOcean, Vultr, Linode). Never lock users into a single provider. Recommend the best value, but let them choose.
+Support multiple VPS providers starting with DigitalOcean as the primary provider. Additional providers (Hetzner, Vultr, Linode) may be added in the future. Never lock users into a single provider. Recommend the best value, but let them choose.
 
 ## 4. Free Core, Premium Extras
 The basic setup wizard is always free. Revenue comes from premium skill packs, advanced integrations, support tiers, and provider referral commissions — never from gatekeeping the basics.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 | Database | Supabase (PostgreSQL) |
 | Auth | Supabase Auth |
 | Billing | Stripe |
-| VM Hosting | Hetzner Cloud |
+| VM Hosting | DigitalOcean |
 | Email | Resend |
 
 ## Quick Start
@@ -36,7 +36,7 @@ Open [http://localhost:3000](http://localhost:3000).
 
 ## Setup
 
-For the full setup guide (Supabase, Stripe, Hetzner, Resend, Vercel, domain config), see **[docs/SETUP.md](docs/SETUP.md)**.
+For the full setup guide (Supabase, Stripe, DigitalOcean, Resend, Vercel, domain config), see **[docs/SETUP.md](docs/SETUP.md)**.
 
 For environment variable reference, see **[docs/ENV_VARS.md](docs/ENV_VARS.md)**.
 

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -24,10 +24,11 @@ STRIPE_WEBHOOK_SECRET=whsec_...
 STRIPE_PRICE_PRO=price_...
 
 # -----------------------------------------------------------------------------
-# Hetzner (VM Hosting)
-# Get from: Hetzner Console → Security → API Tokens → Generate (read/write)
+# DigitalOcean (VM Hosting) — Primary provider
+# Get from: DigitalOcean → API → Generate New Token (read/write)
+# Note: Hetzner support is planned for a future release.
 # -----------------------------------------------------------------------------
-HETZNER_API_TOKEN=your-hetzner-token
+DO_API_TOKEN=your-digitalocean-token
 
 # -----------------------------------------------------------------------------
 # Resend (Email)

--- a/apps/web/src/data/constitution.md
+++ b/apps/web/src/data/constitution.md
@@ -9,7 +9,7 @@ The target user has never opened a terminal. Every interaction happens through a
 We never host user data or agents. We provision and configure on the user's own VPS account, then hand over the keys. Their server, their data, their control.
 
 ## 3. Provider Agnostic
-Support multiple VPS providers (Hetzner, DigitalOcean, Vultr, Linode). Never lock users into a single provider. Recommend the best value, but let them choose.
+Support multiple VPS providers starting with DigitalOcean as the primary provider. Additional providers (Hetzner, Vultr, Linode) may be added in the future. Never lock users into a single provider. Recommend the best value, but let them choose.
 
 ## 4. Free Core, Premium Extras
 The basic setup wizard is always free. Revenue comes from premium skill packs, advanced integrations, support tiers, and provider referral commissions — never from gatekeeping the basics.

--- a/apps/web/src/data/plan.md
+++ b/apps/web/src/data/plan.md
@@ -19,8 +19,8 @@
 └───────┼──────────────┼─────────────┼─────────┘
         │              │             │
    ┌────▼────┐   ┌─────▼────┐  ┌────▼─────┐
-   │ Hetzner │   │ Digital  │  │  Vultr   │
-   │   API   │   │ Ocean API│  │   API    │
+   │ Digital  │   │  (future) │  │ (future) │
+   │ Ocean API│   │  Hetzner  │  │  Vultr   │
    └────┬────┘   └─────┬────┘  └────┬─────┘
         │              │             │
    ┌────▼──────────────▼─────────────▼──────┐
@@ -50,7 +50,7 @@ Total infrastructure cost to run Claw4All: **$0/mo** until significant scale.
 | Database | Supabase (PostgreSQL) | Free tier |
 | Payments | Stripe | 2.9% + $0.30/txn |
 | Provisioning | Vercel Serverless Functions | Free tier (100K/mo) |
-| VPS APIs | Hetzner/DO/Vultr REST APIs | Free |
+| VPS APIs | DigitalOcean REST API (Hetzner/Vultr planned) | Free |
 | Sidecar Agent | Lightweight HTTP agent on user VPS | Bundled |
 | Monitoring | Sidecar heartbeat → Supabase | Free |
 
@@ -96,7 +96,7 @@ apps/
         dashboard/            # User dashboard
         marketplace/          # Skill marketplace
       lib/
-        providers/            # Hetzner, DO, Vultr API clients
+        providers/            # DigitalOcean (primary), Hetzner/Vultr (planned)
         provisioning/         # Cloud-init templates, setup logic
         sidecar/              # Sidecar API client
   sidecar/            # Sidecar agent (deployed to user VPS)

--- a/apps/web/src/data/spec.md
+++ b/apps/web/src/data/spec.md
@@ -16,7 +16,7 @@ Make OpenClaw accessible to everyone by automating the entire setup process. Use
 
 **Acceptance Criteria:**
 - Wizard walks through: pick provider → create account (via referral link) → generate API key → paste it in → we do the rest
-- Supported providers: Hetzner (primary), DigitalOcean, Vultr
+- Supported providers: DigitalOcean (primary). Hetzner and Vultr planned for future.
 - User sees real-time progress ("Creating server… Installing OpenClaw… Connecting messaging…")
 - Total time from start to working agent: < 15 minutes
 - User receives credentials and a "your agent is ready" confirmation
@@ -81,7 +81,7 @@ Make OpenClaw accessible to everyone by automating the entire setup process. Use
 - Server health dashboard
 
 ### Referral Revenue (passive)
-- Hetzner: partner/affiliate commission on signups
+- DigitalOcean: $200 credit referral program
 - DigitalOcean: $200 credit referral program
 - Vultr: 10% recurring commission
 - Estimated: $0.50-1.50/mo per active user (recurring)

--- a/apps/web/src/data/tasks.md
+++ b/apps/web/src/data/tasks.md
@@ -11,13 +11,13 @@
 - [ ] T08: Set up Stripe account + products (Free, Basic $10, Pro $25)
 
 ## Phase 2: Provider Integrations (Week 2)
-- [ ] T09: Hetzner API client (create server, list servers, delete server, SSH keys)
+- [ ] T09: DigitalOcean API client (create server, list servers, delete server, SSH keys)
 - [ ] T10: DigitalOcean API client (same operations)
 - [ ] T11: Vultr API client (same operations)
 - [ ] T12: Provider abstraction layer (common interface for all providers)
 - [ ] T13: Cloud-init template for OpenClaw installation
 - [ ] T14: Cloud-init template for sidecar agent installation
-- [ ] T15: Test provisioning on Hetzner (manual API key)
+- [ ] T15: Test provisioning on DigitalOcean (manual API key)
 - [ ] T16: Test provisioning on DigitalOcean
 - [ ] T17: Set up referral/affiliate links for all providers
 

--- a/apps/web/src/lib/providers/index.ts
+++ b/apps/web/src/lib/providers/index.ts
@@ -1,4 +1,4 @@
-export { HetznerProvider } from "./hetzner";
+export { HetznerProvider } from "./hetzner"; // Planned — not yet active
 export { generateCloudInit } from "./cloud-init";
 export type { CloudProvider, ServerInfo, CreateServerOptions } from "./types";
 export type { CloudInitOptions } from "./cloud-init";

--- a/docs/ENV_VARS.md
+++ b/docs/ENV_VARS.md
@@ -13,7 +13,7 @@ Complete reference for all environment variables used by HandsOff.
 | `STRIPE_WEBHOOK_SECRET` | Stripe webhook signing secret | Stripe → Developers → Webhooks → endpoint → Signing secret | `whsec_abc123...` |
 | `STRIPE_PRICE_STARTER` | Price ID for Starter plan ($12/mo) | Stripe → Products → HandsOff Starter → Price ID | `price_1abc...` |
 | `STRIPE_PRICE_PRO` | Price ID for Pro plan ($25/mo) | Stripe → Products → HandsOff Pro → Price ID | `price_1def...` |
-| `HETZNER_API_TOKEN` | Hetzner Cloud API token (read/write) | Hetzner Console → Security → API Tokens | `htz_abc123...` |
+| `DO_API_TOKEN` | DigitalOcean API token (read/write) | DigitalOcean → API → Generate New Token | `dop_v1_abc123...` |
 | `RESEND_API_KEY` | Resend email API key | Resend → API Keys | `re_abc123...` |
 | `NEXT_PUBLIC_APP_URL` | Your app's public URL | Your domain / Vercel URL | `https://handsoff.yourdomain.com` |
 | `CRON_SECRET` | Secret for authenticating cron job endpoints | Generate: `openssl rand -hex 32` | `a1b2c3d4e5f6...` |

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -2,7 +2,7 @@
 
 Complete step-by-step instructions for setting up all external services needed to run HandsOff.
 
-> **Prerequisites:** A GitHub account, a credit card for Stripe/Hetzner, and ~30 minutes.
+> **Prerequisites:** A GitHub account, a credit card for Stripe/DigitalOcean, and ~30 minutes.
 
 ---
 
@@ -98,23 +98,26 @@ Stripe handles subscriptions and billing.
 
 ---
 
-## 3. Hetzner (VM Hosting)
+## 3. DigitalOcean (VM Hosting)
 
-Hetzner Cloud provides the virtual machines where user OpenClaw instances run.
+DigitalOcean provides the virtual machines (Droplets) where user OpenClaw instances run.
 
-1. Go to [console.hetzner.cloud](https://console.hetzner.cloud) → create an account
+1. Go to [cloud.digitalocean.com](https://cloud.digitalocean.com) → create an account
 2. Create a new project called **HandsOff** (or similar)
-3. Inside the project, go to **Security → API Tokens**
-4. Click **Generate API Token**
-   - Description: `handsoff-api`
-   - Permissions: **Read & Write**
-5. Copy the token immediately (it's only shown once) → `HETZNER_API_TOKEN`
+3. Go to **API** in the left sidebar
+4. Click **Generate New Token**
+   - Name: `handsoff-api`
+   - Expiration: No expiry (or set as needed)
+   - Scopes: **Read & Write**
+5. Copy the token immediately (it's only shown once) → `DO_API_TOKEN`
 
 ### Env vars from this step
 
 | Variable | Value |
 |----------|-------|
-| `HETZNER_API_TOKEN` | Your Hetzner API token |
+| `DO_API_TOKEN` | Your DigitalOcean API token |
+
+> **Note:** Hetzner support is planned for a future release.
 
 ---
 
@@ -170,7 +173,7 @@ Resend handles transactional emails (welcome emails, notifications, etc.).
 
 - [ ] Supabase project created, migration run, auth configured
 - [ ] Stripe products created, API keys copied, webhook set up
-- [ ] Hetzner project created, API token generated
+- [ ] DigitalOcean project created, API token generated
 - [ ] Resend account created, API key generated
 - [ ] All env vars added to Vercel
 - [ ] Domain configured and DNS propagated

--- a/scripts/setup-check.sh
+++ b/scripts/setup-check.sh
@@ -79,18 +79,18 @@ if [[ -n "${STRIPE_SECRET_KEY:-}" ]]; then
 fi
 echo
 
-# --- Hetzner ---
-echo -e "${BOLD}Hetzner${NC}"
-check_var HETZNER_API_TOKEN
+# --- DigitalOcean ---
+echo -e "${BOLD}DigitalOcean${NC}"
+check_var DO_API_TOKEN
 
-if [[ -n "${HETZNER_API_TOKEN:-}" ]]; then
+if [[ -n "${DO_API_TOKEN:-}" ]]; then
   status=$(curl -s -o /dev/null -w "%{http_code}" \
-    -H "Authorization: Bearer $HETZNER_API_TOKEN" \
-    "https://api.hetzner.cloud/v1/servers" 2>/dev/null || echo "000")
+    -H "Authorization: Bearer $DO_API_TOKEN" \
+    "https://api.digitalocean.com/v2/account" 2>/dev/null || echo "000")
   if [[ "$status" == "200" ]]; then
-    ok "Hetzner API connection OK"
+    ok "DigitalOcean API connection OK"
   else
-    fail "Hetzner API connection failed (HTTP $status)"
+    fail "DigitalOcean API connection failed (HTTP $status)"
   fi
 fi
 echo

--- a/specs/mvp/plan.md
+++ b/specs/mvp/plan.md
@@ -19,9 +19,9 @@
 └────────┼──────────────────────────┼───────────────┘
          │                          │
     ┌────▼─────┐             ┌──────▼───────┐
-    │ Hetzner  │             │   Stripe     │
-    │ API      │             │   Billing    │
-    │ (our     │             └──────────────┘
+    │ Digital  │             │   Stripe     │
+    │ Ocean    │             │   Billing    │
+    │ API (our │             └──────────────┘
     │ account) │
     └────┬─────┘
          │
@@ -38,7 +38,7 @@
 ## Key Architecture Decisions
 
 ### We Own the Infrastructure
-- Single Hetzner account, provisioned via API with our credentials
+- Single DigitalOcean account, provisioned via API with our credentials
 - Each user gets a dedicated VM (isolation, security, simplicity)
 - We manage lifecycle: create, monitor, update, suspend, destroy
 - User never sees or accesses the VM directly
@@ -57,7 +57,7 @@
 | Auth | Supabase Auth | Free tier |
 | Database | Supabase (PostgreSQL) | Free tier |
 | Payments | Stripe Subscriptions | 2.9% + $0.30/txn |
-| VM Provisioning | Hetzner Cloud API | ~$5/user/mo |
+| VM Provisioning | DigitalOcean API | ~$6/user/mo |
 | VM Management | Sidecar agent on each VM | Bundled |
 | Background Jobs | Vercel Cron or Inngest | Free tier |
 | AI API Keys | Our keys, metered per user | ~$3-8/user/mo |
@@ -65,7 +65,7 @@
 ## Provisioning Flow
 
 1. User clicks "Launch my assistant"
-2. Serverless function calls Hetzner API:
+2. Serverless function calls DigitalOcean API:
    - Create CX22 VM (2 vCPU, 4GB RAM, 40GB disk)
    - Inject cloud-init script that installs OpenClaw + sidecar agent
    - Tag VM with user ID
@@ -117,7 +117,8 @@ apps/
         onboarding/             # Post-signup messaging setup
         skills/                 # Skill library
       lib/
-        hetzner/                # Hetzner API client
+        digitalocean/           # DigitalOcean API client (primary)
+        hetzner/                # Hetzner API client (planned)
         orchestration/          # VM lifecycle management
         sidecar-client/         # Talk to sidecar agents
         billing/                # Stripe integration
@@ -134,7 +135,7 @@ specs/
 - **No user SSH access:** users never see or touch their VM
 - **Sidecar auth:** mTLS or rotating secrets, not user-facing
 - **AI API keys:** our keys stored encrypted, never exposed to users
-- **Hetzner API key:** single admin key, stored in Vercel env vars, never exposed
+- **DigitalOcean API key:** single admin key, stored in Vercel env vars, never exposed
 - **Data retention:** user cancels → VM destroyed after 30-day grace → data gone
 - **Compliance:** no user data stored on our portal beyond account info; all personal data lives on their isolated VM
 

--- a/specs/mvp/spec.md
+++ b/specs/mvp/spec.md
@@ -20,7 +20,7 @@ Think "Superhuman for AI assistants." Simple signup, instant value, zero technic
 **Acceptance Criteria:**
 - User signs up with email or Google
 - Clicks "Launch my assistant"
-- We provision an OpenClaw VM on our Hetzner account via API (invisible to user)
+- We provision an OpenClaw VM on our DigitalOcean account via API (invisible to user)
 - User sees a friendly progress indicator ("Setting things up…" → "Almost ready…" → "Done!")
 - Total time: < 90 seconds
 - User is prompted to connect a messaging app
@@ -97,7 +97,7 @@ Think "Superhuman for AI assistants." Simple signup, instant value, zero technic
 - API access for power users
 
 ### Unit Economics (per user)
-- Hetzner CX22 VM: ~€4.50/mo ($5/mo)
+- DigitalOcean Droplet (Basic): ~$6/mo
 - AI API usage (Anthropic/OpenAI): ~$3-8/mo avg
 - Our margin at $12/mo Starter: ~$0-4/mo (break-even to slight margin)
 - Our margin at $25/mo Pro: ~$12-17/mo (healthy margin)

--- a/specs/mvp/tasks.md
+++ b/specs/mvp/tasks.md
@@ -12,8 +12,8 @@
 - [x] T09: Rewrite landing page for managed model (no tech jargon)
 
 ## Phase 2: VM Orchestration (Week 2)
-- [ ] T10: Hetzner API client — create VM with cloud-init
-- [ ] T11: Hetzner API client — destroy VM, list VMs, get status
+- [ ] T10: DigitalOcean API client — create VM with cloud-init
+- [ ] T11: DigitalOcean API client — destroy VM, list VMs, get status
 - [ ] T12: Cloud-init template: install OpenClaw + sidecar agent
 - [ ] T13: Sidecar agent scaffold (Node.js, phones home on startup)
 - [ ] T14: Sidecar health endpoint + heartbeat to portal
@@ -21,7 +21,7 @@
 - [ ] T16: Serverless endpoint: POST /api/launch — provisions VM, records in DB
 - [ ] T17: Serverless endpoint: POST /api/suspend — stops VM (free tier off-hours)
 - [ ] T18: Serverless endpoint: POST /api/destroy — tears down VM
-- [ ] T19: Test full provisioning flow end-to-end on Hetzner
+- [ ] T19: Test full provisioning flow end-to-end on DigitalOcean
 - [ ] T20: Free tier scheduler — start/stop VMs based on user timezone + 8h window
 
 ## Phase 3: Onboarding Flow (Week 3)
@@ -74,4 +74,4 @@
 
 **Critical path:** Phase 2 (VM orchestration) → Phase 3 (onboarding) → Phase 5 (billing)
 
-**Quick wins done:** Landing page, repo structure, specs. Next: Supabase + Hetzner API client.
+**Quick wins done:** Landing page, repo structure, specs. Next: Supabase + DigitalOcean API client.

--- a/supabase/migrations/001_initial_schema.sql
+++ b/supabase/migrations/001_initial_schema.sql
@@ -22,7 +22,7 @@ create table public.assistants (
   id uuid primary key default gen_random_uuid(),
   user_id uuid not null references public.users on delete cascade,
   vm_id text,
-  provider text not null default 'hetzner',
+  provider text not null default 'digitalocean',
   region text,
   status public.assistant_status not null default 'provisioning',
   ip_address text,


### PR DESCRIPTION
## Summary

Updates all documentation, specs, env examples, and setup scripts to make DigitalOcean the primary and currently only supported cloud provider. Hetzner is kept as code but noted as a planned future addition in docs.

## Changes (15 files)

- **README.md** — VM Hosting → DigitalOcean, setup guide references updated
- **docs/SETUP.md** — Replaced Hetzner section with DigitalOcean setup instructions
- **docs/ENV_VARS.md** — `HETZNER_API_TOKEN` → `DO_API_TOKEN`
- **specs/mvp/{spec,plan,tasks}.md** — All Hetzner references → DigitalOcean primary
- **apps/web/src/data/{spec,plan,tasks,constitution}.md** — Same updates for web-served copies
- **apps/web/.env.example** — Hetzner token → DO token
- **scripts/setup-check.sh** — Validates DO API instead of Hetzner
- **supabase/migrations/001_initial_schema.sql** — Default provider: `digitalocean`
- **apps/web/src/lib/providers/index.ts** — Comment noting Hetzner as planned
- **.specify/memory/constitution.md** — Updated provider strategy

## What's NOT changed
- `apps/web/src/lib/providers/hetzner.ts` — kept intact for future use