### PR TITLE
fix: handle Azure OAuth callback redirect in onboarding wizard

### DIFF
--- a/apps/web/src/app/onboarding/wizard.tsx
+++ b/apps/web/src/app/onboarding/wizard.tsx
@@ -139,7 +139,11 @@ export default function OnboardingWizard() {
       const s = parseInt(stepParam, 10);
       if (s >= 0 && s < STEPS.length) setStep(s);
     }
-    if (connected === 'digitalocean' && !stepParam) setStep(2);
+    if ((connected === 'digitalocean' || connected === 'azure') && !stepParam) {
+      setHosting(connected);
+      setVmSize(getDefaultSize(connected));
+      setStep(2);
+    }
     if (upgraded === 'true' && !stepParam) {
       setPlan('pro');
       setStep(3);


### PR DESCRIPTION
## Problem
After signing in with a Microsoft account during onboarding, users were redirected back to the Welcome step (step 0) instead of advancing to the Plan step.

## Root Cause
The Azure OAuth callback redirects to `/onboarding?connected=azure`, but the wizard's useEffect only checked for `connected === 'digitalocean'`. The `connected=azure` param was silently ignored.

## Fix
Updated the connected-provider handler to accept both `azure` and `digitalocean`, and also properly sets the `hosting` and `vmSize` state so the wizard continues from the right context.

## Testing
1. Start onboarding flow
2. Click 'Connect Azure' on the Hosting step
3. Complete Microsoft sign-in
4. Should now land on Plan step (step 2) instead of Welcome