### PR TITLE
fix: add port 8787 to Azure NSG (sidecar unreachable)

### DIFF
--- a/apps/web/src/lib/vm/provisioning-steps.ts
+++ b/apps/web/src/lib/vm/provisioning-steps.ts
@@ -249,6 +249,14 @@ export async function advanceProvisioning(assistant: Assistant): Promise<Assista
                   destinationAddressPrefix: '*', destinationPortRange: '3000',
                 },
               },
+              {
+                name: 'AllowSidecar',
+                properties: {
+                  priority: 1030, protocol: 'Tcp', access: 'Allow', direction: 'Inbound',
+                  sourceAddressPrefix: '*', sourcePortRange: '*',
+                  destinationAddressPrefix: '*', destinationPortRange: '8787',
+                },
+              },
             ],
           },
         }),


### PR DESCRIPTION
**Bug:** Sidecar runs and listens on port 8787 on the VM, but the ShiftWorker portal can't reach it because the Azure Network Security Group only allows ports 22, 443, and 3000.

**Fix:** Added `AllowSidecar` rule (priority 1030) to open port 8787 in the NSG during provisioning.

**Verified:** Manually added the NSG rule on the current E2E test VM - sidecar became immediately reachable and returned the OpenClaw Control UI.