### PR TITLE
fix: use DS1_v2 VM size (B-series fully constrained)

### DIFF
--- a/apps/web/src/lib/providers/azure.ts
+++ b/apps/web/src/lib/providers/azure.ts
@@ -4,7 +4,7 @@ const NETWORK_API = '2024-05-01';
 const RESOURCE_API = '2024-07-01';
 
 const DEFAULT_REGION = 'eastus';
-const DEFAULT_VM_SIZE = 'Standard_B2s';
+const DEFAULT_VM_SIZE = 'Standard_DS1_v2';
 const DEFAULT_IMAGE = {
   publisher: 'Canonical',
   offer: 'ubuntu-24_04-lts',

--- a/apps/web/src/lib/vm/lifecycle.ts
+++ b/apps/web/src/lib/vm/lifecycle.ts
@@ -173,7 +173,7 @@ export async function launchAssistant(userId: string): Promise<Assistant> {
         provisioning_step: 'validate' as ProvisioningStep,
         provisioning_data: {
           vmName: `claw-${assistantId.slice(0, 8)}`,
-          vmSize: vmSize ?? 'Standard_B2s',
+          vmSize: vmSize ?? 'Standard_DS1_v2',
           cloudInit,
         } as any,
       });

--- a/apps/web/src/lib/vm/provisioning-steps.ts
+++ b/apps/web/src/lib/vm/provisioning-steps.ts
@@ -360,7 +360,7 @@ export async function advanceProvisioning(assistant: Assistant): Promise<Assista
       const vmBody = {
         location: pd.region ?? DEFAULT_REGION,
         properties: {
-          hardwareProfile: { vmSize: vmSize ?? 'Standard_B2s' },
+          hardwareProfile: { vmSize: vmSize ?? 'Standard_DS1_v2' },
           storageProfile: {
             imageReference: DEFAULT_IMAGE,
             osDisk: {


### PR DESCRIPTION
Both B1s and B2s are SkuNotAvailable in eastus and westus2. Switching to DS1_v2 to prove provisioning works.