### PR TITLE
fix: update fallback VM size in lifecycle.ts

### DIFF
--- a/apps/web/src/lib/vm/lifecycle.ts
+++ b/apps/web/src/lib/vm/lifecycle.ts
@@ -173,7 +173,7 @@ export async function launchAssistant(userId: string): Promise<Assistant> {
         provisioning_step: 'validate' as ProvisioningStep,
         provisioning_data: {
           vmName: `claw-${assistantId.slice(0, 8)}`,
-          vmSize: vmSize ?? 'Standard_B1s',
+          vmSize: vmSize ?? 'Standard_B2s',
           cloudInit,
         } as any,
       });


### PR DESCRIPTION
lifecycle.ts had a hardcoded 'Standard_B1s' fallback separate from DEFAULT_VM_SIZE.