### PR TITLE
feat: update onboarding wizard and lifecycle for Oracle Cloud free tier

### DIFF
--- a/apps/web/src/app/api/onboarding/route.ts
+++ b/apps/web/src/app/api/onboarding/route.ts
@@ -9,7 +9,7 @@ export async function PATCH(request: NextRequest) {
   }
 
   const body = await request.json();
-  const { timezone, plan, windowStart, messengers, skills, onboardingComplete } = body;
+  const { timezone, plan, windowStart, messengers, skills, hosting, onboardingComplete } = body;
 
   const supabase: any = createClient();
 
@@ -20,6 +20,7 @@ export async function PATCH(request: NextRequest) {
   if (messengers !== undefined) update.messengers = messengers;
   if (skills !== undefined) update.skills = skills;
   if (onboardingComplete !== undefined) update.onboarding_complete = onboardingComplete;
+  if (hosting !== undefined) update.provider_preference = hosting;
 
   const { error } = await supabase
     .from('users')

--- a/apps/web/src/app/onboarding/wizard.tsx
+++ b/apps/web/src/app/onboarding/wizard.tsx
@@ -96,7 +96,7 @@ export default function OnboardingWizard() {
   const [direction, setDirection] = useState(1);
   const [animating, setAnimating] = useState(false);
   const [timezone, setTimezone] = useState('');
-  const [hosting, setHosting] = useState('digitalocean');
+  const [hosting, setHosting] = useState('oracle');
   const [plan, setPlan] = useState<'free' | 'pro'>('free');
   const [windowStart, setWindowStart] = useState(9);
   const [messengers, setMessengers] = useState<string[]>([]);
@@ -118,7 +118,7 @@ export default function OnboardingWizard() {
       const s = parseInt(stepParam, 10);
       if (s >= 0 && s < STEPS.length) setStep(s);
     }
-    if (connected === 'digitalocean' && !stepParam) setStep(2);
+    if ((connected === 'digitalocean' || connected === 'oracle') && !stepParam) setStep(2);
     if (upgraded === 'true' && !stepParam) {
       setPlan('pro');
       setStep(3);
@@ -207,7 +207,7 @@ export default function OnboardingWizard() {
       await fetch('/api/onboarding', {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ timezone, plan, windowStart, messengers, skills, onboardingComplete: false }),
+        body: JSON.stringify({ timezone, plan, windowStart, messengers, skills, hosting, onboardingComplete: false }),
       });
       addStatus('Preferences saved');
     } catch {
@@ -220,7 +220,7 @@ export default function OnboardingWizard() {
       const launchRes = await fetch('/api/launch', { method: 'POST' });
       if (!launchRes.ok) {
         const errData = await launchRes.json().catch(() => ({}));
-        addStatus(`⚠️ ${errData.error ?? 'Launch failed — please check your DigitalOcean account'}`);
+        addStatus(`⚠️ ${errData.error ?? 'Launch failed — please try again'}`);
         launchFailed = true;
       } else {
         addStatus('Assistant launched');
@@ -239,7 +239,7 @@ export default function OnboardingWizard() {
     addStatus('Provisioning your server — this usually takes 2–4 minutes...');
     let attempts = 0;
     const milestones = [
-      { at: 15, msg: 'Creating your server on DigitalOcean...' },
+      { at: 15, msg: `Creating your server on ${hosting === 'oracle' ? 'Oracle Cloud' : 'DigitalOcean'}...` },
       { at: 30, msg: 'Installing OpenClaw and dependencies...' },
       { at: 60, msg: 'Configuring your assistant...' },
       { at: 90, msg: 'Almost there — starting services...' },
@@ -477,12 +477,26 @@ export default function OnboardingWizard() {
             <h2 className="text-2xl font-bold text-center">Choose Your Hosting</h2>
             <p className="text-slate-400 text-center">Where should your AI assistant run?</p>
             <div className="grid gap-4">
-              <Card selected={hosting === 'digitalocean'} onClick={() => setHosting('digitalocean')}>
+              <Card selected={hosting === 'oracle'} onClick={() => setHosting('oracle')}>
                 <div className="flex items-center gap-3">
-                  <Cloud className="w-8 h-8 text-blue-400" />
+                  <Sun className="w-8 h-8 text-amber-400" />
                   <div>
-                    <div className="font-semibold">DigitalOcean</div>
-                    <div className="text-sm text-slate-400">Reliable cloud hosting, starting at $4/mo</div>
+                    <div className="font-semibold">Oracle Cloud — Free Tier</div>
+                    <div className="text-sm text-slate-400">Always Free ARM server — no credit card, no hosting cost</div>
+                  </div>
+                </div>
+              </Card>
+              <Card disabled>
+                <div className="flex items-center gap-3">
+                  <Cloud className="w-8 h-8 text-blue-400 opacity-50" />
+                  <div>
+                    <div className="font-semibold text-slate-400">
+                      DigitalOcean{' '}
+                      <span className="ml-2 inline-flex items-center gap-1 bg-violet-500/20 text-violet-400 text-[10px] font-bold px-2 py-0.5 rounded-full">
+                        <Lock className="w-2.5 h-2.5" /> Pro — Coming Soon
+                      </span>
+                    </div>
+                    <div className="text-sm text-slate-500">Managed cloud hosting (requires Pro plan)</div>
                   </div>
                 </div>
               </Card>
@@ -507,14 +521,12 @@ export default function OnboardingWizard() {
             </div>
             <div className="flex justify-between items-center">
               <BackBtn />
-              <PrimaryBtn onClick={() => {
-                window.location.href = '/api/auth/digitalocean';
-              }}>
-                Connect DigitalOcean <ArrowRight className="w-4 h-4" />
+              <PrimaryBtn onClick={next} disabled={!hosting}>
+                Next <ArrowRight className="w-4 h-4" />
               </PrimaryBtn>
             </div>
             <p className="text-xs text-slate-500 text-center">
-              New to DigitalOcean?{' '}
+              Interested in DigitalOcean for the future?{' '}
               <a
                 href="https://cloud.digitalocean.com/account-referrals?i=091ab6c0-097d-4111-baab-ee4872bd796d"
                 target="_blank"
@@ -523,7 +535,7 @@ export default function OnboardingWizard() {
               >
                 Sign up with our referral link
               </a>{' '}
-              for free credits.
+              for free credits when it&apos;s available.
             </p>
           </div>
         )}
@@ -572,6 +584,9 @@ export default function OnboardingWizard() {
                 </div>
               </Card>
             </div>
+            <p className="text-xs text-slate-500 text-center">
+              Oracle Cloud free hosting is included with both plans — no hosting fees ever.
+            </p>
             <div className="flex justify-between items-center">
               <BackBtn />
               <PrimaryBtn onClick={async () => {
@@ -725,7 +740,7 @@ export default function OnboardingWizard() {
             <div className="bg-slate-900 border border-slate-800 rounded-xl p-6 text-left space-y-3 max-w-md mx-auto">
               <div className="flex justify-between text-sm">
                 <span className="text-slate-400">Hosting</span>
-                <span>DigitalOcean</span>
+                <span>{hosting === 'oracle' ? 'Oracle Cloud (Free)' : 'DigitalOcean'}</span>
               </div>
               <div className="flex justify-between text-sm">
                 <span className="text-slate-400">Plan</span>

--- a/apps/web/src/lib/supabase/types.ts
+++ b/apps/web/src/lib/supabase/types.ts
@@ -21,6 +21,7 @@ export interface User {
   timezone: string | null;
   window_start: number | null;
   onboarding_complete: boolean;
+  provider_preference: string | null;
   created_at: string;
   updated_at: string;
 }

--- a/apps/web/src/lib/vm/lifecycle.ts
+++ b/apps/web/src/lib/vm/lifecycle.ts
@@ -1,5 +1,6 @@
 import { createClient } from '../supabase/server';
 import { createDroplet, destroyDroplet, powerOn, powerOff, validateAccount } from '../providers/digitalocean';
+import { OracleProvider } from '../providers/oracle';
 import { getProviderToken, refreshProviderToken } from '../providers/token-store';
 import { generateCloudInit } from '../providers/cloud-init';
 import type { Assistant, AssistantStatus } from '../supabase/types';
@@ -58,17 +59,37 @@ async function getUserDOToken(userId: string): Promise<string> {
 }
 
 /**
- * Launch a new assistant VM on the user's DigitalOcean account.
+ * Determine the cloud provider for a user.
+ * Checks user's provider_preference, falls back to CLOUD_PROVIDER env or 'oracle'.
+ */
+async function getProviderForUser(userId: string): Promise<'oracle' | 'digitalocean'> {
+  const supabase: any = createClient();
+  const { data } = await supabase
+    .from('users')
+    .select('provider_preference')
+    .eq('id', userId)
+    .single();
+
+  const pref = data?.provider_preference;
+  if (pref === 'oracle' || pref === 'digitalocean') return pref;
+  return (process.env.CLOUD_PROVIDER as 'oracle' | 'digitalocean') ?? 'oracle';
+}
+
+/**
+ * Get a shared OracleProvider instance (uses our own OCI credentials).
+ */
+function getOracleProvider(): OracleProvider {
+  return new OracleProvider();
+}
+
+/**
+ * Launch a new assistant VM.
+ * Oracle: uses our own OCI credentials (no user tokens needed).
+ * DigitalOcean: uses the user's OAuth token.
  */
 export async function launchAssistant(userId: string): Promise<Assistant> {
   const supabase: any = createClient();
-  const token = await getUserDOToken(userId);
-
-  // Pre-flight: validate the DO account can create resources
-  const validation = await validateAccount(token);
-  if (!validation.ok) {
-    throw new Error(validation.error ?? 'DigitalOcean account validation failed');
-  }
+  const provider = await getProviderForUser(userId);
 
   const assistantId = randomUUID();
   const sidecarToken = randomUUID();
@@ -85,7 +106,7 @@ export async function launchAssistant(userId: string): Promise<Assistant> {
     .insert({
       id: assistantId,
       user_id: userId,
-      provider: 'digitalocean',
+      provider,
       status: 'provisioning' as AssistantStatus,
       sidecar_token: sidecarToken,
     })
@@ -95,16 +116,37 @@ export async function launchAssistant(userId: string): Promise<Assistant> {
   if (insertError) throw new Error(`Failed to create assistant: ${insertError.message}`);
 
   try {
-    const droplet = await createDroplet(token, {
-      name: `claw-${assistantId.slice(0, 8)}`,
-      cloudInit,
-    });
+    if (provider === 'oracle') {
+      const oracle = getOracleProvider();
+      const server = await oracle.createServer({
+        name: `claw-${assistantId.slice(0, 8)}`,
+        cloudInit,
+      });
 
-    return await updateAssistantStatus(assistantId, 'provisioning', {
-      vm_id: String(droplet.id),
-      ip_address: droplet.publicIpv4,
-      region: droplet.region,
-    });
+      return await updateAssistantStatus(assistantId, 'provisioning', {
+        vm_id: server.id,
+        ip_address: server.publicIpv4,
+        region: server.region,
+      });
+    } else {
+      // DigitalOcean flow — requires user OAuth tokens
+      const token = await getUserDOToken(userId);
+      const validation = await validateAccount(token);
+      if (!validation.ok) {
+        throw new Error(validation.error ?? 'DigitalOcean account validation failed');
+      }
+
+      const droplet = await createDroplet(token, {
+        name: `claw-${assistantId.slice(0, 8)}`,
+        cloudInit,
+      });
+
+      return await updateAssistantStatus(assistantId, 'provisioning', {
+        vm_id: String(droplet.id),
+        ip_address: droplet.publicIpv4,
+        region: droplet.region,
+      });
+    }
   } catch (err) {
     await updateAssistantStatus(assistantId, 'destroyed').catch(() => {});
     throw err;
@@ -112,7 +154,7 @@ export async function launchAssistant(userId: string): Promise<Assistant> {
 }
 
 /**
- * Suspend (power off) an assistant's droplet.
+ * Suspend (power off) an assistant's VM.
  */
 export async function suspendAssistant(assistantId: string): Promise<Assistant> {
   const supabase: any = createClient();
@@ -128,13 +170,19 @@ export async function suspendAssistant(assistantId: string): Promise<Assistant> 
   assertTransition(assistant.status, 'suspended');
   if (!assistant.vm_id) throw new Error('No VM associated with assistant');
 
-  const token = await getUserDOToken(assistant.user_id);
-  await powerOff(token, Number(assistant.vm_id));
+  if (assistant.provider === 'oracle') {
+    const oracle = getOracleProvider();
+    await oracle.powerOff(assistant.vm_id);
+  } else {
+    const token = await getUserDOToken(assistant.user_id);
+    await powerOff(token, Number(assistant.vm_id));
+  }
+
   return await updateAssistantStatus(assistantId, 'suspended');
 }
 
 /**
- * Resume (power on) a suspended assistant's droplet.
+ * Resume (power on) a suspended assistant's VM.
  */
 export async function resumeAssistant(assistantId: string): Promise<Assistant> {
   const supabase: any = createClient();
@@ -150,13 +198,19 @@ export async function resumeAssistant(assistantId: string): Promise<Assistant> {
   assertTransition(assistant.status, 'active');
   if (!assistant.vm_id) throw new Error('No VM associated with assistant');
 
-  const token = await getUserDOToken(assistant.user_id);
-  await powerOn(token, Number(assistant.vm_id));
+  if (assistant.provider === 'oracle') {
+    const oracle = getOracleProvider();
+    await oracle.powerOn(assistant.vm_id);
+  } else {
+    const token = await getUserDOToken(assistant.user_id);
+    await powerOn(token, Number(assistant.vm_id));
+  }
+
   return await updateAssistantStatus(assistantId, 'active');
 }
 
 /**
- * Destroy an assistant's droplet permanently.
+ * Destroy an assistant's VM permanently.
  */
 export async function destroyAssistant(assistantId: string): Promise<Assistant> {
   const supabase: any = createClient();
@@ -174,8 +228,13 @@ export async function destroyAssistant(assistantId: string): Promise<Assistant> 
 
   try {
     if (assistant.vm_id) {
-      const token = await getUserDOToken(assistant.user_id);
-      await destroyDroplet(token, Number(assistant.vm_id));
+      if (assistant.provider === 'oracle') {
+        const oracle = getOracleProvider();
+        await oracle.destroyServer(assistant.vm_id);
+      } else {
+        const token = await getUserDOToken(assistant.user_id);
+        await destroyDroplet(token, Number(assistant.vm_id));
+      }
     }
     return await updateAssistantStatus(assistantId, 'destroyed', {
       vm_id: null,


### PR DESCRIPTION
## Summary

Updates the onboarding wizard and VM lifecycle to support Oracle Cloud as the primary free-tier hosting provider. DigitalOcean is shown as a grayed-out paid alternative.

### Changes

**Wizard (`wizard.tsx`)**
- Oracle Cloud is now the default and pre-selected hosting option
- DigitalOcean shown as disabled with Pro — Coming Soon badge
- Replaced DO OAuth redirect button with simple Next button
- Step 2 notes Oracle free hosting included with both plans
- Step 5 milestone messages are provider-aware
- Step 6 summary dynamically shows selected provider

**Lifecycle (`lifecycle.ts`)**
- Added `getProviderForUser()` — checks user provider_preference, falls back to env or oracle
- `launchAssistant`: Oracle uses our OCI credentials, skips DO validation
- `suspendAssistant`, `resumeAssistant`, `destroyAssistant`: all provider-aware

**Onboarding API (`route.ts`)**
- Accepts `hosting` field, maps to `provider_preference` column

**Supabase types (`types.ts`)**
- Added `provider_preference` to User interface

TypeScript compiles clean.