### PR TITLE
fix: skill cards should all be same height

### DIFF
--- a/apps/web/src/app/onboarding/wizard.tsx
+++ b/apps/web/src/app/onboarding/wizard.tsx
@@ -316,11 +316,11 @@ export default function OnboardingWizard() {
     const showTooltip = proTooltip === skill.id;
 
     return (
-      <div className="relative">
+      <div className="relative h-full">
         <button
           type="button"
           onClick={() => toggleSkill(skill.id)}
-          className={`relative w-full p-4 rounded-xl border-2 text-left transition-all ${
+          className={`relative w-full h-full p-4 rounded-xl border-2 text-left transition-all ${
             isLocked
               ? 'border-slate-700/50 bg-slate-900/30 opacity-60 cursor-pointer hover:opacity-75'
               : isSelected


### PR DESCRIPTION
Cards had uneven heights because content length varies. Added `h-full` to the card wrapper and button so grid rows stretch evenly.