### PR TITLE
fix: trim trailing newlines from DO OAuth env vars

### DIFF
--- a/apps/web/src/app/api/auth/digitalocean/callback/route.ts
+++ b/apps/web/src/app/api/auth/digitalocean/callback/route.ts
@@ -15,9 +15,9 @@ export async function GET(request: NextRequest) {
     body: new URLSearchParams({
       grant_type: 'authorization_code',
       code,
-      client_id: process.env.DO_CLIENT_ID!,
-      client_secret: process.env.DO_CLIENT_SECRET!,
-      redirect_uri: process.env.DO_REDIRECT_URI!,
+      client_id: process.env.DO_CLIENT_ID!.trim(),
+      client_secret: process.env.DO_CLIENT_SECRET!.trim(),
+      redirect_uri: process.env.DO_REDIRECT_URI!.trim(),
     }),
   });
 

--- a/apps/web/src/app/api/auth/digitalocean/route.ts
+++ b/apps/web/src/app/api/auth/digitalocean/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from 'next/server';
 
 export async function GET() {
-  const clientId = process.env.DO_CLIENT_ID;
-  const redirectUri = process.env.DO_REDIRECT_URI;
+  const clientId = process.env.DO_CLIENT_ID?.trim();
+  const redirectUri = process.env.DO_REDIRECT_URI?.trim();
 
   if (!clientId || !redirectUri) {
     return NextResponse.json({ error: 'DigitalOcean OAuth not configured' }, { status: 500 });


### PR DESCRIPTION
Root cause: the DO_CLIENT_ID, DO_CLIENT_SECRET, and DO_REDIRECT_URI env vars in Vercel had trailing newlines. The authorize step was lenient about this, but the token exchange did a strict redirect_uri match and returned 401.