### PR TITLE
fix: request ARM scope upfront in Azure OAuth flow

### DIFF
--- a/apps/web/src/app/api/auth/azure/callback/route.ts
+++ b/apps/web/src/app/api/auth/azure/callback/route.ts
@@ -32,9 +32,9 @@ export async function GET(request: NextRequest) {
   const clientSecret = process.env.AZURE_CLIENT_SECRET!.trim();
   const redirectUri = process.env.AZURE_REDIRECT_URI!.trim();
 
-  // Step 1: Exchange code for identity tokens via /common
-  // This gives us an id_token with the user's tenant ID
-  const identityRes = await fetch('https://login.microsoftonline.com/common/oauth2/v2.0/token', {
+  // Exchange code for tokens - the code was issued with ARM scope, so
+  // the access_token will be an ARM management token directly.
+  const tokenRes = await fetch('https://login.microsoftonline.com/common/oauth2/v2.0/token', {
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
     body: new URLSearchParams({
@@ -43,51 +43,21 @@ export async function GET(request: NextRequest) {
       client_id: clientId,
       client_secret: clientSecret,
       redirect_uri: redirectUri,
-      scope: 'openid profile offline_access',
+      scope: 'openid profile offline_access https://management.azure.com/user_impersonation',
     }),
   });
 
-  if (!identityRes.ok) {
-    const errorBody = await identityRes.text().catch(() => 'no body');
-    console.error(`Azure identity token exchange failed: ${identityRes.status}`, errorBody);
+  if (!tokenRes.ok) {
+    const errorBody = await tokenRes.text().catch(() => 'no body');
+    console.error(`Azure token exchange failed: ${tokenRes.status}`, errorBody);
     return NextResponse.redirect(new URL('/onboarding?error=token_exchange', request.url));
   }
 
-  const identityData = await identityRes.json();
+  const tokenData = await tokenRes.json();
 
-  // Extract tenant ID from the id_token
-  const idTokenClaims = identityData.id_token ? decodeJwt(identityData.id_token) : {};
+  // Extract tenant ID from the id_token for future token refreshes
+  const idTokenClaims = tokenData.id_token ? decodeJwt(tokenData.id_token) : {};
   const tenantId = idTokenClaims.tid as string | undefined;
-
-  if (!tenantId) {
-    console.error('No tenant ID found in id_token');
-    return NextResponse.redirect(new URL('/onboarding?error=no_tenant', request.url));
-  }
-
-  // Step 2: Request ARM token using the tenant-specific endpoint
-  // This works because the user's personal account is associated with an Azure AD tenant
-  const armRes = await fetch(`https://login.microsoftonline.com/${tenantId}/oauth2/v2.0/token`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body: new URLSearchParams({
-      grant_type: 'refresh_token',
-      refresh_token: identityData.refresh_token,
-      client_id: clientId,
-      client_secret: clientSecret,
-      scope: 'https://management.azure.com/.default offline_access',
-    }),
-  });
-
-  if (!armRes.ok) {
-    const errorBody = await armRes.text().catch(() => 'no body');
-    console.error(`Azure ARM token request failed: ${armRes.status}`, errorBody);
-    // Fall back to identity token — user may not have an Azure subscription yet
-    // They can still proceed through onboarding
-  }
-
-  const armData = armRes.ok ? await armRes.json() : null;
-  const accessToken = armData?.access_token ?? identityData.access_token;
-  const refreshToken = armData?.refresh_token ?? identityData.refresh_token;
 
   // Get current user from session
   const session = await getSession();
@@ -95,38 +65,41 @@ export async function GET(request: NextRequest) {
     return NextResponse.redirect(new URL('/auth/signin', request.url));
   }
 
-  // Store encrypted tokens (ARM token if available, otherwise identity token)
-  const expiresIn = armData?.expires_in ?? identityData.expires_in;
-  const expiresAt = expiresIn ? new Date(Date.now() + expiresIn * 1000) : null;
+  // Store encrypted tokens (ARM-scoped access token)
+  const expiresAt = tokenData.expires_in
+    ? new Date(Date.now() + tokenData.expires_in * 1000)
+    : null;
 
   await saveProviderToken(
     session.userId,
     'azure',
-    accessToken,
-    refreshToken,
+    tokenData.access_token,
+    tokenData.refresh_token,
     expiresAt,
   );
 
-  // Store the tenant ID for future token refreshes
-  await saveProviderToken(
-    session.userId,
-    'azure_tenant',
-    tenantId,
-    null,
-    null,
-  );
+  // Store the tenant ID for future token refreshes (if available)
+  if (tenantId) {
+    await saveProviderToken(
+      session.userId,
+      'azure_tenant',
+      tenantId,
+      null,
+      null,
+    );
+  }
 
   // Verify the account works by listing subscriptions
-  if (armData) {
-    try {
-      const subs = await listSubscriptions(accessToken);
-      const active = subs.find((s) => s.state === 'Enabled');
-      if (active) {
-        console.log(`Azure connected: subscription ${active.id} (${active.displayName}) tenant ${tenantId}`);
-      }
-    } catch (e) {
-      console.error('Azure subscription check failed (non-fatal):', e);
+  try {
+    const subs = await listSubscriptions(tokenData.access_token);
+    const active = subs.find((s) => s.state === 'Enabled');
+    if (active) {
+      console.log(`Azure connected: subscription ${active.id} (${active.displayName}) tenant ${tenantId}`);
+    } else {
+      console.warn('Azure connected but no active subscription found');
     }
+  } catch (e) {
+    console.error('Azure subscription check failed (non-fatal):', e);
   }
 
   // Clear the state cookie

--- a/apps/web/src/app/api/auth/azure/route.ts
+++ b/apps/web/src/app/api/auth/azure/route.ts
@@ -12,16 +12,17 @@ export async function GET() {
   // Anti-CSRF state token
   const state = crypto.randomBytes(32).toString('hex');
 
-  // Step 1: Use /common with openid scope only — this accepts ALL Microsoft account types
-  // (personal, work, school). We'll get the tenant ID from the id_token in the callback,
-  // then request ARM tokens via the tenant-specific endpoint.
+  // Request ARM management scope upfront so the user consents during sign-in.
+  // Using /common works for personal, work, and school accounts.
+  // We request user_impersonation (not .default) because .default doesn't work
+  // in the authorization URL for delegated flows.
   const params = new URLSearchParams({
     client_id: clientId,
     response_type: 'code',
     redirect_uri: redirectUri,
-    scope: 'openid profile offline_access',
+    scope: 'openid profile offline_access https://management.azure.com/user_impersonation',
     state,
-    prompt: 'select_account',
+    prompt: 'consent',
   });
 
   const response = NextResponse.redirect(

--- a/apps/web/src/lib/providers/token-store.ts
+++ b/apps/web/src/lib/providers/token-store.ts
@@ -89,9 +89,9 @@ export async function refreshProviderToken(userId: string, provider: string) {
     refreshBody = {
       grant_type: 'refresh_token',
       refresh_token: existing.refreshToken,
-      client_id: process.env.AZURE_CLIENT_ID!,
-      client_secret: process.env.AZURE_CLIENT_SECRET!,
-      scope: 'https://management.azure.com/.default offline_access',
+      client_id: process.env.AZURE_CLIENT_ID!.trim(),
+      client_secret: process.env.AZURE_CLIENT_SECRET!.trim(),
+      scope: 'openid profile offline_access https://management.azure.com/user_impersonation',
     };
   } else {
     const config = getRefreshConfig(provider, existing.refreshToken);
@@ -122,9 +122,9 @@ function getRefreshConfig(provider: string, refreshToken: string): { url: string
         body: {
           grant_type: 'refresh_token',
           refresh_token: refreshToken,
-          client_id: process.env.AZURE_CLIENT_ID!,
-          client_secret: process.env.AZURE_CLIENT_SECRET!,
-          scope: 'https://management.azure.com/.default offline_access',
+          client_id: process.env.AZURE_CLIENT_ID!.trim(),
+          client_secret: process.env.AZURE_CLIENT_SECRET!.trim(),
+          scope: 'openid profile offline_access https://management.azure.com/user_impersonation',
         },
       };
     case 'digitalocean':

--- a/docs/azure-setup.md
+++ b/docs/azure-setup.md
@@ -24,6 +24,19 @@ ShiftWorker uses Azure OAuth to let users connect their Azure subscriptions for 
 | `AZURE_CLIENT_SECRET` | Client secret value (from Azure portal) |
 | `AZURE_REDIRECT_URI` | Must be `https://shiftworker.ai/api/auth/azure/callback` |
 
+## Required API Permissions
+
+In the Azure portal under **App registrations → ShiftWorker → API permissions**, ensure these delegated permissions are configured:
+
+| API | Permission | Type |
+|-----|-----------|------|
+| Microsoft Graph | `openid` | Delegated |
+| Microsoft Graph | `profile` | Delegated |
+| Microsoft Graph | `offline_access` | Delegated |
+| Azure Service Management | `user_impersonation` | Delegated |
+
+The `user_impersonation` permission on Azure Service Management is required to manage VMs on behalf of the user. Without it, the OAuth flow will fail to obtain ARM management tokens.
+
 ## OAuth Flow
 
 1. User clicks **Connect Azure** in the ShiftWorker dashboard


### PR DESCRIPTION
## Problem
After signing in with Microsoft and completing onboarding, clicking **Launch Assistant** fails with:
> Azure authorization failed. Please re-connect your Azure account.

![Screenshot](https://github.com/user-attachments/assets/placeholder)

## Root Cause
The OAuth flow used a two-step approach:
1. Request identity-only tokens (`openid profile offline_access`)
2. Try to exchange refresh token for ARM management tokens

Step 2 silently failed for personal Microsoft accounts. When it failed, the callback saved the identity token (which can't call ARM APIs) and redirected to onboarding as if everything was fine. When Launch later tried to use this token for Azure Resource Manager calls, it got 401.

## Fix
- Request ARM scope (`user_impersonation`) in the **initial authorization URL** so users consent during sign-in
- Simplify callback to a single token exchange (the auth code already has ARM scope baked in)
- Use `prompt=consent` to ensure fresh consent for ARM permissions
- Update token refresh to use consistent scope across all code paths
- Document required API permissions in azure-setup.md

## Important
The Azure app registration must have **Azure Service Management > user_impersonation** as a delegated permission. If this isn't configured in the Azure portal, the flow will still fail. See `docs/azure-setup.md`.

## Testing
1. Sign out, go to /onboarding
2. Click Connect Azure
3. Sign in with Microsoft (personal account)
4. Should see consent screen including Azure management permission
5. Complete onboarding, click Launch Assistant
6. Should NOT see 'Azure authorization failed' error