### PR TITLE
fix: Stripe checkout downloads file instead of redirecting

### DIFF
--- a/apps/web/src/app/onboarding/wizard.tsx
+++ b/apps/web/src/app/onboarding/wizard.tsx
@@ -351,9 +351,17 @@ export default function OnboardingWizard() {
             </div>
             <div className="flex justify-between items-center">
               <BackBtn />
-              <PrimaryBtn onClick={() => {
+              <PrimaryBtn onClick={async () => {
                 if (plan === 'pro') {
-                  window.location.href = '/api/stripe/checkout';
+                  const res = await fetch('/api/stripe/checkout', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ plan: 'pro' }),
+                  });
+                  const data = await res.json();
+                  if (data.url) {
+                    window.location.href = data.url;
+                  }
                 } else {
                   next();
                 }


### PR DESCRIPTION
Clicking 'Subscribe' on the Pro plan was navigating directly to `/api/stripe/checkout` via GET, but that route only handles POST and returns JSON. The browser treated the response as a file download (`checkout.txt`).

Now uses `fetch()` with POST to get the Stripe checkout URL, then redirects to it.