### PR TITLE
VM provisioning: referral link, phone-home endpoint, launch flow

### DIFF
--- a/apps/web/src/app/api/assistant/launch/route.ts
+++ b/apps/web/src/app/api/assistant/launch/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { launchAssistant } from '@/lib/vm/lifecycle';
+
+export async function POST() {
+  const supabase: any = await createClient();
+  const { data: { user }, error: authError } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const assistant = await launchAssistant(user.id);
+    return NextResponse.json({ assistant });
+  } catch (err: any) {
+    return NextResponse.json(
+      { error: err.message ?? 'Failed to launch assistant' },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/src/app/api/instances/[instanceId]/phone-home/route.ts
+++ b/apps/web/src/app/api/instances/[instanceId]/phone-home/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import type { Assistant } from '@/lib/supabase/types';
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ instanceId: string }> },
+) {
+  const { instanceId } = await params;
+
+  // Extract Bearer token
+  const authHeader = request.headers.get('authorization');
+  if (!authHeader?.startsWith('Bearer ')) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const sidecarToken = authHeader.slice(7);
+
+  const supabase: any = await createClient();
+
+  // Find the assistant and verify the sidecar token
+  const { data: assistant, error } = await supabase
+    .from('assistants')
+    .select()
+    .eq('id', instanceId)
+    .single();
+
+  if (error || !assistant) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
+
+  const record = assistant as Assistant;
+
+  if (record.sidecar_token !== sidecarToken) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  if (record.status !== 'provisioning') {
+    // Already active or in another state — just acknowledge
+    return NextResponse.json({ status: record.status });
+  }
+
+  // Transition from provisioning → active
+  const { error: updateError } = await supabase
+    .from('assistants')
+    .update({ status: 'active', updated_at: new Date().toISOString() })
+    .eq('id', instanceId);
+
+  if (updateError) {
+    return NextResponse.json({ error: 'Update failed' }, { status: 500 });
+  }
+
+  return NextResponse.json({ status: 'active' });
+}

--- a/apps/web/src/app/api/stripe/checkout/route.ts
+++ b/apps/web/src/app/api/stripe/checkout/route.ts
@@ -1,18 +1,27 @@
 import { NextRequest, NextResponse } from "next/server";
 import { stripe } from "@/lib/stripe/client";
 import { PLANS, PlanKey } from "@/lib/stripe/config";
