### PR TITLE
fix: messaging setup/status routes return 401 (wrong auth method)

### DIFF
--- a/apps/web/src/app/api/messaging/setup/route.ts
+++ b/apps/web/src/app/api/messaging/setup/route.ts
@@ -1,4 +1,5 @@
 import { createClient } from '@/lib/supabase/server';
+import { getSession } from '@/lib/auth/session';
 import {
   setupTelegramForAssistant,
   setupWhatsAppForAssistant,
@@ -7,12 +8,8 @@ import { NextResponse } from 'next/server';
 
 export async function POST(request: Request) {
   try {
-    const supabase = await createClient();
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-
-    if (!user) {
+    const session = await getSession();
+    if (!session) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
@@ -31,14 +28,14 @@ export async function POST(request: Request) {
     }
 
     // Find the assistant — use provided ID or get the user's active one
+    const supabase: any = createClient();
     let targetAssistantId = assistantId;
     if (!targetAssistantId) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const { data: assistant } = await (supabase as any)
+      const { data: assistant } = await supabase
         .from('assistants')
         .select('id')
-        .eq('user_id', user.id)
-        .in('status', ['running', 'provisioning'])
+        .eq('user_id', session.userId)
+        .in('status', ['active', 'running', 'provisioning'])
         .order('created_at', { ascending: false })
         .limit(1)
         .single();
@@ -57,7 +54,7 @@ export async function POST(request: Request) {
       case 'telegram':
         result = await setupTelegramForAssistant(
           targetAssistantId!,
-          user.id,
+          session.userId,
           displayName,
         );
         break;

--- a/apps/web/src/app/api/messaging/status/route.ts
+++ b/apps/web/src/app/api/messaging/status/route.ts
@@ -1,28 +1,25 @@
 import { createClient } from '@/lib/supabase/server';
+import { getSession } from '@/lib/auth/session';
 import { NextResponse } from 'next/server';
 
 const SIDECAR_PORT = 8787;
 
 export async function GET() {
   try {
-    const supabase = await createClient();
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-
-    if (!user) {
+    const session = await getSession();
+    if (!session) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
     // Get the user's active assistant
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const { data: assistant } = await (supabase as any)
+    const supabase: any = createClient();
+    const { data: assistant } = await supabase
       .from('assistants')
       .select(
         'id, ip_address, sidecar_token, telegram_bot_username, telegram_bot_token, whatsapp_connected',
       )
-      .eq('user_id', user.id)
-      .in('status', ['running', 'provisioning'])
+      .eq('user_id', session.userId)
+      .in('status', ['active', 'running', 'provisioning'])
       .order('created_at', { ascending: false })
       .limit(1)
       .single();


### PR DESCRIPTION
**Bug:** WhatsApp and Telegram setup fails with HTTP 401 on the dashboard and onboarding wizard.

**Root cause:** Both `/api/messaging/setup` and `/api/messaging/status` were calling `supabase.auth.getUser()`, which always returns null because the app uses custom Google OAuth with JWT session cookies - not Supabase Auth.

**Fix:**
- Switched both routes to use `getSession()` from `lib/auth/session`, matching every other API route in the app
- Changed `user.id` references to `session.userId`  
- Added `'active'` to the assistant status filter (VMs that finish provisioning have status `active`, not `running`)

This was the direct cause of Julie's 'Setup failed (HTTP 401)' error on WhatsApp setup.