### PR TITLE
feat: show Destroy button for all assistant states

### DIFF
--- a/apps/web/src/app/dashboard/components/assistant-card.tsx
+++ b/apps/web/src/app/dashboard/components/assistant-card.tsx
@@ -123,7 +123,7 @@ export function AssistantCard({ assistant }: { assistant: Assistant | null }) {
           </button>
         )}
 
-        {current && status !== "offline" && !confirmDestroy && (
+        {current && !confirmDestroy && (
           <button
             onClick={() => setConfirmDestroy(true)}
             className="rounded-lg bg-red-900/50 px-4 py-2 text-sm text-red-300 hover:bg-red-900 disabled:opacity-50"
@@ -151,7 +151,7 @@ export function AssistantCard({ assistant }: { assistant: Assistant | null }) {
           </div>
         )}
 
-        {status === "offline" && (
+        {(!current || status === "offline") && !confirmDestroy && (
           <button
             disabled={!!loading}
             onClick={() => act("/api/assistant/launch")}


### PR DESCRIPTION
The Destroy button was hidden when assistant was in 'provisioning' state. Users couldn't clean up failed provisions. Now shows Destroy for any existing assistant record.