### PR TITLE
fix: use /common endpoint for Azure OAuth (not /consumers)

### DIFF
--- a/apps/web/src/app/api/auth/azure/callback/route.ts
+++ b/apps/web/src/app/api/auth/azure/callback/route.ts
@@ -32,9 +32,9 @@ export async function GET(request: NextRequest) {
   const clientSecret = process.env.AZURE_CLIENT_SECRET!.trim();
   const redirectUri = process.env.AZURE_REDIRECT_URI!.trim();
 
-  // Step 1: Exchange code for identity tokens via /consumers
-  // This gives us an id_token with the user's tenant ID and a refresh_token
-  const identityRes = await fetch('https://login.microsoftonline.com/consumers/oauth2/v2.0/token', {
+  // Step 1: Exchange code for identity tokens via /common
+  // Using /common (matching the authorize endpoint) is required.
+  const identityRes = await fetch('https://login.microsoftonline.com/common/oauth2/v2.0/token', {
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
     body: new URLSearchParams({

--- a/apps/web/src/app/api/auth/azure/route.ts
+++ b/apps/web/src/app/api/auth/azure/route.ts
@@ -12,11 +12,11 @@ export async function GET() {
   // Anti-CSRF state token
   const state = crypto.randomBytes(32).toString('hex');
 
-  // Use /consumers endpoint for personal Microsoft accounts.
-  // We request identity-only scopes here because personal accounts
-  // can't request ARM scope directly in the authorize URL.
-  // The callback will exchange the refresh token for ARM tokens
-  // via the user's tenant-specific endpoint.
+  // Use /common endpoint - this handles BOTH personal and work/school accounts.
+  // We only request identity scopes here. The callback will exchange the refresh
+  // token for ARM tokens. Using /common (not /consumers) is critical because
+  // /consumers issues refresh tokens that can only work in the consumer context,
+  // but /common issues tokens that can be exchanged across tenants.
   const params = new URLSearchParams({
     client_id: clientId,
     response_type: 'code',
@@ -27,7 +27,7 @@ export async function GET() {
   });
 
   const response = NextResponse.redirect(
-    `https://login.microsoftonline.com/consumers/oauth2/v2.0/authorize?${params.toString()}`,
+    `https://login.microsoftonline.com/common/oauth2/v2.0/authorize?${params.toString()}`,
   );
   response.cookies.set('azure_oauth_state', state, {
     httpOnly: true,


### PR DESCRIPTION
## Problem
ARM token exchange still fails even after PR #76 added /organizations fallback. The refresh token from /consumers can only work in the consumer tenant context.

## Root Cause  
Using `/consumers` for the initial auth request scopes the refresh token to the consumer tenant (`9188040d-...`). This refresh token cannot be exchanged for ARM tokens via `/organizations` or any other endpoint because it's locked to the consumer context.

## Fix
Switch from `/consumers` back to `/common` for both the authorize URL and the token exchange. `/common` handles personal accounts just fine AND issues refresh tokens that can cross tenant boundaries - which is exactly what we need for the ARM token exchange.

The earlier switch to `/consumers` (PR #74) was a mistake. The original PR #73 that used `/common` was correct in approach but failed because it also tried to include ARM scope in the authorize URL, which personal accounts reject.