### PR TITLE
feat: replace waitlist with sign-in CTAs and newsletter signup

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -78,10 +78,10 @@ export default function Home() {
             Sign In
           </a>
           <a
-            href="#get-started"
+            href="/auth/signin"
             className="rounded-full bg-violet-600 px-4 py-2 text-xs sm:text-sm font-medium text-white hover:bg-violet-500 transition"
           >
-            Get Started
+            Sign Up
           </a>
         </div>
       </nav>
@@ -105,7 +105,7 @@ export default function Home() {
         </p>
         <div className="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4">
           <a
-            href="#get-started"
+            href="/auth/signin"
             className="rounded-full bg-violet-600 px-8 py-3 text-lg font-medium hover:bg-violet-500 transition"
           >
             Launch My Assistant
@@ -275,7 +275,7 @@ export default function Home() {
               ))}
             </ul>
             <a
-              href="#get-started"
+              href="/auth/signin"
               className="mt-8 block w-full rounded-full py-2.5 text-sm font-medium text-center border border-slate-700 text-slate-300 hover:border-slate-500 hover:text-white transition"
             >
               Get Started Free
@@ -303,7 +303,7 @@ export default function Home() {
               ))}
             </ul>
             <a
-              href="#get-started"
+              href="/auth/signin"
               className="mt-8 block w-full rounded-full py-2.5 text-sm font-medium text-center bg-violet-600 hover:bg-violet-500 text-white transition"
             >
               Go Pro
@@ -320,16 +320,16 @@ export default function Home() {
       {/* FAQ */}
       <FAQ />
 
-      {/* CTA */}
-      <section id="get-started" className="mx-auto max-w-4xl px-6 py-24 text-center">
+      {/* Newsletter */}
+      <section id="updates" className="mx-auto max-w-4xl px-6 py-24 text-center">
         <h2 className="text-3xl font-bold sm:text-4xl mb-4">
-          Ready to meet your assistant?
+          Stay in the loop
         </h2>
         <p className="text-slate-400 max-w-xl mx-auto mb-8">
-          Join the waitlist and be first in line when we launch.
+          Get notified when we add new cloud providers, features, and integrations.
         </p>
         <WaitlistForm />
-        <p className="text-xs text-slate-600 mt-3">No spam. We&apos;ll email you once when it&apos;s ready.</p>
+        <p className="text-xs text-slate-600 mt-3">No spam. Just product updates when they matter.</p>
       </section>
 
       {/* Footer */}

--- a/apps/web/src/components/waitlist-form.tsx
+++ b/apps/web/src/components/waitlist-form.tsx
@@ -25,7 +25,7 @@ export function WaitlistForm() {
         setMessage(data.error || 'Something went wrong.');
       } else {
         setStatus('success');
-        setMessage(data.message);
+        setMessage(data.message || "You're on the list! We'll keep you posted.");
         setEmail('');
       }
     } catch {
@@ -58,7 +58,7 @@ export function WaitlistForm() {
           disabled={status === 'loading'}
           className="w-full sm:w-auto rounded-full bg-violet-600 px-8 py-3 font-medium hover:bg-violet-500 transition whitespace-nowrap disabled:opacity-50 disabled:cursor-not-allowed"
         >
-          {status === 'loading' ? 'Joining...' : 'Join Waitlist'}
+          {status === 'loading' ? 'Subscribing...' : 'Get Updates'}
         </button>
       </div>
       {status === 'error' && (


### PR DESCRIPTION
Updates the landing page per Julie's request:

- All 'Get Started' buttons now go to /auth/signin (direct signup flow)
- 'Launch My Assistant' hero button goes to /auth/signin
- Pricing buttons go to /auth/signin
- Bottom section: 'Join the waitlist' replaced with 'Stay in the loop' newsletter for product updates (new providers like AWS, features, integrations)
- Waitlist form repurposed as newsletter subscription ('Get Updates' instead of 'Join Waitlist')