### PR TITLE
fix: provisioning timer resets to 0 when user navigates away

### DIFF
--- a/apps/web/src/app/onboarding/wizard.tsx
+++ b/apps/web/src/app/onboarding/wizard.tsx
@@ -273,16 +273,26 @@ export default function OnboardingWizard() {
 
   const [elapsedSecs, setElapsedSecs] = useState(0);
 
-  // Timer for setup step
+  // Timer for setup step - persists launch time in sessionStorage
   useEffect(() => {
     if (step !== 6 || setupDone) return;
-    const interval = setInterval(() => setElapsedSecs((s) => s + 1), 1000);
+    // Recover or set launch timestamp
+    let launchTime = Number(sessionStorage.getItem('sw_launch_ts') || '0');
+    if (!launchTime) {
+      launchTime = Date.now();
+      sessionStorage.setItem('sw_launch_ts', String(launchTime));
+    }
+    const tick = () => setElapsedSecs(Math.floor((Date.now() - launchTime) / 1000));
+    tick(); // set immediately
+    const interval = setInterval(tick, 1000);
     return () => clearInterval(interval);
   }, [step, setupDone]);
 
   const saveAndLaunch = async () => {
     goTo(6);
     setServerActive(false);
+    // Reset launch timer
+    sessionStorage.setItem('sw_launch_ts', String(Date.now()));
     const statuses: string[] = [];
     const addStatus = (s: string) => {
       statuses.push(s);


### PR DESCRIPTION
Timer was a simple `setInterval` counter that reset on navigation. Now persists the launch timestamp in `sessionStorage` and calculates elapsed time from that. Accurate even after page refresh or tab switch.