### PR TITLE
fix: add error logging to DO OAuth callback

### DIFF
--- a/apps/web/src/app/api/auth/digitalocean/callback/route.ts
+++ b/apps/web/src/app/api/auth/digitalocean/callback/route.ts
@@ -22,6 +22,12 @@ export async function GET(request: NextRequest) {
   });
 
   if (!tokenRes.ok) {
+    const errorBody = await tokenRes.text().catch(() => 'no body');
+    console.error(
+      `DO token exchange failed: ${tokenRes.status} ${tokenRes.statusText}`,
+      `redirect_uri=${process.env.DO_REDIRECT_URI}`,
+      `body=${errorBody}`,
+    );
     return NextResponse.redirect(new URL('/onboarding?error=token_exchange', request.url));
   }
 


### PR DESCRIPTION
Logs DO's actual error response (status + body) when token exchange fails, so we can diagnose redirect_uri mismatches and other OAuth issues from Vercel runtime logs.