### PR TITLE
Stripe: webhook, checkout flow, Pro upgrade

### DIFF
--- a/apps/web/src/app/api/stripe/checkout/route.ts
+++ b/apps/web/src/app/api/stripe/checkout/route.ts
@@ -1,18 +1,27 @@
 import { NextRequest, NextResponse } from "next/server";
 import { stripe } from "@/lib/stripe/client";
 import { PLANS, PlanKey } from "@/lib/stripe/config";
+import { createClient } from "@/lib/supabase/server";
 
 /**
  * POST /api/stripe/checkout
  * Creates a Stripe Checkout session for upgrading to a paid plan.
+ * Requires authenticated user (via Supabase session cookie).
  */
 export async function POST(req: NextRequest) {
   try {
-    const { plan, userId, email } = (await req.json()) as {
-      plan: PlanKey;
-      userId: string;
-      email: string;
-    };
+    const supabase: any = await createClient();
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body = await req.json().catch(() => ({}));
+    const plan: PlanKey = body.plan ?? "pro";
 
     const planConfig = PLANS[plan];
     if (!planConfig || !planConfig.stripePriceId) {
@@ -22,11 +31,11 @@ export async function POST(req: NextRequest) {
     const session = await stripe.checkout.sessions.create({
       mode: "subscription",
       payment_method_types: ["card"],
-      customer_email: email,
-      metadata: { userId, plan },
+      customer_email: user.email,
+      metadata: { userId: user.id, plan },
       line_items: [{ price: planConfig.stripePriceId, quantity: 1 }],
       success_url: `${process.env.NEXT_PUBLIC_APP_URL}/dashboard?upgraded=true`,
-      cancel_url: `${process.env.NEXT_PUBLIC_APP_URL}/dashboard?cancelled=true`,
+      cancel_url: `${process.env.NEXT_PUBLIC_APP_URL}/dashboard`,
     });
 
     return NextResponse.json({ url: session.url });
@@ -34,7 +43,7 @@ export async function POST(req: NextRequest) {
     console.error("Stripe checkout error:", error);
     return NextResponse.json(
       { error: "Failed to create checkout session" },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }

--- a/apps/web/src/app/dashboard/components/plan-card.tsx
+++ b/apps/web/src/app/dashboard/components/plan-card.tsx
@@ -1,4 +1,7 @@
+"use client";
+
 import Link from "next/link";
+import { useState } from "react";
 import { PLANS, type PlanKey } from "@/lib/stripe/config";
 
 const planLimits: Record<PlanKey, string[]> = {
@@ -9,6 +12,28 @@ const planLimits: Record<PlanKey, string[]> = {
 export function PlanCard({ plan }: { plan: PlanKey }) {
   const info = PLANS[plan];
   const limits = planLimits[plan];
+  const [loading, setLoading] = useState(false);
+
+  async function handleUpgrade() {
+    setLoading(true);
+    try {
+      const res = await fetch("/api/stripe/checkout", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ plan: "pro" }),
+      });
+      const data = await res.json();
+      if (data.url) {
+        window.location.href = data.url;
+      } else {
+        console.error("Checkout error:", data.error);
+        setLoading(false);
+      }
+    } catch (err) {
+      console.error("Checkout error:", err);
+      setLoading(false);
+    }
+  }
 
   return (
     <div className="rounded-xl border border-slate-800 bg-slate-900 p-6">
@@ -37,14 +62,15 @@ export function PlanCard({ plan }: { plan: PlanKey }) {
       {plan === "free" && (
         <div className="pt-2 border-t border-slate-800">
           <p className="text-sm text-slate-400 mb-3">
-            Upgrade for unlimited messages and more cloud accounts
+            Upgrade to Pro for unlimited messages and 24/7 availability
           </p>
-          <Link
-            href="/api/stripe/checkout"
-            className="inline-block rounded-lg bg-indigo-600 px-4 py-2 text-sm text-white hover:bg-indigo-500"
+          <button
+            onClick={handleUpgrade}
+            disabled={loading}
+            className="inline-block rounded-lg bg-indigo-600 px-4 py-2 text-sm text-white hover:bg-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"
           >
-            Upgrade
-          </Link>
+            {loading ? "Redirecting…" : "Upgrade to Pro — $12/mo"}
+          </button>
         </div>
       )}
 

--- a/apps/web/src/app/dashboard/components/upgrade-banner.tsx
+++ b/apps/web/src/app/dashboard/components/upgrade-banner.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export function UpgradeBanner() {
+  const [visible, setVisible] = useState(true);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setVisible(false), 8000);
+    return () => clearTimeout(timer);
+  }, []);
+
+  if (!visible) return null;
+
+  return (
+    <div className="mb-6 rounded-lg border border-green-800 bg-green-900/50 px-4 py-3 flex items-center justify-between">
+      <p className="text-sm text-green-300">
+        🎉 Welcome to <strong>ShiftWorker Pro</strong>! Your assistant now runs
+        24/7 with unlimited messages.
+      </p>
+      <button
+        onClick={() => setVisible(false)}
+        className="text-green-400 hover:text-green-200 ml-4"
+      >
+        ✕
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -5,9 +5,17 @@ import { AssistantCard } from "./components/assistant-card";
 import { UsageCard } from "./components/usage-card";
 import { ConnectionsCard } from "./components/connections-card";
 import { PlanCard } from "./components/plan-card";
+import { UpgradeBanner } from "./components/upgrade-banner";
 import type { PlanKey } from "@/lib/stripe/config";
 
-async function DashboardContent() {
+async function DashboardContent({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const params = await searchParams;
+  const upgraded = params?.upgraded === "true";
+
   const supabase: any = await createClient();
   const { data: { user }, error } = await supabase.auth.getUser();
 
@@ -37,6 +45,7 @@ async function DashboardContent() {
   return (
     <div className="min-h-screen bg-slate-950 px-4 py-8 sm:px-6 lg:px-8">
       <div className="mx-auto max-w-5xl">
+        {upgraded && <UpgradeBanner />}
         <h1 className="text-3xl font-bold text-white mb-8">Dashboard</h1>
 
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
@@ -50,7 +59,11 @@ async function DashboardContent() {
   );
 }
 
-export default function DashboardPage() {
+export default async function DashboardPage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
   return (
     <Suspense
       fallback={
@@ -59,7 +72,7 @@ export default function DashboardPage() {
         </div>
       }
     >
-      <DashboardContent />
+      <DashboardContent searchParams={searchParams} />
     </Suspense>
   );
 }


### PR DESCRIPTION
## Changes

- **Checkout route** now authenticates via Supabase session cookie instead of trusting client-sent userId/email
- **PlanCard** converted to client component with proper POST to `/api/stripe/checkout` (was broken — used a GET `<Link>` to a POST-only route)
- **Upgrade banner** shows on dashboard after successful checkout (`?upgraded=true`)
- Cancel URL simplified to `/dashboard` (no query param)

### Already existed (no changes needed)
- Webhook handler (`checkout.session.completed`, `subscription.updated`, `subscription.deleted`, `invoice.payment_failed`)
- Stripe client, config, portal route
- Supabase types with Subscription model
- `.env.example` with all Stripe env vars