### PR TITLE
fix: remove invalid 'running' status from DB queries (causes 404)

### DIFF
--- a/apps/web/src/app/admin/page.tsx
+++ b/apps/web/src/app/admin/page.tsx
@@ -18,7 +18,7 @@ export default async function AdminDashboard() {
   const { count: activeAssistants } = await supabase
     .from('assistants')
     .select('*', { count: 'exact', head: true })
-    .eq('status', 'running');
+    .eq('status', 'active');
 
   const { count: totalVMs } = await supabase
     .from('assistants')

--- a/apps/web/src/app/admin/users/page.tsx
+++ b/apps/web/src/app/admin/users/page.tsx
@@ -123,7 +123,7 @@ export default function AdminUsersPage() {
                   <td className="p-3">
                     {u.assistant_status ? (
                       <span className={`px-2 py-0.5 rounded-full text-xs ${
-                        u.assistant_status === 'running' ? 'bg-green-900/50 text-green-400' :
+                        u.assistant_status === 'active' ? 'bg-green-900/50 text-green-400' :
                         u.assistant_status === 'suspended' ? 'bg-yellow-900/50 text-yellow-400' :
                         'bg-slate-800 text-slate-400'
                       }`}>
@@ -193,7 +193,7 @@ export default function AdminUsersPage() {
                   >
                     {selectedUser.plan === 'pro' ? 'Downgrade to Free' : 'Upgrade to Pro'}
                   </button>
-                  {selectedUser.assistant_status === 'running' && (
+                  {selectedUser.assistant_status === 'active' && (
                     <button
                       disabled={actionLoading}
                       onClick={() => handleAction(selectedUser.id, 'suspend-assistant')}

--- a/apps/web/src/app/api/admin/stats/route.ts
+++ b/apps/web/src/app/api/admin/stats/route.ts
@@ -22,7 +22,7 @@ export async function GET() {
     const { count: activeAssistants } = await supabase
       .from('assistants')
       .select('*', { count: 'exact', head: true })
-      .eq('status', 'running');
+      .eq('status', 'active');
 
     const { count: totalVMs } = await supabase
       .from('assistants')

--- a/apps/web/src/app/api/messaging/setup/route.ts
+++ b/apps/web/src/app/api/messaging/setup/route.ts
@@ -35,7 +35,7 @@ export async function POST(request: Request) {
         .from('assistants')
         .select('id')
         .eq('user_id', session.userId)
-        .in('status', ['active', 'running', 'provisioning'])
+        .in('status', ['active', 'provisioning'])
         .order('created_at', { ascending: false })
         .limit(1)
         .single();

--- a/apps/web/src/app/api/messaging/status/route.ts
+++ b/apps/web/src/app/api/messaging/status/route.ts
@@ -19,7 +19,7 @@ export async function GET() {
         'id, ip_address, sidecar_token, telegram_bot_username, telegram_bot_token, whatsapp_connected',
       )
       .eq('user_id', session.userId)
-      .in('status', ['active', 'running', 'provisioning'])
+      .in('status', ['active', 'provisioning'])
       .order('created_at', { ascending: false })
       .limit(1)
       .single();


### PR DESCRIPTION
**Bug:** Telegram/WhatsApp setup shows 'Setup failed (HTTP 404)' even though the VM is active and the user is authenticated.

**Root cause:** The `assistant_status` enum in Postgres only has: `provisioning`, `active`, `suspended`, `destroying`, `destroyed`. Multiple routes were querying with `status IN ('active', 'running', 'provisioning')` - the `'running'` value causes a Postgres enum validation error. Supabase JS silently returns `data: null` on this error, so the route thinks no assistant exists and returns 404.

**Fix:** Replaced all `'running'` references with `'active'` across:
- `/api/messaging/setup`
- `/api/messaging/status`
- `/api/admin/stats`
- Admin dashboard pages

**Found during E2E test** - this was the last blocker preventing messenger setup from working.