### PR TITLE
fix: improve mobile readability - PRO badges and subscription picker

### DIFF
--- a/apps/web/src/app/onboarding/wizard.tsx
+++ b/apps/web/src/app/onboarding/wizard.tsx
@@ -441,7 +441,7 @@ export default function OnboardingWizard() {
         >
           {/* Pro badge */}
           {skill.pro && (
-            <div className="absolute top-2.5 right-2.5 flex items-center gap-1 bg-amber-500/20 text-amber-400 text-[10px] font-bold px-2 py-0.5 rounded-full">
+            <div className="absolute top-2.5 right-2.5 flex items-center gap-1 bg-amber-500/30 text-amber-300 text-[10px] font-bold px-2 py-0.5 rounded-full border border-amber-500/40">
               <Lock className="w-2.5 h-2.5" />
               PRO
             </div>
@@ -860,19 +860,21 @@ export default function OnboardingWizard() {
                       disabled={!isEnabled}
                       onClick={isEnabled ? () => setSelectedSubId(sub.id) : undefined}
                     >
-                      <div className="flex items-center gap-3">
-                        <Server className="w-7 h-7 text-blue-400 flex-shrink-0" />
+                      <div className="flex items-start gap-3">
+                        <Server className="w-7 h-7 text-blue-400 flex-shrink-0 mt-0.5" />
                         <div className="min-w-0 flex-1">
-                          <div className="font-semibold truncate">{sub.displayName}</div>
-                          <div className="text-xs text-slate-500 font-mono truncate">{sub.id}</div>
+                          <div className="flex items-center gap-2 flex-wrap">
+                            <span className="font-semibold">{sub.displayName}</span>
+                            <span className={`text-[10px] font-bold uppercase tracking-wider px-2 py-0.5 rounded-full ${
+                              isEnabled
+                                ? 'bg-green-500/20 text-green-400'
+                                : 'bg-slate-700 text-slate-400'
+                            }`}>
+                              {sub.state}
+                            </span>
+                          </div>
+                          <div className="text-xs text-slate-500 font-mono truncate mt-0.5">{sub.id}</div>
                         </div>
-                        <span className={`text-[10px] font-bold uppercase tracking-wider px-2 py-0.5 rounded-full flex-shrink-0 ${
-                          isEnabled
-                            ? 'bg-green-500/20 text-green-400'
-                            : 'bg-slate-700 text-slate-400'
-                        }`}>
-                          {sub.state}
-                        </span>
                       </div>
                     </Card>
                   );


### PR DESCRIPTION
Fixes two mobile UX issues Julie reported:

**PRO Badge Readability:**
- Increased background opacity from 20% to 30%
- Brighter text color (amber-300 vs amber-400)
- Added subtle border (amber-500/40) for contrast on dark cards

**Subscription Picker:**
- Moved ENABLED/state badge inline with subscription name using flex-wrap
- Badge no longer gets clipped on narrow screens
- Subscription ID on its own line below for clean truncation

Screenshots from Julie's iPhone showed the PRO badges were hard to read against the dark card backgrounds, and the ENABLED badge was getting cut off on the right edge of the subscription card.