### PR TITLE
fix: run 'openclaw gateway install' before starting sidecar service

### DIFF
--- a/apps/web/src/lib/providers/cloud-init.ts
+++ b/apps/web/src/lib/providers/cloud-init.ts
@@ -74,6 +74,8 @@ write_files:
       curl -fsSL https://deb.nodesource.com/setup_${nodeVersion}.x | bash -
       apt-get install -y nodejs
       npm install -g openclaw@${ocVersion}
+      # Set up OpenClaw gateway for the claw user
+      su - ${user} -c "openclaw gateway install" || true
       systemctl daemon-reload
       systemctl enable --now openclaw-sidecar
       source /etc/shiftworker/sidecar.env


### PR DESCRIPTION
**Bug:** Sidecar crash-loops on every provisioned VM (1800+ restarts). Logs show:
```
Gateway service disabled.
Start with: openclaw gateway install
```

**Root cause:** The cloud-init setup script installs OpenClaw via npm but never runs `openclaw gateway install`, which creates the `~/.openclaw` directory and gateway configuration. Without it, `openclaw gateway start` immediately exits.

**Fix:** Added `su - claw -c 'openclaw gateway install'` to the setup script, run after npm install and before enabling the systemd service.

**Found during E2E test** - this was why the sidecar port (8787) never came online on any provisioned VM.