### PR TITLE
fix: use Standard_B2s VM size (B1s unavailable everywhere)

### DIFF
--- a/apps/web/src/lib/providers/azure.ts
+++ b/apps/web/src/lib/providers/azure.ts
@@ -4,11 +4,11 @@ const NETWORK_API = '2024-05-01';
 const RESOURCE_API = '2024-07-01';
 
 const DEFAULT_REGION = 'eastus';
-const DEFAULT_VM_SIZE = 'Standard_B1s';
+const DEFAULT_VM_SIZE = 'Standard_B2s';
 const DEFAULT_IMAGE = {
   publisher: 'Canonical',
   offer: 'ubuntu-24_04-lts',
-  sku: 'server-gen1',
+  sku: 'server',
   version: 'latest',
 };
 const RG_NAME = 'shiftworker-rg';

--- a/apps/web/src/lib/vm/provisioning-steps.ts
+++ b/apps/web/src/lib/vm/provisioning-steps.ts
@@ -32,7 +32,7 @@ const NSG_NAME = 'shiftworker-nsg';
 const DEFAULT_IMAGE = {
   publisher: 'Canonical',
   offer: 'ubuntu-24_04-lts',
-  sku: 'server-gen1',
+  sku: 'server',
   version: 'latest',
 };
 
@@ -360,7 +360,7 @@ export async function advanceProvisioning(assistant: Assistant): Promise<Assista
       const vmBody = {
         location: pd.region ?? DEFAULT_REGION,
         properties: {
-          hardwareProfile: { vmSize: vmSize ?? 'Standard_B1s' },
+          hardwareProfile: { vmSize: vmSize ?? 'Standard_B2s' },
           storageProfile: {
             imageReference: DEFAULT_IMAGE,
             osDisk: {


### PR DESCRIPTION
B1s has SkuNotAvailable in both westus2 and eastus. It's being retired. Switched to B2s which is available. Also restored Gen2 image since B2s supports it.