### PR TITLE
fix: Azure OAuth for personal Microsoft accounts

### DIFF
--- a/apps/web/src/app/api/auth/azure/callback/route.ts
+++ b/apps/web/src/app/api/auth/azure/callback/route.ts
@@ -32,9 +32,9 @@ export async function GET(request: NextRequest) {
   const clientSecret = process.env.AZURE_CLIENT_SECRET!.trim();
   const redirectUri = process.env.AZURE_REDIRECT_URI!.trim();
 
-  // Exchange code for tokens - the code was issued with ARM scope, so
-  // the access_token will be an ARM management token directly.
-  const tokenRes = await fetch('https://login.microsoftonline.com/common/oauth2/v2.0/token', {
+  // Step 1: Exchange code for identity tokens via /consumers
+  // This gives us an id_token with the user's tenant ID and a refresh_token
+  const identityRes = await fetch('https://login.microsoftonline.com/consumers/oauth2/v2.0/token', {
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
     body: new URLSearchParams({
@@ -43,21 +43,50 @@ export async function GET(request: NextRequest) {
       client_id: clientId,
       client_secret: clientSecret,
       redirect_uri: redirectUri,
-      scope: 'openid profile offline_access https://management.azure.com/user_impersonation',
+      scope: 'openid profile offline_access',
     }),
   });
 
-  if (!tokenRes.ok) {
-    const errorBody = await tokenRes.text().catch(() => 'no body');
-    console.error(`Azure token exchange failed: ${tokenRes.status}`, errorBody);
+  if (!identityRes.ok) {
+    const errorBody = await identityRes.text().catch(() => 'no body');
+    console.error(`Azure identity token exchange failed: ${identityRes.status}`, errorBody);
     return NextResponse.redirect(new URL('/onboarding?error=token_exchange', request.url));
   }
 
-  const tokenData = await tokenRes.json();
+  const identityData = await identityRes.json();
 
-  // Extract tenant ID from the id_token for future token refreshes
-  const idTokenClaims = tokenData.id_token ? decodeJwt(tokenData.id_token) : {};
+  // Extract tenant ID from the id_token
+  const idTokenClaims = identityData.id_token ? decodeJwt(identityData.id_token) : {};
   const tenantId = idTokenClaims.tid as string | undefined;
+
+  if (!tenantId) {
+    console.error('No tenant ID found in id_token');
+    return NextResponse.redirect(new URL('/onboarding?error=no_tenant', request.url));
+  }
+
+  // Step 2: Use the refresh token to get an ARM management token
+  // We use the tenant-specific endpoint so the token is scoped to the user's Azure tenant.
+  // The app registration needs Azure Service Management > user_impersonation permission.
+  const armRes = await fetch(`https://login.microsoftonline.com/${tenantId}/oauth2/v2.0/token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      grant_type: 'refresh_token',
+      refresh_token: identityData.refresh_token,
+      client_id: clientId,
+      client_secret: clientSecret,
+      scope: 'https://management.azure.com/.default offline_access',
+    }),
+  });
+
+  if (!armRes.ok) {
+    const errorBody = await armRes.text().catch(() => 'no body');
+    console.error(`Azure ARM token request failed: ${armRes.status}`, errorBody);
+    // Don't silently continue - redirect with a clear error so the user knows
+    return NextResponse.redirect(new URL('/onboarding?error=azure_no_subscription', request.url));
+  }
+
+  const armData = await armRes.json();
 
   // Get current user from session
   const session = await getSession();
@@ -65,33 +94,31 @@ export async function GET(request: NextRequest) {
     return NextResponse.redirect(new URL('/auth/signin', request.url));
   }
 
-  // Store encrypted tokens (ARM-scoped access token)
-  const expiresAt = tokenData.expires_in
-    ? new Date(Date.now() + tokenData.expires_in * 1000)
+  // Store the ARM-scoped tokens (these can actually call management APIs)
+  const expiresAt = armData.expires_in
+    ? new Date(Date.now() + armData.expires_in * 1000)
     : null;
 
   await saveProviderToken(
     session.userId,
     'azure',
-    tokenData.access_token,
-    tokenData.refresh_token,
+    armData.access_token,
+    armData.refresh_token ?? identityData.refresh_token,
     expiresAt,
   );
 
-  // Store the tenant ID for future token refreshes (if available)
-  if (tenantId) {
-    await saveProviderToken(
-      session.userId,
-      'azure_tenant',
-      tenantId,
-      null,
-      null,
-    );
-  }
+  // Store the tenant ID for future token refreshes
+  await saveProviderToken(
+    session.userId,
+    'azure_tenant',
+    tenantId,
+    null,
+    null,
+  );
 
   // Verify the account works by listing subscriptions
   try {
-    const subs = await listSubscriptions(tokenData.access_token);
+    const subs = await listSubscriptions(armData.access_token);
     const active = subs.find((s) => s.state === 'Enabled');
     if (active) {
       console.log(`Azure connected: subscription ${active.id} (${active.displayName}) tenant ${tenantId}`);

--- a/apps/web/src/app/api/auth/azure/route.ts
+++ b/apps/web/src/app/api/auth/azure/route.ts
@@ -12,21 +12,22 @@ export async function GET() {
   // Anti-CSRF state token
   const state = crypto.randomBytes(32).toString('hex');
 
-  // Request ARM management scope upfront so the user consents during sign-in.
-  // Using /common works for personal, work, and school accounts.
-  // We request user_impersonation (not .default) because .default doesn't work
-  // in the authorization URL for delegated flows.
+  // Use /consumers endpoint for personal Microsoft accounts.
+  // We request identity-only scopes here because personal accounts
+  // can't request ARM scope directly in the authorize URL.
+  // The callback will exchange the refresh token for ARM tokens
+  // via the user's tenant-specific endpoint.
   const params = new URLSearchParams({
     client_id: clientId,
     response_type: 'code',
     redirect_uri: redirectUri,
-    scope: 'openid profile offline_access https://management.azure.com/user_impersonation',
+    scope: 'openid profile offline_access',
     state,
     prompt: 'consent',
   });
 
   const response = NextResponse.redirect(
-    `https://login.microsoftonline.com/common/oauth2/v2.0/authorize?${params.toString()}`,
+    `https://login.microsoftonline.com/consumers/oauth2/v2.0/authorize?${params.toString()}`,
   );
   response.cookies.set('azure_oauth_state', state, {
     httpOnly: true,

--- a/apps/web/src/app/onboarding/wizard.tsx
+++ b/apps/web/src/app/onboarding/wizard.tsx
@@ -125,6 +125,7 @@ export default function OnboardingWizard() {
   const [setupDone, setSetupDone] = useState(false);
   const [serverActive, setServerActive] = useState(false);
   const [proTooltip, setProTooltip] = useState<string | null>(null);
+  const [onboardingError, setOnboardingError] = useState<string | null>(null);
   const [botLinks, setBotLinks] = useState<Record<string, string>>({});
 
   // Init from URL params and timezone
@@ -134,6 +135,20 @@ export default function OnboardingWizard() {
     const stepParam = searchParams.get('step');
     const connected = searchParams.get('connected');
     const upgraded = searchParams.get('upgraded');
+    const errorParam = searchParams.get('error');
+
+    if (errorParam) {
+      const errorMessages: Record<string, string> = {
+        azure_no_subscription: 'Could not connect to Azure. Make sure you have an active Azure subscription with your Microsoft account.',
+        token_exchange: 'Sign-in failed. Please try again.',
+        missing_code: 'Sign-in was incomplete. Please try again.',
+        invalid_state: 'Sign-in verification failed. Please try again.',
+        no_tenant: 'Could not determine your Azure tenant. Please try again.',
+      };
+      setOnboardingError(errorMessages[errorParam] ?? 'Something went wrong. Please try again.');
+      setStep(1); // Go back to hosting step
+      return;
+    }
 
     if (stepParam) {
       const s = parseInt(stepParam, 10);
@@ -677,6 +692,11 @@ export default function OnboardingWizard() {
           <div className="space-y-6">
             <h2 className="text-2xl font-bold text-center">Choose Your Hosting</h2>
             <p className="text-slate-400 text-center">Where should your AI assistant run?</p>
+            {onboardingError && (
+              <div className="bg-red-900/30 border border-red-700 rounded-lg p-4 text-sm text-red-300 text-center">
+                {onboardingError}
+              </div>
+            )}
             <div className="grid gap-4">
               <Card selected={hosting === 'azure'} onClick={() => { setHosting('azure'); setVmSize(getDefaultSize('azure')); }}>
                 <div className="flex items-center gap-3">

--- a/apps/web/src/lib/providers/token-store.ts
+++ b/apps/web/src/lib/providers/token-store.ts
@@ -91,7 +91,7 @@ export async function refreshProviderToken(userId: string, provider: string) {
       refresh_token: existing.refreshToken,
       client_id: process.env.AZURE_CLIENT_ID!.trim(),
       client_secret: process.env.AZURE_CLIENT_SECRET!.trim(),
-      scope: 'openid profile offline_access https://management.azure.com/user_impersonation',
+      scope: 'https://management.azure.com/.default offline_access',
     };
   } else {
     const config = getRefreshConfig(provider, existing.refreshToken);
@@ -124,7 +124,7 @@ function getRefreshConfig(provider: string, refreshToken: string): { url: string
           refresh_token: refreshToken,
           client_id: process.env.AZURE_CLIENT_ID!.trim(),
           client_secret: process.env.AZURE_CLIENT_SECRET!.trim(),
-          scope: 'openid profile offline_access https://management.azure.com/user_impersonation',
+          scope: 'https://management.azure.com/.default offline_access',
         },
       };
     case 'digitalocean':


### PR DESCRIPTION
## Problem
PR #73 broke sign-in for personal Microsoft accounts (e.g. Gmail-based). Requesting ARM scope in the initial auth URL caused Microsoft to reject personal accounts with: *'You can't sign in here with a personal account.'*

## Root Cause
Personal Microsoft accounts can't request `https://management.azure.com/user_impersonation` scope in the authorization URL when using `/common`. The OAuth endpoint routes them to an organizational login flow that rejects non-work accounts.

## Fix
1. **Use `/consumers` endpoint** instead of `/common` for the initial auth - this properly handles personal Microsoft accounts
2. **Two-step token exchange**: Get identity tokens first (identity-only scopes), then exchange the refresh token for ARM management tokens via the tenant-specific endpoint
3. **Fail clearly**: If ARM token exchange fails, redirect to onboarding with a visible error message instead of silently saving an unusable identity token
4. **Error UI**: Added error display in the onboarding wizard's Hosting step
5. **Azure app registration**: Added `Azure Service Management > user_impersonation` delegated permission (done manually in Azure portal - this was missing before!)

## What was wrong with the original code (pre-PR #73)
- The two-step approach was correct in theory
- BUT: the app registration was missing the `user_impersonation` permission
- AND: when Step 2 failed, it silently saved the identity token as if it were an ARM token

## Testing
1. Go to /onboarding
2. Click Connect Azure
3. Sign in with a personal Microsoft account (Gmail-based)
4. Should complete without 'can't sign in with personal account' error
5. If no Azure subscription, should show clear error on the Hosting step
6. If subscription exists, should proceed to Plan step