### PR TITLE
fix: add --allow-unconfigured flag to sidecar gateway command

### DIFF
--- a/apps/web/src/lib/providers/cloud-init.ts
+++ b/apps/web/src/lib/providers/cloud-init.ts
@@ -54,7 +54,7 @@ write_files:
       Type=simple
       User=${user}
       EnvironmentFile=/etc/shiftworker/sidecar.env
-      ExecStart=/usr/bin/openclaw gateway run --bind lan --port 8787
+      ExecStart=/usr/bin/openclaw gateway run --bind lan --port 8787 --allow-unconfigured
       Restart=always
       RestartSec=5
       [Install]


### PR DESCRIPTION
Third iteration of sidecar startup fixes. Gateway blocks unless `gateway.mode=local` is set in config or `--allow-unconfigured` is passed. Added the flag.

Error was: `Gateway start blocked: set gateway.mode=local (current: unset) or pass --allow-unconfigured`