### PR TITLE
fix: align vm-scheduler with actual DB schema

### DIFF
--- a/apps/web/src/app/api/cron/vm-scheduler/route.ts
+++ b/apps/web/src/app/api/cron/vm-scheduler/route.ts
@@ -42,13 +42,13 @@ export async function GET(request: NextRequest) {
     try {
       const inWindow = isInWindow(user.window_start, user.timezone);
 
-      // Get DO token
+      // Get DO token (column is access_token_encrypted in DB)
       const { data: tokenRow } = await supabase
         .from('provider_tokens' as never)
-        .select('access_token')
+        .select('access_token_encrypted')
         .eq('user_id', user.id)
         .eq('provider', 'digitalocean')
-        .single() as unknown as { data: { access_token: string } | null };
+        .single() as unknown as { data: { access_token_encrypted: string } | null };
 
       if (!tokenRow) {
         console.warn(`No DO token for user ${user.id}, skipping`);
@@ -56,14 +56,14 @@ export async function GET(request: NextRequest) {
         continue;
       }
 
-      // Get assistant/droplet
+      // Get assistant (column is vm_id, not droplet_id)
       const { data: assistant } = await supabase
         .from('assistants' as never)
-        .select('id, status, droplet_id')
+        .select('id, status, vm_id')
         .eq('user_id', user.id)
-        .single() as unknown as { data: { id: string; status: string; droplet_id: string | null } | null };
+        .single() as unknown as { data: { id: string; status: string; vm_id: string | null } | null };
 
-      if (!assistant?.droplet_id) {
+      if (!assistant?.vm_id) {
         console.warn(`No droplet for user ${user.id}, skipping`);
         skipped++;
         continue;
@@ -71,22 +71,22 @@ export async function GET(request: NextRequest) {
 
       if (inWindow && assistant.status === 'suspended') {
         // Power on
-        await powerOnDroplet(assistant.droplet_id, tokenRow.access_token);
+        await powerOnDroplet(assistant.vm_id, tokenRow.access_token_encrypted);
         await supabase
           .from('assistants' as never)
           .update({ status: 'active' } as never)
           .eq('id', assistant.id);
         powered_on++;
-        console.log(`Powered ON droplet ${assistant.droplet_id} for user ${user.id}`);
+        console.log(`Powered ON droplet ${assistant.vm_id} for user ${user.id}`);
       } else if (!inWindow && assistant.status === 'active') {
         // Power off
-        await powerOffDroplet(assistant.droplet_id, tokenRow.access_token);
+        await powerOffDroplet(assistant.vm_id, tokenRow.access_token_encrypted);
         await supabase
           .from('assistants' as never)
           .update({ status: 'suspended' } as never)
           .eq('id', assistant.id);
         powered_off++;
-        console.log(`Powered OFF droplet ${assistant.droplet_id} for user ${user.id}`);
+        console.log(`Powered OFF droplet ${assistant.vm_id} for user ${user.id}`);
       } else {
         skipped++;
       }

--- a/apps/web/src/lib/supabase/types.ts
+++ b/apps/web/src/lib/supabase/types.ts
@@ -19,6 +19,8 @@ export interface User {
   name: string | null;
   plan: Plan;
   timezone: string | null;
+  window_start: number | null;
+  onboarding_complete: boolean;
   created_at: string;
   updated_at: string;
 }

--- a/supabase/migrations/003_vm_scheduler_columns.sql
+++ b/supabase/migrations/003_vm_scheduler_columns.sql
@@ -1,0 +1,9 @@
+-- Add columns needed by the VM scheduler cron endpoint
+
+-- Users: window_start (0-23 hour in user's timezone) and onboarding_complete flag
+ALTER TABLE public.users
+  ADD COLUMN IF NOT EXISTS window_start integer,
+  ADD COLUMN IF NOT EXISTS onboarding_complete boolean NOT NULL DEFAULT false;
+
+-- Note: assistants table already has vm_id; the scheduler route should use vm_id
+-- instead of the non-existent droplet_id column.


### PR DESCRIPTION
## Problem
The `/api/cron/vm-scheduler` endpoint returns 500 (`Failed to fetch users`) because:

1. **Missing columns**: `users.window_start` and `users.onboarding_complete` don't exist in the DB
2. **Wrong column names**: Route references `assistants.droplet_id` (should be `vm_id`) and `provider_tokens.access_token` (should be `access_token_encrypted`)

## Fix
- Added migration `003_vm_scheduler_columns.sql` to add the missing columns
- Updated the route handler to use correct column names (`vm_id`, `access_token_encrypted`)
- Updated TypeScript types to match

## Note
The migration needs to be applied to Supabase manually (`supabase db push` or run the SQL in the dashboard).