### PR TITLE
fix: DO OAuth callback redirect + improve disabled card contrast

### DIFF
--- a/apps/web/src/app/api/auth/digitalocean/callback/route.ts
+++ b/apps/web/src/app/api/auth/digitalocean/callback/route.ts
@@ -5,7 +5,7 @@ import { saveProviderToken } from '@/lib/providers/token-store';
 export async function GET(request: NextRequest) {
   const code = request.nextUrl.searchParams.get('code');
   if (!code) {
-    return NextResponse.redirect(new URL('/onboarding/connect?error=missing_code', request.url));
+    return NextResponse.redirect(new URL('/onboarding?error=missing_code', request.url));
   }
 
   // Exchange code for tokens
@@ -22,7 +22,7 @@ export async function GET(request: NextRequest) {
   });
 
   if (!tokenRes.ok) {
-    return NextResponse.redirect(new URL('/onboarding/connect?error=token_exchange', request.url));
+    return NextResponse.redirect(new URL('/onboarding?error=token_exchange', request.url));
   }
 
   const tokenData = await tokenRes.json();
@@ -46,5 +46,5 @@ export async function GET(request: NextRequest) {
     expiresAt,
   );
 
-  return NextResponse.redirect(new URL('/onboarding/connect?connected=digitalocean', request.url));
+  return NextResponse.redirect(new URL('/onboarding?connected=digitalocean', request.url));
 }

--- a/apps/web/src/app/onboarding/wizard.tsx
+++ b/apps/web/src/app/onboarding/wizard.tsx
@@ -182,7 +182,7 @@ export default function OnboardingWizard() {
       onClick={onClick}
       className={`relative p-5 rounded-xl border-2 text-left transition-all ${
         disabled
-          ? 'border-slate-800 bg-slate-900/50 opacity-50 cursor-not-allowed'
+          ? 'border-slate-700 bg-slate-900/50 opacity-70 cursor-not-allowed'
           : selected
             ? 'border-violet-600 bg-slate-900 shadow-lg shadow-violet-600/10'
             : 'border-slate-800 bg-slate-900 hover:border-slate-700 cursor-pointer'
@@ -267,7 +267,7 @@ export default function OnboardingWizard() {
                 <div className="flex items-center gap-3">
                   <Server className="w-8 h-8 text-blue-300" />
                   <div>
-                    <div className="font-semibold">Azure <span className="text-xs text-slate-500 ml-2">Coming soon</span></div>
+                    <div className="font-semibold">Azure <span className="text-xs text-slate-400 ml-2">Coming soon</span></div>
                     <div className="text-sm text-slate-400">Microsoft Azure cloud</div>
                   </div>
                 </div>
@@ -276,7 +276,7 @@ export default function OnboardingWizard() {
                 <div className="flex items-center gap-3">
                   <Server className="w-8 h-8 text-orange-300" />
                   <div>
-                    <div className="font-semibold">AWS <span className="text-xs text-slate-500 ml-2">Coming soon</span></div>
+                    <div className="font-semibold">AWS <span className="text-xs text-slate-400 ml-2">Coming soon</span></div>
                     <div className="text-sm text-slate-400">Amazon Web Services</div>
                   </div>
                 </div>


### PR DESCRIPTION
## Problems

**1. 404 after DigitalOcean OAuth redirect**
The callback route was redirecting to `/onboarding/connect?connected=digitalocean` — but that page doesn't exist. Should be `/onboarding?connected=digitalocean`.

**2. Unreadable 'Coming soon' options on Hosting step**
Azure and AWS cards had `opacity-50` + `border-slate-800` making them nearly invisible on the dark background.

## Fix
- Changed callback redirect to `/onboarding?connected=digitalocean`
- Also fixed error redirect paths
- Bumped disabled card opacity from 50 to 70, border from slate-800 to slate-700