### PR TITLE
fix: use Gen1 Ubuntu image for B1s VMs + provisioning error logging

### DIFF
--- a/apps/web/src/app/api/assistant/status/route.ts
+++ b/apps/web/src/app/api/assistant/status/route.ts
@@ -36,9 +36,23 @@ export async function GET() {
         const updated = await advanceProvisioning(assistant);
         return NextResponse.json({ assistant: updated });
       } catch (err) {
-        console.error('Provisioning step failed:', err);
-        // Return current state — next poll will retry
-        return NextResponse.json({ assistant });
+        const errMsg = err instanceof Error ? err.message : String(err);
+        console.error('Provisioning step failed:', errMsg);
+        // Store error in provisioning_data for debugging
+        try {
+          const supabaseUpdate: any = createClient();
+          const existingData = assistant.provisioning_data || {};
+          await supabaseUpdate
+            .from('assistants')
+            .update({
+              provisioning_data: { ...existingData, lastError: errMsg, lastErrorAt: new Date().toISOString() },
+            })
+            .eq('id', assistant.id);
+        } catch { /* best effort */ }
+        // Return current state with error info
+        return NextResponse.json({
+          assistant: { ...assistant, _provisioningError: errMsg },
+        });
       }
     }
 

--- a/apps/web/src/lib/providers/azure.ts
+++ b/apps/web/src/lib/providers/azure.ts
@@ -8,7 +8,7 @@ const DEFAULT_VM_SIZE = 'Standard_B1s';
 const DEFAULT_IMAGE = {
   publisher: 'Canonical',
   offer: 'ubuntu-24_04-lts',
-  sku: 'server',
+  sku: 'server-gen1',
   version: 'latest',
 };
 const RG_NAME = 'shiftworker-rg';

--- a/apps/web/src/lib/vm/provisioning-steps.ts
+++ b/apps/web/src/lib/vm/provisioning-steps.ts
@@ -32,7 +32,7 @@ const NSG_NAME = 'shiftworker-nsg';
 const DEFAULT_IMAGE = {
   publisher: 'Canonical',
   offer: 'ubuntu-24_04-lts',
-  sku: 'server',
+  sku: 'server-gen1',
   version: 'latest',
 };
 


### PR DESCRIPTION
B1s is Gen1 only, can't use Gen2 'server' image. Switched to 'server-gen1'. Also stores provisioning errors in DB for debugging.