### PR TITLE
fix: drop auth.users FK constraint for custom OAuth

### DIFF
--- a/supabase/migrations/004_drop_auth_users_fk.sql
+++ b/supabase/migrations/004_drop_auth_users_fk.sql
@@ -1,0 +1,21 @@
+-- 004_drop_auth_users_fk.sql
+-- The app uses custom Google OAuth (not Supabase Auth), so users.id
+-- should not reference auth.users. Drop the FK constraint.
+
+-- Also add missing columns used by the Google callback
+alter table public.users
+  add column if not exists google_id text,
+  add column if not exists avatar_url text;
+
+-- Drop the FK to auth.users
+alter table public.users
+  drop constraint if exists users_id_fkey,
+  drop constraint if exists users_pkey;
+
+alter table public.users
+  alter column id set default gen_random_uuid(),
+  add primary key (id);
+
+-- Create unique index on google_id for upserts
+create unique index if not exists idx_users_google_id on public.users (google_id) where google_id is not null;
+create unique index if not exists idx_users_email on public.users (email);


### PR DESCRIPTION
The users table had a FK from users.id → auth.users, but we use custom Google OAuth, not Supabase Auth. This caused FK violations when inserting users during sign-in.

**Migration already applied in production.**

Changes:
- Drop users_id_fkey constraint
- Add google_id and avatar_url columns
- Set default gen_random_uuid() on id
- Add unique indexes on google_id and email