### PR TITLE
Rebrand: HandsOff/Claw4All → ShiftWorker

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-# HandsOff environment variables
+# ShiftWorker environment variables
 
 # Supabase
 NEXT_PUBLIC_SUPABASE_URL=

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,6 +1,6 @@
-# Claw4All Constitution
+# ShiftWorker Constitution
 
-_The guiding principles for building Claw4All — the free OpenClaw setup wizard._
+_The guiding principles for building ShiftWorker — the free OpenClaw setup wizard._
 
 ## 1. Zero-CLI for End Users
 The target user has never opened a terminal. Every interaction happens through a web UI. If they need to type a command, we failed.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# HandsOff (OCaaS)
+# ShiftWorker
 
-**Your personal AI assistant, set up in minutes.** HandsOff is a managed hosting platform for [OpenClaw](https://github.com/openclaw/openclaw) — it handles servers, configuration, and infrastructure so you can focus on having an AI assistant that actually helps. Sign up, connect your services, and start chatting.
+**AI agent hosting platform.** ShiftWorker provisions and manages [OpenClaw](https://github.com/openclaw/openclaw) instances for users — it handles servers, configuration, and infrastructure so you can focus on having an AI assistant that actually helps. Sign up, connect your services, and start chatting.
 
 ## Tech Stack
 

--- a/apps/sidecar/src/routes/usage.ts
+++ b/apps/sidecar/src/routes/usage.ts
@@ -4,7 +4,7 @@ import { dirname } from 'path';
 
 const router = Router();
 
-const USAGE_FILE = process.env.USAGE_FILE || '/var/lib/handsoff/usage.json';
+const USAGE_FILE = process.env.USAGE_FILE || '/var/lib/shiftworker/usage.json';
 
 interface DailyUsage {
   date: string;

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,5 +1,5 @@
 # =============================================================================
-# HandsOff Environment Variables
+# ShiftWorker Environment Variables
 # Copy this file to .env.local and fill in your values.
 # See docs/SETUP.md for step-by-step instructions.
 # See docs/ENV_VARS.md for detailed descriptions.

--- a/apps/web/src/app/api/waitlist/route.ts
+++ b/apps/web/src/app/api/waitlist/route.ts
@@ -38,12 +38,12 @@ export async function POST(request: Request) {
     // Send welcome email
     try {
       const token = await generateToken(trimmed);
-      const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://claw4all-app.vercel.app';
+      const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://shiftworker.ai';
       const unsubscribeUrl = `${baseUrl}/api/waitlist/unsubscribe?email=${encodeURIComponent(trimmed)}&token=${token}`;
 
       const welcomeEmail = waitlistWelcomeEmail({ unsubscribeUrl });
       await getResend().emails.send({
-        from: 'HandsOff <onboarding@resend.dev>',
+        from: 'ShiftWorker <hello@shiftworker.ai>',
         to: trimmed,
         subject: welcomeEmail.subject,
         html: welcomeEmail.html,

--- a/apps/web/src/app/auth/signin/page.tsx
+++ b/apps/web/src/app/auth/signin/page.tsx
@@ -68,7 +68,7 @@ function Inner() {
   return (
     <main className="min-h-screen flex items-center justify-center bg-gray-950 px-4">
       <div className="w-full max-w-sm space-y-6">
-        <h1 className="text-2xl font-bold text-white text-center">Sign in to HandsOff</h1>
+        <h1 className="text-2xl font-bold text-white text-center">Sign in to ShiftWorker</h1>
 
         {error && <p className="text-red-400 text-sm text-center">{error}</p>}
 

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,28 +1,28 @@
 import type { Metadata } from "next";
 import "./globals.css";
 
-const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://handsoff.app";
+const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://shiftworker.ai";
 
 export const metadata: Metadata = {
-  title: "HandsOff — Your Personal AI Assistant That Actually Does Things",
+  title: "ShiftWorker — AI Agent Hosting Platform",
   description:
-    "Not a chatbot. A doer. HandsOff gives you a personal AI assistant that handles your email, calendar, research, and more — all through the messaging app you already use.",
+    "ShiftWorker provisions and manages OpenClaw instances for you. Get a personal AI agent that handles your email, calendar, research, and more — no servers, no setup.",
   metadataBase: new URL(siteUrl),
   icons: { icon: "/favicon.ico" },
   themeColor: "#020617", // slate-950
   openGraph: {
-    title: "HandsOff — Your Personal AI Assistant That Actually Does Things",
+    title: "ShiftWorker — AI Agent Hosting Platform",
     description:
-      "Not a chatbot. A doer. HandsOff gives you a personal AI assistant that handles your email, calendar, research, and more — all through the messaging app you already use.",
+      "ShiftWorker provisions and manages OpenClaw instances for you. Get a personal AI agent that handles your email, calendar, research, and more — no servers, no setup.",
     type: "website",
     url: siteUrl,
-    images: [{ url: "/opengraph-image", width: 1200, height: 630, alt: "HandsOff" }],
+    images: [{ url: "/opengraph-image", width: 1200, height: 630, alt: "ShiftWorker" }],
   },
   twitter: {
     card: "summary_large_image",
-    title: "HandsOff — Your Personal AI Assistant That Actually Does Things",
+    title: "ShiftWorker — AI Agent Hosting Platform",
     description:
-      "Not a chatbot. A doer. HandsOff gives you a personal AI assistant that handles your email, calendar, research, and more.",
+      "ShiftWorker provisions and manages OpenClaw instances for you. Get a personal AI agent that handles your email, calendar, research, and more — no servers, no setup.",
     images: ["/opengraph-image"],
   },
 };

--- a/apps/web/src/app/manifest.ts
+++ b/apps/web/src/app/manifest.ts
@@ -2,8 +2,8 @@ import type { MetadataRoute } from "next";
 
 export default function manifest(): MetadataRoute.Manifest {
   return {
-    name: "HandsOff",
-    short_name: "HandsOff",
+    name: "ShiftWorker",
+    short_name: "ShiftWorker",
     description:
       "Your personal AI assistant that handles email, calendar, research, and more.",
     start_url: "/",

--- a/apps/web/src/app/opengraph-image.tsx
+++ b/apps/web/src/app/opengraph-image.tsx
@@ -1,7 +1,7 @@
 import { ImageResponse } from "next/og";
 
 export const runtime = "edge";
-export const alt = "HandsOff — Your Personal AI Assistant";
+export const alt = "ShiftWorker — AI Agent Hosting Platform";
 export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";
 
@@ -28,7 +28,7 @@ export default function OgImage() {
             letterSpacing: "-0.02em",
           }}
         >
-          HandsOff
+          ShiftWorker
         </div>
         <div
           style={{

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -7,7 +7,7 @@ export default function Home() {
       {/* Nav */}
       <nav className="mx-auto flex max-w-6xl items-center justify-between px-4 py-4 sm:px-6 sm:py-6">
         <div className="flex items-center gap-2 text-lg sm:text-xl font-bold shrink-0">
-          <span>HandsOff</span>
+          <span>ShiftWorker</span>
         </div>
         <div className="hidden sm:flex items-center gap-6 text-sm text-slate-300">
           <a href="#how-it-works" className="hover:text-white transition">
@@ -307,12 +307,12 @@ export default function Home() {
       <footer className="border-t border-slate-800 py-12">
         <div className="mx-auto max-w-6xl px-6 flex flex-col sm:flex-row items-center justify-between gap-4">
           <div className="flex items-center gap-2">
-            <span className="font-bold">HandsOff</span>
+            <span className="font-bold">ShiftWorker</span>
           </div>
           <div className="flex gap-6 text-sm text-slate-400">
           </div>
           <p className="text-sm text-slate-500">
-            © {new Date().getFullYear()} HandsOff
+            © {new Date().getFullYear()} ShiftWorker
           </p>
         </div>
       </footer>

--- a/apps/web/src/app/robots.ts
+++ b/apps/web/src/app/robots.ts
@@ -1,6 +1,6 @@
 import type { MetadataRoute } from "next";
 
-const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://handsoff.app";
+const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://shiftworker.ai";
 
 export default function robots(): MetadataRoute.Robots {
   return {

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -1,6 +1,6 @@
 import type { MetadataRoute } from "next";
 
-const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://handsoff.app";
+const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://shiftworker.ai";
 
 export default function sitemap(): MetadataRoute.Sitemap {
   return [

--- a/apps/web/src/app/unsubscribe/page.tsx
+++ b/apps/web/src/app/unsubscribe/page.tsx
@@ -14,7 +14,7 @@ function UnsubscribeContent() {
           <>
             <h1 className="text-2xl font-bold mb-4">You&apos;ve been removed</h1>
             <p className="text-slate-400">
-              Your email has been removed from the HandsOff waitlist. Sorry to see you go!
+              Your email has been removed from the ShiftWorker waitlist. Sorry to see you go!
             </p>
           </>
         )}
@@ -44,7 +44,7 @@ function UnsubscribeContent() {
           href="/"
           className="inline-block mt-8 text-violet-400 hover:text-violet-300 transition"
         >
-          ← Back to HandsOff
+          ← Back to ShiftWorker
         </a>
       </div>
     </div>

--- a/apps/web/src/components/faq.tsx
+++ b/apps/web/src/components/faq.tsx
@@ -9,7 +9,7 @@ const faqs = [
   },
   {
     q: "Do I need any technical skills?",
-    a: "Absolutely not. If you can send a text message, you can use HandsOff. Just chat with your assistant like you'd chat with a friend.",
+    a: "Absolutely not. If you can send a text message, you can use ShiftWorker. Just chat with your assistant like you'd chat with a friend.",
   },
   {
     q: "How do I talk to my assistant?",

--- a/apps/web/src/components/nav/dashboard-nav.tsx
+++ b/apps/web/src/components/nav/dashboard-nav.tsx
@@ -29,7 +29,7 @@ export function DashboardNav({ userName = 'User', plan = 'Free' }: DashboardNavP
     <>
       {/* Mobile top bar */}
       <div className="lg:hidden flex items-center justify-between bg-slate-900 border-b border-slate-800 px-4 py-3">
-        <span className="text-white font-semibold">HandsOff</span>
+        <span className="text-white font-semibold">ShiftWorker</span>
         <button onClick={() => setOpen(!open)} className="text-slate-300 hover:text-white" aria-label="Toggle nav">
           <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
             {open ? (
@@ -48,7 +48,7 @@ export function DashboardNav({ userName = 'User', plan = 'Free' }: DashboardNavP
         ${open ? 'translate-x-0' : '-translate-x-full'}
       `}>
         <div className="hidden lg:flex items-center gap-2 px-6 py-5 border-b border-slate-800">
-          <Link href="/" className="text-lg font-bold text-white">HandsOff</Link>
+          <Link href="/" className="text-lg font-bold text-white">ShiftWorker</Link>
         </div>
 
         <div className="px-4 py-4 border-b border-slate-800">

--- a/apps/web/src/components/nav/main-nav.tsx
+++ b/apps/web/src/components/nav/main-nav.tsx
@@ -37,7 +37,7 @@ export function MainNav() {
     <nav className="sticky top-0 z-50 bg-slate-900/95 backdrop-blur border-b border-slate-800">
       <div className="mx-auto flex max-w-6xl items-center justify-between px-4 py-3 sm:px-6">
         <Link href="/" className="text-lg sm:text-xl font-bold text-white">
-          HandsOff
+          ShiftWorker
         </Link>
 
         {/* Desktop */}

--- a/apps/web/src/data/constitution.md
+++ b/apps/web/src/data/constitution.md
@@ -1,6 +1,6 @@
-# Claw4All Constitution
+# ShiftWorker Constitution
 
-_The guiding principles for building Claw4All — the free OpenClaw setup wizard._
+_The guiding principles for building ShiftWorker — the free OpenClaw setup wizard._
 
 ## 1. Zero-CLI for End Users
 The target user has never opened a terminal. Every interaction happens through a web UI. If they need to type a command, we failed.

--- a/apps/web/src/data/plan.md
+++ b/apps/web/src/data/plan.md
@@ -1,10 +1,10 @@
-# Claw4All — Implementation Plan
+# ShiftWorker — Implementation Plan
 
 ## Architecture Overview
 
 ```
 ┌─────────────────────────────────────────────┐
-│              Claw4All Portal                 │
+│              ShiftWorker Portal                 │
 │         (Next.js on Vercel — FREE)           │
 │                                              │
 │  ┌──────────┐ ┌───────────┐ ┌────────────┐  │
@@ -39,7 +39,7 @@ Because we don't host anything, the entire portal can run on:
 - **Supabase Free Tier** — Auth + database (50K monthly active users)
 - **No servers to manage** — all provisioning is API calls to user's provider
 
-Total infrastructure cost to run Claw4All: **$0/mo** until significant scale.
+Total infrastructure cost to run ShiftWorker: **$0/mo** until significant scale.
 
 ## Tech Stack
 
@@ -124,7 +124,7 @@ specs/
 
 ## Competitive Advantages
 
-| Us (Claw4All) | EZClaw / OpenClawd.ai | Emergent / Moltbot |
+| Us (ShiftWorker) | EZClaw / OpenClawd.ai | Emergent / Moltbot |
 |---|---|---|
 | User owns server | They own server | They own everything |
 | $0 to run the platform | Infrastructure costs | VC-funded burn |

--- a/apps/web/src/data/spec.md
+++ b/apps/web/src/data/spec.md
@@ -1,4 +1,4 @@
-# Claw4All — MVP Specification
+# ShiftWorker — MVP Specification
 
 _Free OpenClaw Setup Wizard + Skill Marketplace_
 
@@ -43,7 +43,7 @@ Make OpenClaw accessible to everyone by automating the entire setup process. Use
 - Marketplace page with categories (productivity, smart home, social, finance)
 - Each skill has: description, rating, install count, "Install" button
 - Free skills available to all users
-- Premium skills require Claw4All account upgrade
+- Premium skills require ShiftWorker account upgrade
 - Installation happens via API call to user's sidecar agent
 - Installed skills visible in "My Skills" dashboard
 
@@ -95,7 +95,7 @@ Make OpenClaw accessible to everyone by automating the entire setup process. Use
 
 ### Marketplace Revenue (future)
 - Skill creators list premium skills
-- Claw4All takes 20-30% commission
+- ShiftWorker takes 20-30% commission
 - Creates ecosystem flywheel
 
 ---

--- a/apps/web/src/data/tasks.md
+++ b/apps/web/src/data/tasks.md
@@ -1,4 +1,4 @@
-# Claw4All — Task Breakdown
+# ShiftWorker — Task Breakdown
 
 ## Phase 1: Foundation (Week 1)
 - [x] T01: Initialize repo + monorepo structure
@@ -43,7 +43,7 @@
 - [ ] T34: Skill list endpoint
 - [ ] T35: Bearer token auth middleware
 - [ ] T36: HTTPS setup (self-signed cert or Let's Encrypt)
-- [ ] T37: Heartbeat to Claw4All portal (server online/offline tracking)
+- [ ] T37: Heartbeat to ShiftWorker portal (server online/offline tracking)
 
 ## Phase 5: User Dashboard (Week 4)
 - [ ] T38: Dashboard layout + navigation
@@ -86,4 +86,4 @@
 
 **Critical path:** Phase 2 (provider APIs) → Phase 3 (wizard) → Phase 4 (sidecar) — these are sequential and blocking.
 
-**Quick wins:** Phase 1 is mostly done. Landing page is live at claw4all-app.vercel.app.
+**Quick wins:** Phase 1 is mostly done. Landing page is live at shiftworker.ai.

--- a/apps/web/src/lib/email/send.ts
+++ b/apps/web/src/lib/email/send.ts
@@ -8,7 +8,7 @@ const resend = new Proxy({} as Resend, {
   },
 });
 
-const FROM_EMAIL = 'HandsOff <noreply@handsoff.app>';
+const FROM_EMAIL = 'ShiftWorker <hello@shiftworker.ai>';
 
 export async function sendEmail(to: string, subject: string, html: string) {
   if (!process.env.RESEND_API_KEY) {

--- a/apps/web/src/lib/email/templates.ts
+++ b/apps/web/src/lib/email/templates.ts
@@ -1,4 +1,4 @@
-const APP_URL = process.env.NEXT_PUBLIC_APP_URL || 'https://handsoff.app';
+const APP_URL = process.env.NEXT_PUBLIC_APP_URL || 'https://shiftworker.ai';
 
 function layout(content: string) {
   return `<!DOCTYPE html>
@@ -9,13 +9,13 @@ function layout(content: string) {
 <tr><td align="center">
 <table width="600" cellpadding="0" cellspacing="0" style="background:#1a1128;border-radius:12px;overflow:hidden;">
 <tr><td style="padding:32px 40px 24px;text-align:center;">
-  <h1 style="margin:0;font-size:24px;color:#c084fc;font-weight:700;">HandsOff</h1>
+  <h1 style="margin:0;font-size:24px;color:#c084fc;font-weight:700;">ShiftWorker</h1>
 </td></tr>
 <tr><td style="padding:0 40px 40px;">
   ${content}
 </td></tr>
 <tr><td style="padding:24px 40px;border-top:1px solid #2d2040;text-align:center;">
-  <p style="margin:0;font-size:13px;color:#6b5a7e;">© HandsOff — Your personal AI assistant</p>
+  <p style="margin:0;font-size:13px;color:#6b5a7e;">© ShiftWorker — Your personal AI assistant</p>
 </td></tr>
 </table>
 </td></tr>
@@ -37,7 +37,7 @@ function p(text: string) {
 export function welcomeEmail(name: string): string {
   return layout(`
     ${p(`Hey ${name} 👋`)}
-    ${p(`Welcome to HandsOff! Your personal AI assistant awaits.`)}
+    ${p(`Welcome to ShiftWorker! Your personal AI assistant awaits.`)}
     ${p(`We're setting things up for you right now. You'll get another email as soon as your assistant is ready to go.`)}
     ${button('Go to Dashboard', `${APP_URL}/dashboard`)}
   `);

--- a/apps/web/src/lib/email/triggers.ts
+++ b/apps/web/src/lib/email/triggers.ts
@@ -19,7 +19,7 @@ async function getUserEmail(userId: string): Promise<{ email: string; name: stri
 export async function onUserSignup(userId: string) {
   const user = await getUserEmail(userId);
   if (!user) return;
-  await sendEmail(user.email, 'Welcome to HandsOff! 🎉', welcomeEmail(user.name));
+  await sendEmail(user.email, 'Welcome to ShiftWorker! 🎉', welcomeEmail(user.name));
 }
 
 export async function onAssistantReady(userId: string) {

--- a/apps/web/src/lib/emails/waitlist-welcome.ts
+++ b/apps/web/src/lib/emails/waitlist-welcome.ts
@@ -11,7 +11,7 @@ export function waitlistWelcomeEmail({ unsubscribeUrl }: WaitlistEmailProps) {
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Welcome to HandsOff</title>
+  <title>Welcome to ShiftWorker</title>
 </head>
 <body style="margin: 0; padding: 0; background-color: #f4f4f5; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;">
   <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #f4f4f5; padding: 40px 0;">
@@ -21,7 +21,7 @@ export function waitlistWelcomeEmail({ unsubscribeUrl }: WaitlistEmailProps) {
           <!-- Header -->
           <tr>
             <td style="background-color: #18181b; padding: 32px 40px;">
-              <span style="font-size: 20px; font-weight: 700; color: #ffffff; letter-spacing: -0.3px;">HandsOff</span>
+              <span style="font-size: 20px; font-weight: 700; color: #ffffff; letter-spacing: -0.3px;">ShiftWorker</span>
             </td>
           </tr>
           <!-- Body -->
@@ -31,7 +31,7 @@ export function waitlistWelcomeEmail({ unsubscribeUrl }: WaitlistEmailProps) {
                 You're on the list.
               </h1>
               <p style="margin: 0 0 16px; font-size: 15px; color: #3f3f46; line-height: 1.65;">
-                Thanks for your interest in HandsOff. We're building an AI assistant that handles the day-to-day stuff you shouldn't have to think about — email, scheduling, research, follow-ups.
+                Thanks for your interest in ShiftWorker. We're building an AI assistant that handles the day-to-day stuff you shouldn't have to think about — email, scheduling, research, follow-ups.
               </p>
               <p style="margin: 0 0 16px; font-size: 15px; color: #3f3f46; line-height: 1.65;">
                 It connects to the tools you already use and works through the messaging apps already on your phone. No new apps to install, no dashboards to learn.
@@ -48,7 +48,7 @@ export function waitlistWelcomeEmail({ unsubscribeUrl }: WaitlistEmailProps) {
                 <tr>
                   <td style="border-top: 1px solid #e4e4e7; padding-top: 24px;">
                     <p style="margin: 0; font-size: 13px; color: #a1a1aa; line-height: 1.5;">
-                      You received this because you signed up at claw4all-app.vercel.app.<br>
+                      You received this because you signed up at shiftworker.ai.<br>
                       <a href="${unsubscribeUrl}" style="color: #a1a1aa; text-decoration: underline;">Unsubscribe</a>
                     </p>
                   </td>

--- a/apps/web/src/lib/providers/cloud-init.ts
+++ b/apps/web/src/lib/providers/cloud-init.ts
@@ -1,5 +1,5 @@
 /**
- * Generate cloud-init user data for a Claw4All instance.
+ * Generate cloud-init user data for a ShiftWorker instance.
  */
 
 export interface CloudInitOptions {
@@ -23,7 +23,7 @@ export function generateCloudInit(opts: CloudInitOptions): string {
   const ocVersion = opts.openclawVersion ?? "latest";
 
   return `#cloud-config
-# Claw4All instance provisioning — managed, do not edit
+# ShiftWorker instance provisioning — managed, do not edit
 
 users:
   - name: ${user}
@@ -42,7 +42,7 @@ packages:
   - unzip
 
 write_files:
-  - path: /etc/claw4all/sidecar.env
+  - path: /etc/shiftworker/sidecar.env
     permissions: "0600"
     content: |
       SIDECAR_TOKEN=${opts.sidecarToken}
@@ -76,7 +76,7 @@ runcmd:
     [Service]
     Type=simple
     User=${user}
-    EnvironmentFile=/etc/claw4all/sidecar.env
+    EnvironmentFile=/etc/shiftworker/sidecar.env
     ExecStart=/usr/bin/openclaw gateway start
     Restart=always
     RestartSec=5

--- a/apps/web/src/lib/providers/digitalocean.ts
+++ b/apps/web/src/lib/providers/digitalocean.ts
@@ -1,5 +1,5 @@
 const API = 'https://api.digitalocean.com/v2';
-const TAG = 'handsoff';
+const TAG = 'shiftworker';
 
 interface DropletOptions {
   name: string;

--- a/apps/web/src/lib/providers/hetzner.ts
+++ b/apps/web/src/lib/providers/hetzner.ts
@@ -61,7 +61,7 @@ export class HetznerProvider implements CloudProvider {
         location: options.region ?? DEFAULT_REGION,
         image: "ubuntu-24.04",
         user_data: options.cloudInit ?? undefined,
-        labels: options.labels ?? { managed_by: "claw4all" },
+        labels: options.labels ?? { managed_by: "shiftworker" },
         start_after_create: true,
       }),
     });

--- a/apps/web/src/lib/providers/types.ts
+++ b/apps/web/src/lib/providers/types.ts
@@ -1,5 +1,5 @@
 /**
- * Cloud provider abstraction for Claw4All.
+ * Cloud provider abstraction for ShiftWorker.
  * Implement this interface to add DigitalOcean, Vultr, etc.
  */
 

--- a/apps/web/src/lib/stripe/config.ts
+++ b/apps/web/src/lib/stripe/config.ts
@@ -1,5 +1,5 @@
 /**
- * Stripe product and price configuration for HandsOff.
+ * Stripe product and price configuration for ShiftWorker.
  *
  * Two tiers: Free (limited) and Pro (unlimited).
  * Users pay their cloud provider separately for VM hosting.

--- a/apps/web/src/lib/supabase/types.ts
+++ b/apps/web/src/lib/supabase/types.ts
@@ -1,5 +1,5 @@
 /* ------------------------------------------------------------------ */
-/*  Supabase Database Types for HandsOff                               */
+/*  Supabase Database Types for ShiftWorker                               */
 /* ------------------------------------------------------------------ */
 
 export type Plan = 'free' | 'starter' | 'pro';

--- a/apps/web/src/lib/vm/lifecycle.ts
+++ b/apps/web/src/lib/vm/lifecycle.ts
@@ -5,7 +5,7 @@ import { generateCloudInit } from '../providers/cloud-init';
 import type { Assistant, AssistantStatus } from '../supabase/types';
 import { randomUUID } from 'crypto';
 
-const PORTAL_URL = process.env.NEXT_PUBLIC_APP_URL ?? 'https://app.claw4all.com';
+const PORTAL_URL = process.env.NEXT_PUBLIC_APP_URL ?? 'https://shiftworker.ai';
 
 /**
  * Valid state transitions for the assistant lifecycle.

--- a/apps/web/src/lib/waitlist-token.ts
+++ b/apps/web/src/lib/waitlist-token.ts
@@ -1,5 +1,5 @@
 export async function generateToken(email: string): Promise<string> {
-  const secret = process.env.WAITLIST_UNSUBSCRIBE_SECRET || 'handsoff-waitlist-default-secret';
+  const secret = process.env.WAITLIST_UNSUBSCRIBE_SECRET || 'shiftworker-waitlist-default-secret';
   const encoder = new TextEncoder();
   const key = await crypto.subtle.importKey(
     'raw',

--- a/docs/ENV_VARS.md
+++ b/docs/ENV_VARS.md
@@ -1,6 +1,6 @@
 # Environment Variables Reference
 
-Complete reference for all environment variables used by HandsOff.
+Complete reference for all environment variables used by ShiftWorker.
 
 ## Required Variables
 
@@ -11,11 +11,11 @@ Complete reference for all environment variables used by HandsOff.
 | `STRIPE_SECRET_KEY` | Stripe secret API key | Stripe → Developers → API keys | `sk_test_51abc...` |
 | `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` | Stripe publishable key | Stripe → Developers → API keys | `pk_test_51abc...` |
 | `STRIPE_WEBHOOK_SECRET` | Stripe webhook signing secret | Stripe → Developers → Webhooks → endpoint → Signing secret | `whsec_abc123...` |
-| `STRIPE_PRICE_STARTER` | Price ID for Starter plan ($12/mo) | Stripe → Products → HandsOff Starter → Price ID | `price_1abc...` |
-| `STRIPE_PRICE_PRO` | Price ID for Pro plan ($25/mo) | Stripe → Products → HandsOff Pro → Price ID | `price_1def...` |
+| `STRIPE_PRICE_STARTER` | Price ID for Starter plan ($12/mo) | Stripe → Products → ShiftWorker Starter → Price ID | `price_1abc...` |
+| `STRIPE_PRICE_PRO` | Price ID for Pro plan ($25/mo) | Stripe → Products → ShiftWorker Pro → Price ID | `price_1def...` |
 | `DO_API_TOKEN` | DigitalOcean API token (read/write) | DigitalOcean → API → Generate New Token | `dop_v1_abc123...` |
 | `RESEND_API_KEY` | Resend email API key | Resend → API Keys | `re_abc123...` |
-| `NEXT_PUBLIC_APP_URL` | Your app's public URL | Your domain / Vercel URL | `https://handsoff.yourdomain.com` |
+| `NEXT_PUBLIC_APP_URL` | Your app's public URL | Your domain / Vercel URL | `https://shiftworker.ai` |
 | `CRON_SECRET` | Secret for authenticating cron job endpoints | Generate: `openssl rand -hex 32` | `a1b2c3d4e5f6...` |
 
 ## Optional Variables

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -1,6 +1,6 @@
-# HandsOff Setup Guide
+# ShiftWorker Setup Guide
 
-Complete step-by-step instructions for setting up all external services needed to run HandsOff.
+Complete step-by-step instructions for setting up all external services needed to run ShiftWorker.
 
 > **Prerequisites:** A GitHub account, a credit card for Stripe/DigitalOcean, and ~30 minutes.
 
@@ -11,7 +11,7 @@ Complete step-by-step instructions for setting up all external services needed t
 Supabase provides the PostgreSQL database and authentication layer.
 
 1. Go to [supabase.com](https://supabase.com) → **New Project**
-2. Choose an organization (or create one), name the project (e.g., `handsoff`), set a strong database password, and pick a region close to your users
+2. Choose an organization (or create one), name the project (e.g., `shiftworker`), set a strong database password, and pick a region close to your users
 3. Wait for the project to finish provisioning (~2 minutes)
 
 ### Get your API credentials
@@ -30,7 +30,7 @@ Supabase provides the PostgreSQL database and authentication layer.
 ### Configure Auth
 
 11. Go to **Authentication → URL Configuration**
-12. Set **Site URL** to your Vercel deployment URL (e.g., `https://handsoff.yourdomain.com`)
+12. Set **Site URL** to your Vercel deployment URL (e.g., `https://shiftworker.ai`)
 13. Add `http://localhost:3000` to **Redirect URLs** for local development
 
 ### Env vars from this step
@@ -53,12 +53,12 @@ Stripe handles subscriptions and billing.
 
 3. Go to **Dashboard → Products → + Add product**
 4. Create the first product:
-   - **Name:** `HandsOff Starter`
+   - **Name:** `ShiftWorker Starter`
    - **Pricing:** `$12.00` / month (recurring)
    - Click **Save product**
    - Copy the **Price ID** (starts with `price_`) → this is `STRIPE_PRICE_STARTER`
 5. Create the second product:
-   - **Name:** `HandsOff Pro`
+   - **Name:** `ShiftWorker Pro`
    - **Pricing:** `$25.00` / month (recurring)
    - Click **Save product**
    - Copy the **Price ID** → this is `STRIPE_PRICE_PRO`
@@ -103,10 +103,10 @@ Stripe handles subscriptions and billing.
 DigitalOcean provides the virtual machines (Droplets) where user OpenClaw instances run.
 
 1. Go to [cloud.digitalocean.com](https://cloud.digitalocean.com) → create an account
-2. Create a new project called **HandsOff** (or similar)
+2. Create a new project called **ShiftWorker** (or similar)
 3. Go to **API** in the left sidebar
 4. Click **Generate New Token**
-   - Name: `handsoff-api`
+   - Name: `shiftworker-api`
    - Expiration: No expiry (or set as needed)
    - Scopes: **Read & Write**
 5. Copy the token immediately (it's only shown once) → `DO_API_TOKEN`
@@ -128,7 +128,7 @@ Resend handles transactional emails (welcome emails, notifications, etc.).
 1. Go to [resend.com](https://resend.com) → create an account
 2. Go to **API Keys** in the sidebar
 3. Click **Create API Key**
-   - Name: `handsoff`
+   - Name: `shiftworker`
    - Permission: **Full access** (or Sending access if you prefer)
 4. Copy the key → `RESEND_API_KEY`
 

--- a/docs/stripe-setup.md
+++ b/docs/stripe-setup.md
@@ -1,4 +1,4 @@
-# Stripe Setup for Claw4All
+# Stripe Setup for ShiftWorker
 
 ## 1. Create a Stripe Account
 

--- a/specs/mvp/plan.md
+++ b/specs/mvp/plan.md
@@ -1,10 +1,10 @@
-# Claw4All — Implementation Plan
+# ShiftWorker — Implementation Plan
 
 ## Architecture Overview
 
 ```
 ┌──────────────────────────────────────────────────┐
-│              Claw4All Portal                      │
+│              ShiftWorker Portal                      │
 │         (Next.js on Vercel — FREE tier)           │
 │                                                   │
 │  ┌───────────┐ ┌────────────┐ ┌───────────────┐  │
@@ -26,7 +26,7 @@
     └────┬─────┘
          │
     ┌────▼──────────────────────────────────┐
-    │    Claw4All-Managed VM Pool           │
+    │    ShiftWorker-Managed VM Pool           │
     │                                        │
     │  ┌──────────┐ ┌──────────┐ ┌────────┐ │
     │  │ User A's │ │ User B's │ │User C's│ │
@@ -78,7 +78,7 @@
 
 Internal management agent — user never interacts with it directly.
 
-- **Phones home** to Claw4All API on startup and via heartbeat
+- **Phones home** to ShiftWorker API on startup and via heartbeat
 - **Endpoints** (called by our orchestration layer only):
   - `GET /health` — VM and OpenClaw status
   - `POST /openclaw/restart` — restart OpenClaw
@@ -141,7 +141,7 @@ specs/
 
 ## Competitive Positioning
 
-| | Claw4All | Self-hosted OpenClaw | Competitor SaaS |
+| | ShiftWorker | Self-hosted OpenClaw | Competitor SaaS |
 |---|---|---|---|
 | Setup time | 60 seconds | 30+ minutes | Varies |
 | Technical skill needed | None | Moderate | Low-Moderate |

--- a/specs/mvp/spec.md
+++ b/specs/mvp/spec.md
@@ -1,10 +1,10 @@
-# Claw4All — MVP Specification
+# ShiftWorker — MVP Specification
 
 _Managed AI assistants you talk to via chat. We handle everything._
 
 ## Vision
 
-Claw4All gives everyone a personal AI assistant that lives in their favorite chat app. Users click a button, connect WhatsApp or Telegram, and start talking. We provision and manage the infrastructure invisibly — the user never sees a server, terminal, or config file.
+ShiftWorker gives everyone a personal AI assistant that lives in their favorite chat app. Users click a button, connect WhatsApp or Telegram, and start talking. We provision and manage the infrastructure invisibly — the user never sees a server, terminal, or config file.
 
 Think "Superhuman for AI assistants." Simple signup, instant value, zero technical knowledge required.
 

--- a/specs/mvp/tasks.md
+++ b/specs/mvp/tasks.md
@@ -1,4 +1,4 @@
-# Claw4All — Task Breakdown
+# ShiftWorker — Task Breakdown
 
 ## Phase 1: Foundation (Week 1)
 - [x] T01: Initialize repo + monorepo structure


### PR DESCRIPTION
Rebrands the entire codebase from HandsOff / Claw4All to **ShiftWorker** (shiftworker.ai).

## Changes (39 files)
- All user-facing references updated: HandsOff, Claw4All → ShiftWorker
- Domain: claw4all-app.vercel.app / handsoff.app → shiftworker.ai
- Email sender: hello@shiftworker.ai
- Meta titles, OG tags, Twitter cards updated
- Email templates (welcome, waitlist) rebranded
- Landing page, nav, footer, FAQ copy updated
- README, docs, specs updated
- Cloud-init labels and paths updated

## Not changed
- package.json name fields / workspace names
- Git remote URLs
- Supabase project refs / API keys
- Stripe keys / Vercel project name