### PR TITLE
fix: use 'openclaw gateway run' for sidecar (fix systemd crash-loop)

### DIFF
--- a/apps/web/src/lib/providers/cloud-init.ts
+++ b/apps/web/src/lib/providers/cloud-init.ts
@@ -54,7 +54,7 @@ write_files:
       Type=simple
       User=${user}
       EnvironmentFile=/etc/shiftworker/sidecar.env
-      ExecStart=/usr/bin/openclaw gateway start
+      ExecStart=/usr/bin/openclaw gateway run --bind lan --port 8787
       Restart=always
       RestartSec=5
       [Install]


### PR DESCRIPTION
**Bug:** Sidecar crash-loops on every VM with: `Gateway service check failed: Failed to connect to bus: No medium found`

**Root cause:** The systemd service runs `openclaw gateway start` which internally tries `systemctl --user` to manage a user-level service. But since the service runs under the system-level systemd (not a user session), there's no D-Bus user bus available.

**Fix:** Use `openclaw gateway run --bind lan --port 8787` instead:
- `run` = foreground mode (exactly what systemd Type=simple expects)
- `--bind lan` = listen on 0.0.0.0 so the portal can reach it
- `--port 8787` = explicit port for the sidecar API

**E2E test:** Previous VM confirmed that cloud-init completes and `openclaw gateway install` creates the config, but `gateway start` fails due to the user-bus issue. This should be the final fix to get the sidecar online.