### PR TITLE
fix: use /organizations endpoint for ARM token exchange

### DIFF
--- a/apps/web/src/app/api/auth/azure/callback/route.ts
+++ b/apps/web/src/app/api/auth/azure/callback/route.ts
@@ -64,29 +64,46 @@ export async function GET(request: NextRequest) {
     return NextResponse.redirect(new URL('/onboarding?error=no_tenant', request.url));
   }
 
-  // Step 2: Use the refresh token to get an ARM management token
-  // We use the tenant-specific endpoint so the token is scoped to the user's Azure tenant.
-  // The app registration needs Azure Service Management > user_impersonation permission.
-  const armRes = await fetch(`https://login.microsoftonline.com/${tenantId}/oauth2/v2.0/token`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body: new URLSearchParams({
-      grant_type: 'refresh_token',
-      refresh_token: identityData.refresh_token,
-      client_id: clientId,
-      client_secret: clientSecret,
-      scope: 'https://management.azure.com/.default offline_access',
-    }),
-  });
+  // Step 2: Use the refresh token to get an ARM management token.
+  // For personal Microsoft accounts, the tid from /consumers is the consumer tenant
+  // (9188040d-...) which can't issue ARM tokens. We must use /organizations instead,
+  // which lets Microsoft route to the user's actual Azure AD tenant.
+  // If that fails, fall back to the specific tenant ID.
+  let armData: any = null;
 
-  if (!armRes.ok) {
-    const errorBody = await armRes.text().catch(() => 'no body');
-    console.error(`Azure ARM token request failed: ${armRes.status}`, errorBody);
-    // Don't silently continue - redirect with a clear error so the user knows
-    return NextResponse.redirect(new URL('/onboarding?error=azure_no_subscription', request.url));
+  // Try /organizations first - this works for personal accounts with Azure subscriptions
+  const armEndpoints = [
+    'https://login.microsoftonline.com/organizations/oauth2/v2.0/token',
+    `https://login.microsoftonline.com/${tenantId}/oauth2/v2.0/token`,
+  ];
+
+  for (const endpoint of armEndpoints) {
+    const armRes = await fetch(endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: 'refresh_token',
+        refresh_token: identityData.refresh_token,
+        client_id: clientId,
+        client_secret: clientSecret,
+        scope: 'https://management.azure.com/.default offline_access',
+      }),
+    });
+
+    if (armRes.ok) {
+      armData = await armRes.json();
+      console.log(`ARM token obtained via ${endpoint}`);
+      break;
+    } else {
+      const errorBody = await armRes.text().catch(() => 'no body');
+      console.warn(`ARM token request failed via ${endpoint}: ${armRes.status}`, errorBody);
+    }
   }
 
-  const armData = await armRes.json();
+  if (!armData) {
+    console.error('All ARM token endpoints failed');
+    return NextResponse.redirect(new URL('/onboarding?error=azure_no_subscription', request.url));
+  }
 
   // Get current user from session
   const session = await getSession();
@@ -107,11 +124,15 @@ export async function GET(request: NextRequest) {
     expiresAt,
   );
 
-  // Store the tenant ID for future token refreshes
+  // Store the tenant ID for future token refreshes.
+  // Use the tid from the ARM token (actual Azure AD tenant), not the consumer tenant.
+  const armTokenClaims = armData.access_token ? decodeJwt(armData.access_token) : {};
+  const azureTenantId = (armTokenClaims.tid as string) ?? tenantId;
+
   await saveProviderToken(
     session.userId,
     'azure_tenant',
-    tenantId,
+    azureTenantId,
     null,
     null,
   );

--- a/apps/web/src/lib/providers/token-store.ts
+++ b/apps/web/src/lib/providers/token-store.ts
@@ -84,7 +84,7 @@ export async function refreshProviderToken(userId: string, provider: string) {
 
   if (provider === 'azure') {
     const tenantData = await getProviderToken(userId, 'azure_tenant');
-    const tenantId = tenantData?.accessToken ?? 'common'; // accessToken field stores the tenant ID
+    const tenantId = tenantData?.accessToken ?? 'organizations'; // accessToken field stores the tenant ID
     refreshUrl = `https://login.microsoftonline.com/${tenantId}/oauth2/v2.0/token`;
     refreshBody = {
       grant_type: 'refresh_token',


### PR DESCRIPTION
## Problem
Personal Microsoft accounts with active Azure subscriptions still get 'Could not connect to Azure' error after signing in.

## Root Cause
The /consumers identity endpoint returns the consumer tenant ID (`9188040d-...`). When we tried to exchange the refresh token for ARM tokens via this consumer tenant, it failed because the consumer tenant has no Azure subscriptions. The actual subscription lives on the user's Azure AD tenant (`943cf1f9-...`).

## Fix
- Try `/organizations` endpoint first for ARM token exchange - this lets Microsoft route to the correct Azure AD tenant
- Fall back to tenant-specific endpoint if /organizations fails
- Extract the real Azure AD tenant ID from the ARM access token (not the consumer tenant)
- Store the correct tenant ID for future token refreshes
- Use `/organizations` as default fallback in token refresh