### PR TITLE
fix: correct Ubuntu image reference for Azure VM provisioning

### DIFF
--- a/apps/web/src/lib/providers/azure.ts
+++ b/apps/web/src/lib/providers/azure.ts
@@ -7,8 +7,8 @@ const DEFAULT_REGION = 'westus2';
 const DEFAULT_VM_SIZE = 'Standard_B1s';
 const DEFAULT_IMAGE = {
   publisher: 'Canonical',
-  offer: '0001-com-ubuntu-server-noble',
-  sku: '24_04-lts',
+  offer: 'ubuntu-24_04-lts',
+  sku: 'server',
   version: 'latest',
 };
 const RG_NAME = 'shiftworker-rg';


### PR DESCRIPTION
The Ubuntu 24.04 image offer name was wrong. Changed from `0001-com-ubuntu-server-noble:24_04-lts` to `ubuntu-24_04-lts:server` which is available in westus2.