+import { createClient } from "@/lib/supabase/server";
 
 /**
  * POST /api/stripe/checkout
  * Creates a Stripe Checkout session for upgrading to a paid plan.
+ * Requires authenticated user (via Supabase session cookie).
  */
 export async function POST(req: NextRequest) {
   try {
-    const { plan, userId, email } = (await req.json()) as {
-      plan: PlanKey;
-      userId: string;
-      email: string;
-    };
+    const supabase: any = await createClient();
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body = await req.json().catch(() => ({}));
+    const plan: PlanKey = body.plan ?? "pro";
 
     const planConfig = PLANS[plan];
     if (!planConfig || !planConfig.stripePriceId) {
@@ -22,11 +31,11 @@ export async function POST(req: NextRequest) {
     const session = await stripe.checkout.sessions.create({
       mode: "subscription",
       payment_method_types: ["card"],
-      customer_email: email,
-      metadata: { userId, plan },
+      customer_email: user.email,
+      metadata: { userId: user.id, plan },
       line_items: [{ price: planConfig.stripePriceId, quantity: 1 }],
       success_url: `${process.env.NEXT_PUBLIC_APP_URL}/dashboard?upgraded=true`,
-      cancel_url: `${process.env.NEXT_PUBLIC_APP_URL}/dashboard?cancelled=true`,
+      cancel_url: `${process.env.NEXT_PUBLIC_APP_URL}/dashboard`,
     });
 
     return NextResponse.json({ url: session.url });
@@ -34,7 +43,7 @@ export async function POST(req: NextRequest) {
     console.error("Stripe checkout error:", error);
     return NextResponse.json(
       { error: "Failed to create checkout session" },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }

--- a/apps/web/src/app/dashboard/components/assistant-card.tsx
+++ b/apps/web/src/app/dashboard/components/assistant-card.tsx
@@ -120,12 +120,13 @@ export function AssistantCard({ assistant }: { assistant: Assistant | null }) {
         )}
 
         {status === "offline" && (
-          <a
-            href="/onboarding"
-            className="rounded-lg bg-indigo-600 px-4 py-2 text-sm text-white hover:bg-indigo-500"
+          <button
+            disabled={!!loading}
+            onClick={() => act("/api/assistant/launch")}
+            className="rounded-lg bg-indigo-600 px-4 py-2 text-sm text-white hover:bg-indigo-500 disabled:opacity-50"
           >
-            Launch Assistant
-          </a>
+            {loading === "/api/assistant/launch" ? "Launching…" : "Launch Assistant"}
+          </button>
         )}
       </div>
     </div>

--- a/apps/web/src/app/dashboard/components/plan-card.tsx
+++ b/apps/web/src/app/dashboard/components/plan-card.tsx
@@ -1,4 +1,7 @@
+"use client";
+
 import Link from "next/link";
+import { useState } from "react";
 import { PLANS, type PlanKey } from "@/lib/stripe/config";
 
 const planLimits: Record<PlanKey, string[]> = {
@@ -9,6 +12,28 @@ const planLimits: Record<PlanKey, string[]> = {
 export function PlanCard({ plan }: { plan: PlanKey }) {
   const info = PLANS[plan];
   const limits = planLimits[plan];
+  const [loading, setLoading] = useState(false);
+
+  async function handleUpgrade() {
+    setLoading(true);
+    try {
+      const res = await fetch("/api/stripe/checkout", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ plan: "pro" }),
+      });
+      const data = await res.json();
+      if (data.url) {
+        window.location.href = data.url;
+      } else {
+        console.error("Checkout error:", data.error);
+        setLoading(false);
+      }
+    } catch (err) {
+      console.error("Checkout error:", err);
+      setLoading(false);
+    }
+  }
 
   return (
     <div className="rounded-xl border border-slate-800 bg-slate-900 p-6">
@@ -37,14 +62,15 @@ export function PlanCard({ plan }: { plan: PlanKey }) {
       {plan === "free" && (
         <div className="pt-2 border-t border-slate-800">
           <p className="text-sm text-slate-400 mb-3">
-            Upgrade for unlimited messages and more cloud accounts
+            Upgrade to Pro for unlimited messages and 24/7 availability
           </p>
-          <Link
-            href="/api/stripe/checkout"
-            className="inline-block rounded-lg bg-indigo-600 px-4 py-2 text-sm text-white hover:bg-indigo-500"
+          <button
+            onClick={handleUpgrade}
+            disabled={loading}
+            className="inline-block rounded-lg bg-indigo-600 px-4 py-2 text-sm text-white hover:bg-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"
           >
-            Upgrade
-          </Link>
+            {loading ? "Redirecting…" : "Upgrade to Pro — $12/mo"}
+          </button>
         </div>
       )}
 

--- a/apps/web/src/app/onboarding/connect/page.tsx
+++ b/apps/web/src/app/onboarding/connect/page.tsx
@@ -41,6 +41,23 @@ export default async function ConnectPage({
         </div>
 
         <div className="space-y-3">
+          {/* Referral callout */}
+          {!isConnected && (
+            <div className="p-4 bg-blue-950/50 rounded-xl border border-blue-800/50 text-center space-y-2">
+              <p className="text-blue-200 font-medium">
+                Don&apos;t have a DigitalOcean account?
+              </p>
+              <a
+                href="https://cloud.digitalocean.com/account-referrals?i=091ab6c0-097d-4111-baab-ee4872bd796d"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-block text-blue-400 hover:text-blue-300 font-semibold underline underline-offset-2 transition-colors"
+              >
+                Sign up and get $200 in free credits →
+              </a>
+            </div>
+          )}
+
           <div className="flex items-center justify-between p-4 bg-slate-900 rounded-xl border border-slate-800">
             <div className="flex items-center gap-3">
               <span className="text-2xl">🌊</span>

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -305,6 +305,15 @@ export default function Home() {
         <p className="mt-8 text-center text-sm text-slate-500 max-w-2xl mx-auto">
           Hosting runs on DigitalOcean (~$4/mo after credits). AI is powered by
           Google Gemini Flash — free with your Google account, no card required.
+          {' '}
+          <a
+            href="https://cloud.digitalocean.com/account-referrals?i=091ab6c0-097d-4111-baab-ee4872bd796d"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-violet-400 hover:text-violet-300 underline underline-offset-2"
+          >
+            Sign up for DigitalOcean and get $200 in free credits
+          </a>.
         </p>
       </section>
 

--- a/apps/web/src/lib/supabase/types.ts
+++ b/apps/web/src/lib/supabase/types.ts
@@ -58,6 +58,17 @@ export interface UsageLog {
   api_tokens_used: number;
 }
 
+export interface ProviderToken {
+  id: string;
+  user_id: string;
+  provider: string;
+  access_token_encrypted: string;
+  refresh_token_encrypted: string | null;
+  expires_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
 export type Database = {
   public: {
     Tables: {
@@ -83,6 +94,12 @@ export type Database = {
         Row: UsageLog;
         Insert: Partial<UsageLog> & Pick<UsageLog, 'id' | 'assistant_id' | 'date'>;
         Update: Partial<UsageLog>;
+        Relationships: [];
+      };
+      provider_tokens: {
+        Row: ProviderToken;
+        Insert: Partial<ProviderToken> & Pick<ProviderToken, 'user_id' | 'provider' | 'access_token_encrypted'>;
+        Update: Partial<ProviderToken>;
         Relationships: [];
       };
       waitlist: {


### PR DESCRIPTION
## Changes

- **DO referral link on onboarding** — Prominent callout before the Connect button: "Sign up and get $200 in free credits" with referral URL
- **DO referral link on landing page** — Added to pricing section footnote
- **Phone-home endpoint** — `POST /api/instances/[instanceId]/phone-home` accepts Bearer sidecar_token, transitions assistant from provisioning → active
- **Launch endpoint** — `POST /api/assistant/launch` requires auth, calls launchAssistant(userId)
- **Dashboard Launch button** — Now calls the launch API directly instead of linking to onboarding
- **Supabase types** — Added `ProviderToken` interface and `provider_tokens` table to Database type