### PR TITLE
fix: Launch Assistant returning Unauthorized

### DIFF
--- a/apps/web/src/app/api/assistant/launch/route.ts
+++ b/apps/web/src/app/api/assistant/launch/route.ts
@@ -1,17 +1,15 @@
 import { NextResponse } from 'next/server';
-import { createClient } from '@/lib/supabase/server';
+import { getSession } from '@/lib/auth/session';
 import { launchAssistant } from '@/lib/vm/lifecycle';
 
 export async function POST() {
-  const supabase: any = await createClient();
-  const { data: { user }, error: authError } = await supabase.auth.getUser();
-
-  if (authError || !user) {
+  const session = await getSession();
+  if (!session) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
   try {
-    const assistant = await launchAssistant(user.id);
+    const assistant = await launchAssistant(session.userId);
     return NextResponse.json({ assistant });
   } catch (err: any) {
     return NextResponse.json(


### PR DESCRIPTION
The `/api/assistant/launch` route was using `supabase.auth.getUser()` (Supabase's built-in auth), but we use custom Google OAuth with JWT sessions. This always returned null → 'Unauthorized'.

Switched to `getSession()` to match all other API routes.