### PR TITLE
fix: revert Azure OAuth to /common + .default (app reg changed to multi-org)

### DIFF
--- a/apps/web/src/app/api/auth/azure/callback/route.ts
+++ b/apps/web/src/app/api/auth/azure/callback/route.ts
@@ -18,7 +18,7 @@ export async function GET(request: NextRequest) {
   }
 
   // Exchange code for tokens
-  const tokenRes = await fetch('https://login.microsoftonline.com/organizations/oauth2/v2.0/token', {
+  const tokenRes = await fetch('https://login.microsoftonline.com/common/oauth2/v2.0/token', {
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
     body: new URLSearchParams({

--- a/apps/web/src/app/api/auth/azure/route.ts
+++ b/apps/web/src/app/api/auth/azure/route.ts
@@ -16,17 +16,17 @@ export async function GET() {
     client_id: clientId,
     response_type: 'code',
     redirect_uri: redirectUri,
-    scope: 'https://management.azure.com/user_impersonation offline_access openid profile',
+    scope: 'https://management.azure.com/.default offline_access openid profile',
     state,
     // Prompt account selection so users can pick their Azure-linked account
     prompt: 'select_account',
   });
 
-  // Use /organizations endpoint — ARM API requires work/school (Azure AD) accounts.
-  // Personal Microsoft accounts get auto-upgraded to org accounts when they create
-  // an Azure subscription, so this works for all Azure subscribers.
+  // Use /common — works for both single-tenant and multi-tenant org accounts.
+  // Personal Microsoft accounts (outlook.com, gmail) get an Azure AD directory
+  // when they create a subscription, making them org accounts for ARM purposes.
   const response = NextResponse.redirect(
-    `https://login.microsoftonline.com/organizations/oauth2/v2.0/authorize?${params.toString()}`,
+    `https://login.microsoftonline.com/common/oauth2/v2.0/authorize?${params.toString()}`,
   );
   response.cookies.set('azure_oauth_state', state, {
     httpOnly: true,

--- a/apps/web/src/lib/providers/token-store.ts
+++ b/apps/web/src/lib/providers/token-store.ts
@@ -99,13 +99,13 @@ function getRefreshConfig(provider: string, refreshToken: string): { url: string
   switch (provider) {
     case 'azure':
       return {
-        url: 'https://login.microsoftonline.com/organizations/oauth2/v2.0/token',
+        url: 'https://login.microsoftonline.com/common/oauth2/v2.0/token',
         body: {
           grant_type: 'refresh_token',
           refresh_token: refreshToken,
           client_id: process.env.AZURE_CLIENT_ID!,
           client_secret: process.env.AZURE_CLIENT_SECRET!,
-          scope: 'https://management.azure.com/user_impersonation offline_access',
+          scope: 'https://management.azure.com/.default offline_access',
         },
       };
     case 'digitalocean':


### PR DESCRIPTION
The /organizations endpoint also rejects personal accounts. The actual fix was changing the Azure app registration from AzureADandPersonalMicrosoftAccount to AzureADMultipleOrgs.

Personal Microsoft accounts (gmail, outlook) can't access Azure Resource Manager directly — but when they create an Azure subscription, they get an Azure AD org account. So /common with .default scope works for them as org accounts.

Changes:
- Reverted to /common endpoint (from /organizations)
- Reverted to .default scope (from user_impersonation)
- Kept prompt=select_account for UX
- Azure app registration updated to AzureADMultipleOrgs in portal