### PR TITLE
fix: switch default Azure region to eastus (B1s unavailable in westus2)

### DIFF
--- a/apps/web/src/lib/providers/azure.ts
+++ b/apps/web/src/lib/providers/azure.ts
@@ -3,7 +3,7 @@ const COMPUTE_API = '2024-07-01';
 const NETWORK_API = '2024-05-01';
 const RESOURCE_API = '2024-07-01';
 
-const DEFAULT_REGION = 'westus2';
+const DEFAULT_REGION = 'eastus';
 const DEFAULT_VM_SIZE = 'Standard_B1s';
 const DEFAULT_IMAGE = {
   publisher: 'Canonical',

--- a/apps/web/src/lib/vm/provisioning-steps.ts
+++ b/apps/web/src/lib/vm/provisioning-steps.ts
@@ -23,7 +23,7 @@ const COMPUTE_API = '2024-07-01';
 const NETWORK_API = '2024-05-01';
 const RESOURCE_API = '2024-07-01';
 
-const DEFAULT_REGION = 'westus2';
+const DEFAULT_REGION = 'eastus';
 const RG_NAME = 'shiftworker-rg';
 const VNET_NAME = 'shiftworker-vnet';
 const SUBNET_NAME = 'default';


### PR DESCRIPTION
SkuNotAvailable error: Standard_B1s not available in westus2. Switching to eastus which has more capacity.