### PR TITLE
feat: async step-based Azure VM provisioning

### DIFF
--- a/apps/web/src/app/api/assistant/status/route.ts
+++ b/apps/web/src/app/api/assistant/status/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { getSession } from '@/lib/auth/session';
 import { createClient } from '@/lib/supabase/server';
+import { advanceProvisioning } from '@/lib/vm/provisioning-steps';
 
 export async function GET() {
   try {
@@ -21,6 +22,24 @@ export async function GET() {
 
     if (error || !assistant) {
       return NextResponse.json({ assistant: null });
+    }
+
+    // If the assistant is mid-provisioning on Azure, advance one step.
+    // Each step is a single API call that fits within the 10s timeout.
+    if (
+      assistant.status === 'provisioning' &&
+      assistant.provider === 'azure' &&
+      assistant.provisioning_step &&
+      assistant.provisioning_step !== 'done'
+    ) {
+      try {
+        const updated = await advanceProvisioning(assistant);
+        return NextResponse.json({ assistant: updated });
+      } catch (err) {
+        console.error('Provisioning step failed:', err);
+        // Return current state — next poll will retry
+        return NextResponse.json({ assistant });
+      }
     }
 
     return NextResponse.json({ assistant });

--- a/apps/web/src/app/api/cron/vm-scheduler/route.ts
+++ b/apps/web/src/app/api/cron/vm-scheduler/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 import { isInWindow, powerOnDroplet, powerOffDroplet } from '@/lib/vm/scheduler';
+import { advanceProvisioning } from '@/lib/vm/provisioning-steps';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -12,6 +13,36 @@ export async function GET(request: NextRequest) {
   }
 
   const supabase = createClient();
+
+  // ---- Advance any stuck Azure provisioning assistants ----
+  let provisioning_advanced = 0;
+  try {
+    const { data: provisioningAssistants } = await supabase
+      .from('assistants' as never)
+      .select('*')
+      .eq('status', 'provisioning')
+      .eq('provider', 'azure')
+      .not('provisioning_step', 'is', null) as unknown as {
+        data: Array<any> | null;
+      };
+
+    if (provisioningAssistants) {
+      for (const assistant of provisioningAssistants) {
+        if (assistant.provisioning_step && assistant.provisioning_step !== 'done') {
+          try {
+            await advanceProvisioning(assistant);
+            provisioning_advanced++;
+          } catch (err) {
+            console.error(`Failed to advance provisioning for ${assistant.id}:`, err);
+          }
+        }
+      }
+    }
+  } catch (err) {
+    console.error('Failed to process provisioning assistants:', err);
+  }
+
+  // ---- Existing window-based scheduling ----
 
   // Get all free users with a configured window who completed onboarding
   const { data: users, error: usersError } = await supabase
@@ -99,6 +130,7 @@ export async function GET(request: NextRequest) {
   return Response.json({
     message: 'VM scheduler complete',
     processed: users.length,
+    provisioning_advanced,
     powered_on,
     powered_off,
     skipped,

--- a/apps/web/src/lib/supabase/types.ts
+++ b/apps/web/src/lib/supabase/types.ts
@@ -11,6 +11,21 @@ export type AssistantStatus =
   | 'destroying'
   | 'destroyed';
 
+/**
+ * Steps for async Azure VM provisioning.
+ * Each step is a single Azure API call that completes within ~10 seconds.
+ */
+export type ProvisioningStep =
+  | 'validate'
+  | 'create_rg'
+  | 'create_nsg'
+  | 'create_vnet'
+  | 'create_ip'
+  | 'create_nic'
+  | 'create_vm'
+  | 'wait_vm'
+  | 'done';
+
 export type SubscriptionStatus = 'active' | 'past_due' | 'cancelled' | 'trialing';
 
 export interface User {
@@ -37,6 +52,8 @@ export interface Assistant {
   status: AssistantStatus;
   ip_address: string | null;
   sidecar_token: string | null;
+  provisioning_step: ProvisioningStep | null;
+  provisioning_data: Record<string, unknown> | null;
   created_at: string;
   updated_at: string;
   telegram_bot_username: string | null;

--- a/apps/web/src/lib/vm/lifecycle.ts
+++ b/apps/web/src/lib/vm/lifecycle.ts
@@ -4,7 +4,7 @@ import { createVM, destroyVM, powerOnVM, powerOffVM, validateAccount as validate
 import { OracleProvider } from '../providers/oracle';
 import { getProviderToken, refreshProviderToken } from '../providers/token-store';
 import { generateCloudInit } from '../providers/cloud-init';
-import type { Assistant, AssistantStatus } from '../supabase/types';
+import type { Assistant, AssistantStatus, ProvisioningStep } from '../supabase/types';
 import { randomUUID } from 'crypto';
 
 const RG_NAME = 'shiftworker-rg';
@@ -164,26 +164,18 @@ export async function launchAssistant(userId: string): Promise<Assistant> {
         region: server.region,
       });
     } else if (provider === 'azure') {
-      const token = await getUserProviderToken(userId, 'azure');
-      const validation = await validateAzureAccount(token);
-      if (!validation.ok || !validation.subscriptionId) {
-        throw new Error(validation.error ?? 'No active Azure subscription found');
-      }
-      const subscriptionId = validation.subscriptionId;
-      const resourceGroup = await ensureResourceGroup(token, subscriptionId);
-      const networking = await ensureNetworking(token, subscriptionId, resourceGroup);
-      const vm = await createVM(token, {
-        subscriptionId,
-        resourceGroup,
-        name: `claw-${assistantId.slice(0, 8)}`,
-        cloudInit,
-        vmSize: vmSize ?? 'Standard_B1s',
-      });
-
+      // Azure provisioning is done step-by-step to stay within Vercel's
+      // 10-second function timeout.  We just record the first step here
+      // and return immediately — subsequent calls to advanceProvisioning()
+      // (triggered by the status-polling endpoint) will walk through the
+      // remaining steps.
       return await updateAssistantStatus(assistantId, 'provisioning', {
-        vm_id: vm.id,
-        ip_address: vm.publicIpv4,
-        region: vm.region,
+        provisioning_step: 'validate' as ProvisioningStep,
+        provisioning_data: {
+          vmName: `claw-${assistantId.slice(0, 8)}`,
+          vmSize: vmSize ?? 'Standard_B1s',
+          cloudInit,
+        } as any,
       });
     } else {
       // DigitalOcean flow — requires user OAuth tokens

--- a/apps/web/src/lib/vm/provisioning-steps.ts
+++ b/apps/web/src/lib/vm/provisioning-steps.ts
@@ -1,0 +1,431 @@
+/**
+ * Step-based Azure VM provisioning.
+ *
+ * Each step performs a single Azure API call (PUT or GET) that completes
+ * well within Vercel's 10-second function timeout.  The provisioning state
+ * is persisted in the assistant record so any invocation can pick up where
+ * the previous one left off.
+ *
+ * Steps:
+ *   validate → create_rg → create_nsg → create_vnet → create_ip → create_nic → create_vm → wait_vm → done
+ */
+
+import { createClient } from '../supabase/server';
+import {
+  validateAccount as validateAzureAccount,
+} from '../providers/azure';
+import { getProviderToken, refreshProviderToken } from '../providers/token-store';
+import type { Assistant, ProvisioningStep } from '../supabase/types';
+
+// Re-use constants from azure.ts
+const ARM_BASE = 'https://management.azure.com';
+const COMPUTE_API = '2024-07-01';
+const NETWORK_API = '2024-05-01';
+const RESOURCE_API = '2024-07-01';
+
+const DEFAULT_REGION = 'westus2';
+const RG_NAME = 'shiftworker-rg';
+const VNET_NAME = 'shiftworker-vnet';
+const SUBNET_NAME = 'default';
+const NSG_NAME = 'shiftworker-nsg';
+
+const DEFAULT_IMAGE = {
+  publisher: 'Canonical',
+  offer: 'ubuntu-24_04-lts',
+  sku: 'server',
+  version: 'latest',
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function azureFetch(token: string, path: string, init: RequestInit = {}) {
+  const url = path.startsWith('http') ? path : `${ARM_BASE}${path}`;
+  const res = await fetch(url, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      ...init.headers,
+    },
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    throw new Error(`Azure API error ${res.status}: ${body}`);
+  }
+  if (res.status === 204) return null;
+  const text = await res.text();
+  return text ? JSON.parse(text) : null;
+}
+
+/** Check if a resource is provisioned. Returns 'Succeeded' | 'Failed' | 'InProgress' | null */
+async function checkProvisioningState(
+  token: string,
+  path: string,
+): Promise<string | null> {
+  try {
+    const data = await azureFetch(token, path);
+    return data?.properties?.provisioningState ?? null;
+  } catch {
+    return null;
+  }
+}
+
+async function getUserToken(userId: string): Promise<string> {
+  const tokenData = await getProviderToken(userId, 'azure');
+  if (!tokenData) throw new Error('Azure account not connected');
+  if (tokenData.expiresAt && tokenData.expiresAt.getTime() < Date.now() + 5 * 60 * 1000) {
+    return await refreshProviderToken(userId, 'azure');
+  }
+  return tokenData.accessToken;
+}
+
+async function updateAssistant(
+  assistantId: string,
+  updates: Partial<Assistant>,
+): Promise<Assistant> {
+  const supabase: any = createClient();
+  const { data, error } = await supabase
+    .from('assistants')
+    .update({ ...updates, updated_at: new Date().toISOString() })
+    .eq('id', assistantId)
+    .select()
+    .single();
+  if (error) throw new Error(`DB update failed: ${error.message}`);
+  return data as Assistant;
+}
+
+// ---------------------------------------------------------------------------
+// Main entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Advance an assistant's Azure provisioning by one step.
+ * Returns the updated assistant record.
+ * Safe to call repeatedly — idempotent per step.
+ */
+export async function advanceProvisioning(assistant: Assistant): Promise<Assistant> {
+  const step = assistant.provisioning_step as ProvisioningStep;
+  const pd = (assistant.provisioning_data ?? {}) as Record<string, any>;
+
+  if (!step || step === 'done') return assistant;
+
+  const token = await getUserToken(assistant.user_id);
+
+  switch (step) {
+    case 'validate': {
+      const validation = await validateAzureAccount(token);
+      if (!validation.ok || !validation.subscriptionId) {
+        // Mark as failed
+        return await updateAssistant(assistant.id, {
+          status: 'destroyed',
+          provisioning_step: null,
+          provisioning_data: null,
+        });
+      }
+      return await updateAssistant(assistant.id, {
+        provisioning_step: 'create_rg' as ProvisioningStep,
+        provisioning_data: {
+          ...pd,
+          subscriptionId: validation.subscriptionId,
+        } as any,
+      });
+    }
+
+    case 'create_rg': {
+      const { subscriptionId } = pd;
+      const path = `/subscriptions/${subscriptionId}/resourceGroups/${RG_NAME}?api-version=${RESOURCE_API}`;
+      await azureFetch(token, path, {
+        method: 'PUT',
+        body: JSON.stringify({ location: DEFAULT_REGION }),
+      });
+      return await updateAssistant(assistant.id, {
+        provisioning_step: 'create_nsg' as ProvisioningStep,
+      });
+    }
+
+    case 'create_nsg': {
+      const { subscriptionId } = pd;
+      const base = `/subscriptions/${subscriptionId}/resourceGroups/${RG_NAME}/providers`;
+      const nsgPath = `${base}/Microsoft.Network/networkSecurityGroups/${NSG_NAME}?api-version=${NETWORK_API}`;
+
+      // Check if already provisioned from a previous attempt
+      const state = await checkProvisioningState(token, nsgPath);
+      if (state === 'Succeeded') {
+        return await updateAssistant(assistant.id, {
+          provisioning_step: 'create_vnet' as ProvisioningStep,
+        });
+      }
+
+      await azureFetch(token, nsgPath, {
+        method: 'PUT',
+        body: JSON.stringify({
+          location: DEFAULT_REGION,
+          properties: {
+            securityRules: [
+              {
+                name: 'AllowSSH',
+                properties: {
+                  priority: 1000, protocol: 'Tcp', access: 'Allow', direction: 'Inbound',
+                  sourceAddressPrefix: '*', sourcePortRange: '*',
+                  destinationAddressPrefix: '*', destinationPortRange: '22',
+                },
+              },
+              {
+                name: 'AllowHTTPS',
+                properties: {
+                  priority: 1010, protocol: 'Tcp', access: 'Allow', direction: 'Inbound',
+                  sourceAddressPrefix: '*', sourcePortRange: '*',
+                  destinationAddressPrefix: '*', destinationPortRange: '443',
+                },
+              },
+              {
+                name: 'AllowGateway',
+                properties: {
+                  priority: 1020, protocol: 'Tcp', access: 'Allow', direction: 'Inbound',
+                  sourceAddressPrefix: '*', sourcePortRange: '*',
+                  destinationAddressPrefix: '*', destinationPortRange: '3000',
+                },
+              },
+            ],
+          },
+        }),
+      });
+
+      // NSG PUT usually returns synchronously or near-instantly, but check
+      const postState = await checkProvisioningState(token, nsgPath);
+      if (postState === 'Succeeded') {
+        return await updateAssistant(assistant.id, {
+          provisioning_step: 'create_vnet' as ProvisioningStep,
+        });
+      }
+      // Still creating — stay on this step, next poll will check again
+      return assistant;
+    }
+
+    case 'create_vnet': {
+      const { subscriptionId } = pd;
+      const base = `/subscriptions/${subscriptionId}/resourceGroups/${RG_NAME}/providers`;
+      const nsgId = `/subscriptions/${subscriptionId}/resourceGroups/${RG_NAME}/providers/Microsoft.Network/networkSecurityGroups/${NSG_NAME}`;
+      const vnetPath = `${base}/Microsoft.Network/virtualNetworks/${VNET_NAME}?api-version=${NETWORK_API}`;
+
+      const state = await checkProvisioningState(token, vnetPath);
+      if (state === 'Succeeded') {
+        return await updateAssistant(assistant.id, {
+          provisioning_step: 'create_ip' as ProvisioningStep,
+        });
+      }
+
+      await azureFetch(token, vnetPath, {
+        method: 'PUT',
+        body: JSON.stringify({
+          location: DEFAULT_REGION,
+          properties: {
+            addressSpace: { addressPrefixes: ['10.0.0.0/16'] },
+            subnets: [{
+              name: SUBNET_NAME,
+              properties: {
+                addressPrefix: '10.0.0.0/24',
+                networkSecurityGroup: { id: nsgId },
+              },
+            }],
+          },
+        }),
+      });
+
+      const postState = await checkProvisioningState(token, vnetPath);
+      if (postState === 'Succeeded') {
+        return await updateAssistant(assistant.id, {
+          provisioning_step: 'create_ip' as ProvisioningStep,
+        });
+      }
+      return assistant;
+    }
+
+    case 'create_ip': {
+      const { subscriptionId, vmName } = pd;
+      const base = `/subscriptions/${subscriptionId}/resourceGroups/${RG_NAME}/providers`;
+      const ipPath = `${base}/Microsoft.Network/publicIPAddresses/${vmName}-ip?api-version=${NETWORK_API}`;
+
+      const state = await checkProvisioningState(token, ipPath);
+      if (state === 'Succeeded') {
+        return await updateAssistant(assistant.id, {
+          provisioning_step: 'create_nic' as ProvisioningStep,
+        });
+      }
+
+      await azureFetch(token, ipPath, {
+        method: 'PUT',
+        body: JSON.stringify({
+          location: DEFAULT_REGION,
+          properties: { publicIPAllocationMethod: 'Static' },
+          sku: { name: 'Standard' },
+        }),
+      });
+
+      const postState = await checkProvisioningState(token, ipPath);
+      if (postState === 'Succeeded') {
+        return await updateAssistant(assistant.id, {
+          provisioning_step: 'create_nic' as ProvisioningStep,
+        });
+      }
+      return assistant;
+    }
+
+    case 'create_nic': {
+      const { subscriptionId, vmName } = pd;
+      const base = `/subscriptions/${subscriptionId}/resourceGroups/${RG_NAME}/providers`;
+      const subnetId = `/subscriptions/${subscriptionId}/resourceGroups/${RG_NAME}/providers/Microsoft.Network/virtualNetworks/${VNET_NAME}/subnets/${SUBNET_NAME}`;
+      const nsgId = `/subscriptions/${subscriptionId}/resourceGroups/${RG_NAME}/providers/Microsoft.Network/networkSecurityGroups/${NSG_NAME}`;
+      const ipId = `/subscriptions/${subscriptionId}/resourceGroups/${RG_NAME}/providers/Microsoft.Network/publicIPAddresses/${vmName}-ip`;
+      const nicPath = `${base}/Microsoft.Network/networkInterfaces/${vmName}-nic?api-version=${NETWORK_API}`;
+
+      const state = await checkProvisioningState(token, nicPath);
+      if (state === 'Succeeded') {
+        return await updateAssistant(assistant.id, {
+          provisioning_step: 'create_vm' as ProvisioningStep,
+        });
+      }
+
+      await azureFetch(token, nicPath, {
+        method: 'PUT',
+        body: JSON.stringify({
+          location: DEFAULT_REGION,
+          properties: {
+            ipConfigurations: [{
+              name: 'primary',
+              properties: {
+                subnet: { id: subnetId },
+                publicIPAddress: { id: ipId },
+                primary: true,
+              },
+            }],
+            networkSecurityGroup: { id: nsgId },
+          },
+        }),
+      });
+
+      const postState = await checkProvisioningState(token, nicPath);
+      if (postState === 'Succeeded') {
+        return await updateAssistant(assistant.id, {
+          provisioning_step: 'create_vm' as ProvisioningStep,
+        });
+      }
+      return assistant;
+    }
+
+    case 'create_vm': {
+      const { subscriptionId, vmName, vmSize, cloudInit } = pd;
+      const base = `/subscriptions/${subscriptionId}/resourceGroups/${RG_NAME}/providers`;
+      const nicId = `/subscriptions/${subscriptionId}/resourceGroups/${RG_NAME}/providers/Microsoft.Network/networkInterfaces/${vmName}-nic`;
+      const vmPath = `${base}/Microsoft.Compute/virtualMachines/${vmName}?api-version=${COMPUTE_API}`;
+
+      // Check if already exists
+      const state = await checkProvisioningState(token, vmPath);
+      if (state === 'Succeeded') {
+        return await updateAssistant(assistant.id, {
+          provisioning_step: 'wait_vm' as ProvisioningStep,
+        });
+      }
+
+      // Generate SSH key
+      const crypto = await import('crypto');
+      const { publicKey } = crypto.generateKeyPairSync('rsa', {
+        modulusLength: 2048,
+        publicKeyEncoding: { type: 'pkcs1', format: 'pem' },
+        privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+      });
+      const pubKeyBase64 = publicKey
+        .replace('-----BEGIN RSA PUBLIC KEY-----', '')
+        .replace('-----END RSA PUBLIC KEY-----', '')
+        .replace(/\n/g, '');
+      const sshPublicKey = `ssh-rsa ${pubKeyBase64} shiftworker@azure`;
+
+      const vmBody = {
+        location: DEFAULT_REGION,
+        properties: {
+          hardwareProfile: { vmSize: vmSize ?? 'Standard_B1s' },
+          storageProfile: {
+            imageReference: DEFAULT_IMAGE,
+            osDisk: {
+              createOption: 'FromImage',
+              managedDisk: { storageAccountType: 'Standard_LRS' },
+            },
+          },
+          osProfile: {
+            computerName: vmName,
+            adminUsername: 'azureuser',
+            linuxConfiguration: {
+              disablePasswordAuthentication: true,
+              ssh: {
+                publicKeys: [{
+                  path: '/home/azureuser/.ssh/authorized_keys',
+                  keyData: sshPublicKey,
+                }],
+              },
+            },
+            ...(cloudInit ? { customData: Buffer.from(cloudInit).toString('base64') } : {}),
+          },
+          networkProfile: {
+            networkInterfaces: [{ id: nicId, properties: { primary: true } }],
+          },
+        },
+      };
+
+      await azureFetch(token, vmPath, {
+        method: 'PUT',
+        body: JSON.stringify(vmBody),
+      });
+
+      return await updateAssistant(assistant.id, {
+        provisioning_step: 'wait_vm' as ProvisioningStep,
+      });
+    }
+
+    case 'wait_vm': {
+      const { subscriptionId, vmName } = pd;
+      const base = `/subscriptions/${subscriptionId}/resourceGroups/${RG_NAME}/providers`;
+      const vmPath = `${base}/Microsoft.Compute/virtualMachines/${vmName}?api-version=${COMPUTE_API}`;
+
+      const state = await checkProvisioningState(token, vmPath);
+      if (state === 'Failed') {
+        return await updateAssistant(assistant.id, {
+          status: 'destroyed',
+          provisioning_step: null,
+          provisioning_data: null,
+        });
+      }
+      if (state !== 'Succeeded') {
+        // Still provisioning — wait for next poll
+        return assistant;
+      }
+
+      // VM is ready — get its info
+      const vmData = await azureFetch(token, vmPath);
+      const vmId = vmData?.id as string;
+
+      // Get public IP
+      let publicIpv4: string | null = null;
+      try {
+        const ipData = await azureFetch(
+          token,
+          `${base}/Microsoft.Network/publicIPAddresses/${vmName}-ip?api-version=${NETWORK_API}`,
+        );
+        publicIpv4 = ipData?.properties?.ipAddress ?? null;
+      } catch { /* ok */ }
+
+      return await updateAssistant(assistant.id, {
+        status: 'provisioning', // still provisioning until sidecar checks in
+        provisioning_step: 'done' as ProvisioningStep,
+        provisioning_data: null,
+        vm_id: vmId,
+        ip_address: publicIpv4,
+        region: DEFAULT_REGION,
+      });
+    }
+
+    default:
+      return assistant;
+  }
+}

--- a/supabase/migrations/20260326_add_provisioning_steps.sql
+++ b/supabase/migrations/20260326_add_provisioning_steps.sql
@@ -1,0 +1,9 @@
+-- Add step-based provisioning columns to assistants table
+-- These track progress through async Azure VM provisioning steps
+
+ALTER TABLE assistants
+  ADD COLUMN IF NOT EXISTS provisioning_step text DEFAULT NULL,
+  ADD COLUMN IF NOT EXISTS provisioning_data jsonb DEFAULT NULL;
+
+COMMENT ON COLUMN assistants.provisioning_step IS 'Current step in async provisioning: validate, create_rg, create_nsg, create_vnet, create_ip, create_nic, create_vm, wait_vm, done';
+COMMENT ON COLUMN assistants.provisioning_data IS 'Ephemeral JSON blob holding state between provisioning steps (subscriptionId, vmName, etc.)';


### PR DESCRIPTION
## Problem
Azure VM provisioning takes 2-5 minutes with sequential resource creation (RG → NSG → VNet → IP → NIC → VM), but Vercel Hobby plan has a 10-second function timeout. The launch endpoint gets killed mid-provisioning.

## Solution
Split Azure provisioning into discrete steps, each completing a single Azure API call within ~5 seconds:

```
validate → create_rg → create_nsg → create_vnet → create_ip → create_nic → create_vm → wait_vm → done
```

### How it works
1. **POST /api/assistant/launch** — creates the assistant record with `provisioning_step='validate'` and returns immediately
2. **GET /api/assistant/status** — the dashboard already polls this endpoint; it now advances one provisioning step per poll when it detects a provisioning Azure assistant
3. **Cron fallback** — the vm-scheduler cron also advances stuck provisioning assistants

### Changes
- `apps/web/src/lib/vm/lifecycle.ts` — Azure branch returns immediately instead of awaiting the full chain
- `apps/web/src/lib/vm/provisioning-steps.ts` — New file with `advanceProvisioning()` step machine
- `apps/web/src/app/api/assistant/status/route.ts` — Triggers step advancement during status polls
- `apps/web/src/app/api/cron/vm-scheduler/route.ts` — Fallback advancement for stuck assistants
- `apps/web/src/lib/supabase/types.ts` — Added `ProvisioningStep` type and new assistant columns
- `supabase/migrations/20260326_add_provisioning_steps.sql` — DB migration

### DB migration required
Run the migration to add `provisioning_step` and `provisioning_data` columns to the assistants table.

Oracle and DigitalOcean providers are unchanged.