### PR TITLE
feat: sidecar messaging endpoints (Telegram + WhatsApp setup)

### DIFF
--- a/apps/sidecar/dist/index.d.ts
+++ b/apps/sidecar/dist/index.d.ts
@@ -1,0 +1,2 @@
+declare const app: import("express-serve-static-core").Express;
+export default app;

--- a/apps/sidecar/dist/index.js
+++ b/apps/sidecar/dist/index.js
@@ -1,0 +1,29 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const express_1 = __importDefault(require("express"));
+const auth_1 = require("./middleware/auth");
+const health_1 = __importDefault(require("./routes/health"));
+const openclaw_1 = __importDefault(require("./routes/openclaw"));
+const heartbeat_1 = __importDefault(require("./routes/heartbeat"));
+const skills_1 = __importDefault(require("./routes/skills"));
+const messaging_1 = __importDefault(require("./routes/messaging"));
+const usage_1 = __importDefault(require("./routes/usage"));
+const app = (0, express_1.default)();
+const PORT = parseInt(process.env.PORT || '8787', 10);
+app.use(express_1.default.json());
+// Auth on all routes
+app.use(auth_1.authMiddleware);
+// Routes
+app.use(health_1.default);
+app.use(openclaw_1.default);
+app.use(heartbeat_1.default);
+app.use(skills_1.default);
+app.use(messaging_1.default);
+app.use(usage_1.default);
+app.listen(PORT, '0.0.0.0', () => {
+    console.log(`[sidecar] listening on port ${PORT}`);
+});
+exports.default = app;

--- a/apps/sidecar/dist/middleware/auth.d.ts
+++ b/apps/sidecar/dist/middleware/auth.d.ts
@@ -1,0 +1,2 @@
+import { Request, Response, NextFunction } from 'express';
+export declare function authMiddleware(req: Request, res: Response, next: NextFunction): void;

--- a/apps/sidecar/dist/middleware/auth.js
+++ b/apps/sidecar/dist/middleware/auth.js
@@ -1,0 +1,16 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.authMiddleware = authMiddleware;
+function authMiddleware(req, res, next) {
+    const token = process.env.SIDECAR_TOKEN;
+    if (!token) {
+        res.status(500).json({ error: 'SIDECAR_TOKEN not configured' });
+        return;
+    }
+    const auth = req.headers.authorization;
+    if (!auth || !auth.startsWith('Bearer ') || auth.slice(7) !== token) {
+        res.status(401).json({ error: 'Unauthorized' });
+        return;
+    }
+    next();
+}

--- a/apps/sidecar/dist/routes/health.d.ts
+++ b/apps/sidecar/dist/routes/health.d.ts
@@ -1,0 +1,2 @@
+declare const router: import("express-serve-static-core").Router;
+export default router;

--- a/apps/sidecar/dist/routes/health.js
+++ b/apps/sidecar/dist/routes/health.js
@@ -1,0 +1,76 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const express_1 = require("express");
+const os_1 = __importDefault(require("os"));
+const child_process_1 = require("child_process");
+const util_1 = require("util");
+const execAsync = (0, util_1.promisify)(child_process_1.exec);
+const router = (0, express_1.Router)();
+async function getDiskUsage() {
+    try {
+        const { stdout } = await execAsync("df -h / | tail -1 | awk '{print $2,$3,$4,$5}'");
+        const [total, used, available, usePercent] = stdout.trim().split(/\s+/);
+        return { total, used, available, usePercent };
+    }
+    catch {
+        return { total: 'unknown', used: 'unknown', available: 'unknown', usePercent: 'unknown' };
+    }
+}
+async function getOpenclawVersion() {
+    try {
+        const { stdout } = await execAsync('openclaw --version');
+        return stdout.trim();
+    }
+    catch {
+        return 'unknown';
+    }
+}
+async function isOpenclawRunning() {
+    try {
+        await execAsync('pgrep -f openclaw');
+        return true;
+    }
+    catch {
+        return false;
+    }
+}
+function getCpuUsage() {
+    const cpus = os_1.default.cpus();
+    return {
+        model: cpus[0]?.model || 'unknown',
+        cores: cpus.length,
+        loadAvg: os_1.default.loadavg(),
+    };
+}
+function getMemoryUsage() {
+    const total = os_1.default.totalmem();
+    const free = os_1.default.freemem();
+    const used = total - free;
+    return {
+        totalMB: Math.round(total / 1024 / 1024),
+        freeMB: Math.round(free / 1024 / 1024),
+        usedPercent: Math.round((used / total) * 100),
+    };
+}
+router.get('/health', async (_req, res) => {
+    const [disk, openclawVersion, openclawRunning] = await Promise.all([
+        getDiskUsage(),
+        getOpenclawVersion(),
+        isOpenclawRunning(),
+    ]);
+    res.json({
+        status: 'ok',
+        uptime: process.uptime(),
+        cpu: getCpuUsage(),
+        memory: getMemoryUsage(),
+        disk,
+        openclaw: {
+            version: openclawVersion,
+            running: openclawRunning,
+        },
+    });
+});
+exports.default = router;

--- a/apps/sidecar/dist/routes/heartbeat.d.ts
+++ b/apps/sidecar/dist/routes/heartbeat.d.ts
@@ -1,0 +1,3 @@
+declare const router: import("express-serve-static-core").Router;
+export declare function isThrottled(): boolean;
+export default router;

--- a/apps/sidecar/dist/routes/heartbeat.js
+++ b/apps/sidecar/dist/routes/heartbeat.js
@@ -1,0 +1,152 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.isThrottled = isThrottled;
+const express_1 = require("express");
+const usage_1 = require("./usage");
+const router = (0, express_1.Router)();
+let heartbeatInterval = null;
+let usageReportInterval = null;
+let portalUrl = null;
+let vmId = null;
+/** Whether the portal has indicated this assistant is throttled */
+let throttled = false;
+function isThrottled() {
+    return throttled;
+}
+async function collectHealthData() {
+    const os = await Promise.resolve().then(() => __importStar(require('os')));
+    const { exec } = await Promise.resolve().then(() => __importStar(require('child_process')));
+    const { promisify } = await Promise.resolve().then(() => __importStar(require('util')));
+    const execAsync = promisify(exec);
+    let openclawRunning = false;
+    try {
+        await execAsync('pgrep -f openclaw');
+        openclawRunning = true;
+    }
+    catch { }
+    const total = os.totalmem();
+    const free = os.freemem();
+    return {
+        uptime: process.uptime(),
+        cpu: { cores: os.cpus().length, loadAvg: os.loadavg() },
+        memory: {
+            totalMB: Math.round(total / 1024 / 1024),
+            freeMB: Math.round(free / 1024 / 1024),
+            usedPercent: Math.round(((total - free) / total) * 100),
+        },
+        openclaw: { running: openclawRunning },
+        timestamp: new Date().toISOString(),
+    };
+}
+async function sendHeartbeat() {
+    if (!portalUrl || !vmId)
+        return;
+    try {
+        const health = await collectHealthData();
+        let usage = { messages_sent: 0, hours_active: 0, api_tokens_used: 0 };
+        try {
+            usage = await (0, usage_1.getTodayUsageSummary)();
+        }
+        catch { }
+        await fetch(`${portalUrl}/api/heartbeat`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ vmId, ...health, usage }),
+        });
+    }
+    catch (err) {
+        console.error('[heartbeat] Failed to phone home:', err.message);
+    }
+}
+/**
+ * Report usage to the portal every 5 minutes.
+ * The portal responds with { throttled } so the sidecar knows to pause.
+ */
+async function reportUsageToPortal() {
+    if (!portalUrl || !vmId)
+        return;
+    const sidecarToken = process.env.SIDECAR_TOKEN;
+    if (!sidecarToken)
+        return;
+    try {
+        const usage = await (0, usage_1.getTodayUsageSummary)();
+        const res = await fetch(`${portalUrl}/api/usage/record`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'Authorization': `Bearer ${sidecarToken}`,
+            },
+            body: JSON.stringify({
+                assistant_id: vmId,
+                messages_sent: usage.messages_sent,
+                hours_active: usage.hours_active,
+                api_tokens_used: usage.api_tokens_used,
+            }),
+        });
+        if (res.ok) {
+            const data = await res.json();
+            throttled = data.throttled === true;
+            if (throttled) {
+                console.warn(`[usage] Throttled by portal: ${data.reason ?? 'limit reached'}`);
+            }
+        }
+    }
+    catch (err) {
+        console.error('[usage] Failed to report usage:', err.message);
+    }
+}
+router.post('/heartbeat/register', (req, res) => {
+    const { url, id } = req.body;
+    if (!url || !id) {
+        res.status(400).json({ error: 'Missing url or id in body' });
+        return;
+    }
+    portalUrl = url;
+    vmId = id;
+    // Clear existing intervals if re-registering
+    if (heartbeatInterval)
+        clearInterval(heartbeatInterval);
+    if (usageReportInterval)
+        clearInterval(usageReportInterval);
+    // Send heartbeat immediately, then every 60s
+    sendHeartbeat();
+    heartbeatInterval = setInterval(sendHeartbeat, 60_000);
+    // Report usage immediately, then every 5 minutes
+    reportUsageToPortal();
+    usageReportInterval = setInterval(reportUsageToPortal, 5 * 60 * 1000);
+    res.json({ status: 'registered', portalUrl, vmId, heartbeatMs: 60_000, usageReportMs: 300_000 });
+});
+exports.default = router;

--- a/apps/sidecar/dist/routes/messaging.d.ts
+++ b/apps/sidecar/dist/routes/messaging.d.ts
@@ -1,0 +1,2 @@
+declare const router: import("express-serve-static-core").Router;
+export default router;

--- a/apps/sidecar/dist/routes/messaging.js
+++ b/apps/sidecar/dist/routes/messaging.js
@@ -1,0 +1,174 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const express_1 = require("express");
+const child_process_1 = require("child_process");
+const util_1 = require("util");
+const execAsync = (0, util_1.promisify)(child_process_1.exec);
+const router = (0, express_1.Router)();
+const VALID_PLATFORMS = ['whatsapp', 'telegram', 'signal', 'discord', 'slack'];
+// Home dir for the claw user (OpenClaw runs as this user)
+const CLAW_USER = process.env.OPENCLAW_USER || 'claw';
+/** Run a command as the claw user */
+async function runAsClaw(cmd, timeoutMs = 30_000) {
+    return execAsync(`su - ${CLAW_USER} -c '${cmd.replace(/'/g, "'\\''")}'`, { timeout: timeoutMs });
+}
+async function setupTelegram(config) {
+    if (!config.botToken || typeof config.botToken !== 'string') {
+        throw new Error('Missing botToken for Telegram setup');
+    }
+    // Use openclaw channels add to configure the Telegram bot
+    await runAsClaw(`openclaw channels add --channel telegram --token ${config.botToken}`);
+    // Restart the gateway to pick up the new channel
+    try {
+        await execAsync('systemctl restart openclaw-sidecar', { timeout: 15_000 });
+        // Wait for restart
+        await new Promise(r => setTimeout(r, 5000));
+    }
+    catch {
+        // If systemctl fails, try restarting via openclaw CLI
+        try {
+            await runAsClaw('openclaw gateway restart');
+        }
+        catch { }
+    }
+    return { status: 'configured' };
+}
+async function setupWhatsApp(_config) {
+    // First check if already connected
+    try {
+        const { stdout } = await runAsClaw('openclaw channels status --channel whatsapp 2>/dev/null', 10_000);
+        if (stdout.toLowerCase().includes('connected') || stdout.toLowerCase().includes('active') || stdout.toLowerCase().includes('ready')) {
+            return { status: 'connected' };
+        }
+    }
+    catch { }
+    // Enable WhatsApp channel if not already configured
+    try {
+        await runAsClaw('openclaw channels add --channel whatsapp');
+    }
+    catch {
+        // May already be configured
+    }
+    // Restart to ensure WhatsApp plugin is loaded
+    try {
+        await execAsync('systemctl restart openclaw-sidecar', { timeout: 15_000 });
+        await new Promise(r => setTimeout(r, 5000));
+    }
+    catch { }
+    // Try to get QR code via the login command
+    try {
+        const { stdout } = await runAsClaw('openclaw channels login --channel whatsapp --json 2>/dev/null', 30_000);
+        try {
+            const data = JSON.parse(stdout.trim());
+            if (data.qr)
+                return { status: 'pairing', qr: data.qr };
+            if (data.pairingCode)
+                return { status: 'pairing', pairingCode: data.pairingCode };
+        }
+        catch {
+            // Not JSON, try to use raw output
+            const trimmed = stdout.trim();
+            if (trimmed.length > 20)
+                return { status: 'pairing', qr: trimmed };
+        }
+    }
+    catch { }
+    return { status: 'pending' };
+}
+router.post('/messaging/setup', async (req, res) => {
+    const { platform, config } = req.body;
+    if (!platform || !VALID_PLATFORMS.includes(platform)) {
+        res.status(400).json({ error: `Invalid platform. Must be one of: ${VALID_PLATFORMS.join(', ')}` });
+        return;
+    }
+    try {
+        let result;
+        switch (platform) {
+            case 'telegram':
+                result = await setupTelegram(config || {});
+                break;
+            case 'whatsapp':
+                result = await setupWhatsApp(config || {});
+                break;
+            default:
+                // For other platforms, try generic channels add
+                if (config?.token) {
+                    await runAsClaw(`openclaw channels add --channel ${platform} --token ${config.token}`);
+                }
+                else {
+                    await runAsClaw(`openclaw channels add --channel ${platform}`);
+                }
+                try {
+                    await execAsync('systemctl restart openclaw-sidecar', { timeout: 15_000 });
+                    await new Promise(r => setTimeout(r, 3000));
+                }
+                catch { }
+                result = { status: 'configured' };
+                break;
+        }
+        res.json({ platform, ...result });
+    }
+    catch (err) {
+        res.status(500).json({ error: `Failed to setup ${platform}`, details: err.message });
+    }
+});
+router.get('/messaging/status', async (_req, res) => {
+    try {
+        const platforms = {};
+        // Use openclaw channels list to check configured channels
+        try {
+            const { stdout } = await runAsClaw('openclaw channels list --json 2>/dev/null', 10_000);
+            const data = JSON.parse(stdout.trim());
+            const channels = Array.isArray(data) ? data : data.channels || [];
+            for (const ch of channels) {
+                const name = (ch.channel || ch.name || '').toLowerCase();
+                if (VALID_PLATFORMS.includes(name)) {
+                    platforms[name] = {
+                        configured: true,
+                        connected: ch.connected !== undefined ? ch.connected : ch.status === 'connected',
+                    };
+                }
+            }
+        }
+        catch {
+            // Channels list failed, return empty
+        }
+        res.json({ platforms });
+    }
+    catch (err) {
+        res.status(500).json({ error: 'Failed to get messaging status', details: err.message });
+    }
+});
+// WhatsApp QR polling endpoint
+router.get('/messaging/whatsapp/qr', async (_req, res) => {
+    try {
+        // Check if connected
+        try {
+            const { stdout } = await runAsClaw('openclaw channels status --channel whatsapp 2>/dev/null', 5_000);
+            if (stdout.toLowerCase().includes('connected') || stdout.toLowerCase().includes('ready')) {
+                res.json({ status: 'connected' });
+                return;
+            }
+        }
+        catch { }
+        // Get fresh QR
+        try {
+            const { stdout } = await runAsClaw('openclaw channels login --channel whatsapp --json 2>/dev/null', 15_000);
+            const data = JSON.parse(stdout.trim());
+            if (data.qr) {
+                res.json({ status: 'pairing', qr: data.qr });
+                return;
+            }
+            if (data.pairingCode) {
+                res.json({ status: 'pairing', pairingCode: data.pairingCode });
+                return;
+            }
+        }
+        catch { }
+        res.json({ status: 'pending' });
+    }
+    catch (err) {
+        res.status(500).json({ error: 'Failed to get WhatsApp QR', details: err.message });
+    }
+});
+exports.default = router;

--- a/apps/sidecar/dist/routes/openclaw.d.ts
+++ b/apps/sidecar/dist/routes/openclaw.d.ts
@@ -1,0 +1,2 @@
+declare const router: import("express-serve-static-core").Router;
+export default router;

--- a/apps/sidecar/dist/routes/openclaw.js
+++ b/apps/sidecar/dist/routes/openclaw.js
@@ -1,0 +1,62 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const express_1 = require("express");
+const child_process_1 = require("child_process");
+const util_1 = require("util");
+const execAsync = (0, util_1.promisify)(child_process_1.exec);
+const router = (0, express_1.Router)();
+async function getOpenclawStatus() {
+    let running = false;
+    let version = 'unknown';
+    let uptime = 'unknown';
+    try {
+        const { stdout } = await execAsync('openclaw --version');
+        version = stdout.trim();
+    }
+    catch { }
+    try {
+        await execAsync('systemctl is-active openclaw');
+        running = true;
+    }
+    catch {
+        // Also try pgrep as fallback
+        try {
+            await execAsync('pgrep -f openclaw');
+            running = true;
+        }
+        catch { }
+    }
+    if (running) {
+        try {
+            const { stdout } = await execAsync("systemctl show openclaw --property=ActiveEnterTimestamp --value");
+            uptime = stdout.trim() || 'unknown';
+        }
+        catch { }
+    }
+    return { running, version, uptime };
+}
+router.get('/openclaw/status', async (_req, res) => {
+    const status = await getOpenclawStatus();
+    res.json(status);
+});
+router.post('/openclaw/restart', async (_req, res) => {
+    try {
+        await execAsync('systemctl restart openclaw');
+        res.json({ status: 'restarted' });
+    }
+    catch (err) {
+        res.status(500).json({ error: 'Failed to restart openclaw', details: err.message });
+    }
+});
+router.post('/openclaw/update', async (_req, res) => {
+    try {
+        await execAsync('npm install -g openclaw@latest');
+        await execAsync('systemctl restart openclaw');
+        const { stdout } = await execAsync('openclaw --version');
+        res.json({ status: 'updated', version: stdout.trim() });
+    }
+    catch (err) {
+        res.status(500).json({ error: 'Failed to update openclaw', details: err.message });
+    }
+});
+exports.default = router;

--- a/apps/sidecar/dist/routes/skills.d.ts
+++ b/apps/sidecar/dist/routes/skills.d.ts
@@ -1,0 +1,2 @@
+declare const router: import("express-serve-static-core").Router;
+export default router;

--- a/apps/sidecar/dist/routes/skills.js
+++ b/apps/sidecar/dist/routes/skills.js
@@ -1,0 +1,91 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const express_1 = require("express");
+const child_process_1 = require("child_process");
+const util_1 = require("util");
+const promises_1 = require("fs/promises");
+const path_1 = require("path");
+const execAsync = (0, util_1.promisify)(child_process_1.exec);
+const router = (0, express_1.Router)();
+const SKILLS_DIRS = [
+    '/usr/local/lib/node_modules/openclaw/skills',
+    (0, path_1.join)(process.env.HOME || '/root', '.openclaw/workspace/skills'),
+    (0, path_1.join)(process.env.HOME || '/root', '.agents/skills'),
+];
+router.get('/skills', async (_req, res) => {
+    try {
+        // Try CLI first
+        try {
+            const { stdout } = await execAsync('openclaw skill list --json 2>/dev/null || openclaw skill list 2>/dev/null');
+            if (stdout.trim()) {
+                try {
+                    const skills = JSON.parse(stdout.trim());
+                    res.json({ skills });
+                    return;
+                }
+                catch {
+                    // CLI returned non-JSON, parse as text
+                    const skills = stdout.trim().split('\n').filter(Boolean).map((name) => ({ name: name.trim() }));
+                    res.json({ skills });
+                    return;
+                }
+            }
+        }
+        catch { }
+        // Fallback: read from filesystem
+        const skills = [];
+        for (const dir of SKILLS_DIRS) {
+            try {
+                const entries = await (0, promises_1.readdir)(dir, { withFileTypes: true });
+                for (const entry of entries) {
+                    if (entry.isDirectory()) {
+                        skills.push({ name: entry.name, path: (0, path_1.join)(dir, entry.name) });
+                    }
+                }
+            }
+            catch { }
+        }
+        res.json({ skills });
+    }
+    catch (err) {
+        res.status(500).json({ error: 'Failed to list skills', details: err.message });
+    }
+});
+router.post('/skills/install', async (req, res) => {
+    const { name } = req.body;
+    if (!name || typeof name !== 'string') {
+        res.status(400).json({ error: 'Missing or invalid skill name' });
+        return;
+    }
+    // Sanitize: only allow alphanumeric, hyphens, underscores
+    if (!/^[a-zA-Z0-9_-]+$/.test(name)) {
+        res.status(400).json({ error: 'Invalid skill name format' });
+        return;
+    }
+    try {
+        const { stdout, stderr } = await execAsync(`openclaw skill install ${name}`, { timeout: 60_000 });
+        res.json({ status: 'installed', name, output: stdout.trim() || stderr.trim() });
+    }
+    catch (err) {
+        res.status(500).json({ error: 'Failed to install skill', details: err.stderr || err.message });
+    }
+});
+router.post('/skills/remove', async (req, res) => {
+    const { name } = req.body;
+    if (!name || typeof name !== 'string') {
+        res.status(400).json({ error: 'Missing or invalid skill name' });
+        return;
+    }
+    if (!/^[a-zA-Z0-9_-]+$/.test(name)) {
+        res.status(400).json({ error: 'Invalid skill name format' });
+        return;
+    }
+    try {
+        const { stdout, stderr } = await execAsync(`openclaw skill remove ${name}`, { timeout: 30_000 });
+        res.json({ status: 'removed', name, output: stdout.trim() || stderr.trim() });
+    }
+    catch (err) {
+        res.status(500).json({ error: 'Failed to remove skill', details: err.stderr || err.message });
+    }
+});
+exports.default = router;

--- a/apps/sidecar/dist/routes/usage.d.ts
+++ b/apps/sidecar/dist/routes/usage.d.ts
@@ -1,0 +1,8 @@
+declare const router: import("express-serve-static-core").Router;
+/** Exported for heartbeat to include usage data when phoning home */
+export declare function getTodayUsageSummary(): Promise<{
+    messages_sent: number;
+    hours_active: number;
+    api_tokens_used: number;
+}>;
+export default router;

--- a/apps/sidecar/dist/routes/usage.js
+++ b/apps/sidecar/dist/routes/usage.js
@@ -1,0 +1,97 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.getTodayUsageSummary = getTodayUsageSummary;
+const express_1 = require("express");
+const promises_1 = require("fs/promises");
+const path_1 = require("path");
+const router = (0, express_1.Router)();
+const USAGE_FILE = process.env.USAGE_FILE || '/var/lib/shiftworker/usage.json';
+function todayKey() {
+    return new Date().toISOString().slice(0, 10);
+}
+async function readUsageStore() {
+    try {
+        const raw = await (0, promises_1.readFile)(USAGE_FILE, 'utf-8');
+        return JSON.parse(raw);
+    }
+    catch {
+        return {};
+    }
+}
+async function writeUsageStore(store) {
+    await (0, promises_1.mkdir)((0, path_1.dirname)(USAGE_FILE), { recursive: true });
+    await (0, promises_1.writeFile)(USAGE_FILE, JSON.stringify(store, null, 2), 'utf-8');
+}
+function getOrCreateToday(store) {
+    const key = todayKey();
+    if (!store[key]) {
+        store[key] = {
+            date: key,
+            messages_sent: 0,
+            active_minutes: 0,
+            api_tokens_used: 0,
+            last_activity: new Date().toISOString(),
+        };
+    }
+    return store[key];
+}
+router.post('/usage/increment', async (req, res) => {
+    const { messages = 1, tokens = 0 } = req.body || {};
+    try {
+        const store = await readUsageStore();
+        const today = getOrCreateToday(store);
+        today.messages_sent += typeof messages === 'number' ? messages : 1;
+        today.api_tokens_used += typeof tokens === 'number' ? tokens : 0;
+        // Track active time: if last activity was within 5 min, add the gap
+        const now = new Date();
+        const lastActivity = new Date(today.last_activity);
+        const gapMinutes = (now.getTime() - lastActivity.getTime()) / 60_000;
+        if (gapMinutes > 0 && gapMinutes <= 5) {
+            today.active_minutes += gapMinutes;
+        }
+        else if (gapMinutes > 5) {
+            // New activity session, count 1 minute
+            today.active_minutes += 1;
+        }
+        today.last_activity = now.toISOString();
+        await writeUsageStore(store);
+        res.json({ status: 'ok', today });
+    }
+    catch (err) {
+        res.status(500).json({ error: 'Failed to increment usage', details: err.message });
+    }
+});
+router.get('/usage/today', async (_req, res) => {
+    try {
+        const store = await readUsageStore();
+        const key = todayKey();
+        const today = store[key] || {
+            date: key,
+            messages_sent: 0,
+            active_minutes: 0,
+            api_tokens_used: 0,
+            last_activity: null,
+        };
+        res.json({
+            messages_sent: today.messages_sent,
+            hours_active: Math.round((today.active_minutes / 60) * 100) / 100,
+            api_tokens_used: today.api_tokens_used,
+        });
+    }
+    catch (err) {
+        res.status(500).json({ error: 'Failed to read usage', details: err.message });
+    }
+});
+/** Exported for heartbeat to include usage data when phoning home */
+async function getTodayUsageSummary() {
+    const store = await readUsageStore();
+    const today = store[todayKey()];
+    if (!today)
+        return { messages_sent: 0, hours_active: 0, api_tokens_used: 0 };
+    return {
+        messages_sent: today.messages_sent,
+        hours_active: Math.round((today.active_minutes / 60) * 100) / 100,
+        api_tokens_used: today.api_tokens_used,
+    };
+}
+exports.default = router;

--- a/apps/sidecar/dist/sidecar.cjs
+++ b/apps/sidecar/dist/sidecar.cjs
@@ -1,0 +1,612 @@
+"use strict";
+var __create = Object.create;
+var __defProp = Object.defineProperty;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __getProtoOf = Object.getPrototypeOf;
+var __hasOwnProp = Object.prototype.hasOwnProperty;
+var __export = (target, all) => {
+  for (var name in all)
+    __defProp(target, name, { get: all[name], enumerable: true });
+};
+var __copyProps = (to, from, except, desc) => {
+  if (from && typeof from === "object" || typeof from === "function") {
+    for (let key of __getOwnPropNames(from))
+      if (!__hasOwnProp.call(to, key) && key !== except)
+        __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+  }
+  return to;
+};
+var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__getProtoOf(mod)) : {}, __copyProps(
+  // If the importer is in node compatibility mode or this is not an ESM
+  // file that has been converted to a CommonJS file using a Babel-
+  // compatible transform (i.e. "__esModule" has not been set), then set
+  // "default" to the CommonJS "module.exports" for node compatibility.
+  isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target,
+  mod
+));
+var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
+
+// src/index.ts
+var index_exports = {};
+__export(index_exports, {
+  default: () => index_default
+});
+module.exports = __toCommonJS(index_exports);
+var import_express7 = __toESM(require("express"));
+
+// src/middleware/auth.ts
+function authMiddleware(req, res, next) {
+  const token = process.env.SIDECAR_TOKEN;
+  if (!token) {
+    res.status(500).json({ error: "SIDECAR_TOKEN not configured" });
+    return;
+  }
+  const auth = req.headers.authorization;
+  if (!auth || !auth.startsWith("Bearer ") || auth.slice(7) !== token) {
+    res.status(401).json({ error: "Unauthorized" });
+    return;
+  }
+  next();
+}
+
+// src/routes/health.ts
+var import_express = require("express");
+var import_os = __toESM(require("os"));
+var import_child_process = require("child_process");
+var import_util = require("util");
+var execAsync = (0, import_util.promisify)(import_child_process.exec);
+var router = (0, import_express.Router)();
+async function getDiskUsage() {
+  try {
+    const { stdout } = await execAsync("df -h / | tail -1 | awk '{print $2,$3,$4,$5}'");
+    const [total, used, available, usePercent] = stdout.trim().split(/\s+/);
+    return { total, used, available, usePercent };
+  } catch {
+    return { total: "unknown", used: "unknown", available: "unknown", usePercent: "unknown" };
+  }
+}
+async function getOpenclawVersion() {
+  try {
+    const { stdout } = await execAsync("openclaw --version");
+    return stdout.trim();
+  } catch {
+    return "unknown";
+  }
+}
+async function isOpenclawRunning() {
+  try {
+    await execAsync("pgrep -f openclaw");
+    return true;
+  } catch {
+    return false;
+  }
+}
+function getCpuUsage() {
+  const cpus = import_os.default.cpus();
+  return {
+    model: cpus[0]?.model || "unknown",
+    cores: cpus.length,
+    loadAvg: import_os.default.loadavg()
+  };
+}
+function getMemoryUsage() {
+  const total = import_os.default.totalmem();
+  const free = import_os.default.freemem();
+  const used = total - free;
+  return {
+    totalMB: Math.round(total / 1024 / 1024),
+    freeMB: Math.round(free / 1024 / 1024),
+    usedPercent: Math.round(used / total * 100)
+  };
+}
+router.get("/health", async (_req, res) => {
+  const [disk, openclawVersion, openclawRunning] = await Promise.all([
+    getDiskUsage(),
+    getOpenclawVersion(),
+    isOpenclawRunning()
+  ]);
+  res.json({
+    status: "ok",
+    uptime: process.uptime(),
+    cpu: getCpuUsage(),
+    memory: getMemoryUsage(),
+    disk,
+    openclaw: {
+      version: openclawVersion,
+      running: openclawRunning
+    }
+  });
+});
+var health_default = router;
+
+// src/routes/openclaw.ts
+var import_express2 = require("express");
+var import_child_process2 = require("child_process");
+var import_util2 = require("util");
+var execAsync2 = (0, import_util2.promisify)(import_child_process2.exec);
+var router2 = (0, import_express2.Router)();
+async function getOpenclawStatus() {
+  let running = false;
+  let version = "unknown";
+  let uptime = "unknown";
+  try {
+    const { stdout } = await execAsync2("openclaw --version");
+    version = stdout.trim();
+  } catch {
+  }
+  try {
+    await execAsync2("systemctl is-active openclaw");
+    running = true;
+  } catch {
+    try {
+      await execAsync2("pgrep -f openclaw");
+      running = true;
+    } catch {
+    }
+  }
+  if (running) {
+    try {
+      const { stdout } = await execAsync2("systemctl show openclaw --property=ActiveEnterTimestamp --value");
+      uptime = stdout.trim() || "unknown";
+    } catch {
+    }
+  }
+  return { running, version, uptime };
+}
+router2.get("/openclaw/status", async (_req, res) => {
+  const status = await getOpenclawStatus();
+  res.json(status);
+});
+router2.post("/openclaw/restart", async (_req, res) => {
+  try {
+    await execAsync2("systemctl restart openclaw");
+    res.json({ status: "restarted" });
+  } catch (err) {
+    res.status(500).json({ error: "Failed to restart openclaw", details: err.message });
+  }
+});
+router2.post("/openclaw/update", async (_req, res) => {
+  try {
+    await execAsync2("npm install -g openclaw@latest");
+    await execAsync2("systemctl restart openclaw");
+    const { stdout } = await execAsync2("openclaw --version");
+    res.json({ status: "updated", version: stdout.trim() });
+  } catch (err) {
+    res.status(500).json({ error: "Failed to update openclaw", details: err.message });
+  }
+});
+var openclaw_default = router2;
+
+// src/routes/heartbeat.ts
+var import_express4 = require("express");
+
+// src/routes/usage.ts
+var import_express3 = require("express");
+var import_promises = require("fs/promises");
+var import_path = require("path");
+var router3 = (0, import_express3.Router)();
+var USAGE_FILE = process.env.USAGE_FILE || "/var/lib/shiftworker/usage.json";
+function todayKey() {
+  return (/* @__PURE__ */ new Date()).toISOString().slice(0, 10);
+}
+async function readUsageStore() {
+  try {
+    const raw = await (0, import_promises.readFile)(USAGE_FILE, "utf-8");
+    return JSON.parse(raw);
+  } catch {
+    return {};
+  }
+}
+async function writeUsageStore(store) {
+  await (0, import_promises.mkdir)((0, import_path.dirname)(USAGE_FILE), { recursive: true });
+  await (0, import_promises.writeFile)(USAGE_FILE, JSON.stringify(store, null, 2), "utf-8");
+}
+function getOrCreateToday(store) {
+  const key = todayKey();
+  if (!store[key]) {
+    store[key] = {
+      date: key,
+      messages_sent: 0,
+      active_minutes: 0,
+      api_tokens_used: 0,
+      last_activity: (/* @__PURE__ */ new Date()).toISOString()
+    };
+  }
+  return store[key];
+}
+router3.post("/usage/increment", async (req, res) => {
+  const { messages = 1, tokens = 0 } = req.body || {};
+  try {
+    const store = await readUsageStore();
+    const today = getOrCreateToday(store);
+    today.messages_sent += typeof messages === "number" ? messages : 1;
+    today.api_tokens_used += typeof tokens === "number" ? tokens : 0;
+    const now = /* @__PURE__ */ new Date();
+    const lastActivity = new Date(today.last_activity);
+    const gapMinutes = (now.getTime() - lastActivity.getTime()) / 6e4;
+    if (gapMinutes > 0 && gapMinutes <= 5) {
+      today.active_minutes += gapMinutes;
+    } else if (gapMinutes > 5) {
+      today.active_minutes += 1;
+    }
+    today.last_activity = now.toISOString();
+    await writeUsageStore(store);
+    res.json({ status: "ok", today });
+  } catch (err) {
+    res.status(500).json({ error: "Failed to increment usage", details: err.message });
+  }
+});
+router3.get("/usage/today", async (_req, res) => {
+  try {
+    const store = await readUsageStore();
+    const key = todayKey();
+    const today = store[key] || {
+      date: key,
+      messages_sent: 0,
+      active_minutes: 0,
+      api_tokens_used: 0,
+      last_activity: null
+    };
+    res.json({
+      messages_sent: today.messages_sent,
+      hours_active: Math.round(today.active_minutes / 60 * 100) / 100,
+      api_tokens_used: today.api_tokens_used
+    });
+  } catch (err) {
+    res.status(500).json({ error: "Failed to read usage", details: err.message });
+  }
+});
+async function getTodayUsageSummary() {
+  const store = await readUsageStore();
+  const today = store[todayKey()];
+  if (!today) return { messages_sent: 0, hours_active: 0, api_tokens_used: 0 };
+  return {
+    messages_sent: today.messages_sent,
+    hours_active: Math.round(today.active_minutes / 60 * 100) / 100,
+    api_tokens_used: today.api_tokens_used
+  };
+}
+var usage_default = router3;
+
+// src/routes/heartbeat.ts
+var router4 = (0, import_express4.Router)();
+var heartbeatInterval = null;
+var usageReportInterval = null;
+var portalUrl = null;
+var vmId = null;
+var throttled = false;
+async function collectHealthData() {
+  const os2 = await import("os");
+  const { exec: exec5 } = await import("child_process");
+  const { promisify: promisify5 } = await import("util");
+  const execAsync5 = promisify5(exec5);
+  let openclawRunning = false;
+  try {
+    await execAsync5("pgrep -f openclaw");
+    openclawRunning = true;
+  } catch {
+  }
+  const total = os2.totalmem();
+  const free = os2.freemem();
+  return {
+    uptime: process.uptime(),
+    cpu: { cores: os2.cpus().length, loadAvg: os2.loadavg() },
+    memory: {
+      totalMB: Math.round(total / 1024 / 1024),
+      freeMB: Math.round(free / 1024 / 1024),
+      usedPercent: Math.round((total - free) / total * 100)
+    },
+    openclaw: { running: openclawRunning },
+    timestamp: (/* @__PURE__ */ new Date()).toISOString()
+  };
+}
+async function sendHeartbeat() {
+  if (!portalUrl || !vmId) return;
+  try {
+    const health = await collectHealthData();
+    let usage = { messages_sent: 0, hours_active: 0, api_tokens_used: 0 };
+    try {
+      usage = await getTodayUsageSummary();
+    } catch {
+    }
+    await fetch(`${portalUrl}/api/heartbeat`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ vmId, ...health, usage })
+    });
+  } catch (err) {
+    console.error("[heartbeat] Failed to phone home:", err.message);
+  }
+}
+async function reportUsageToPortal() {
+  if (!portalUrl || !vmId) return;
+  const sidecarToken = process.env.SIDECAR_TOKEN;
+  if (!sidecarToken) return;
+  try {
+    const usage = await getTodayUsageSummary();
+    const res = await fetch(`${portalUrl}/api/usage/record`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Authorization": `Bearer ${sidecarToken}`
+      },
+      body: JSON.stringify({
+        assistant_id: vmId,
+        messages_sent: usage.messages_sent,
+        hours_active: usage.hours_active,
+        api_tokens_used: usage.api_tokens_used
+      })
+    });
+    if (res.ok) {
+      const data = await res.json();
+      throttled = data.throttled === true;
+      if (throttled) {
+        console.warn(`[usage] Throttled by portal: ${data.reason ?? "limit reached"}`);
+      }
+    }
+  } catch (err) {
+    console.error("[usage] Failed to report usage:", err.message);
+  }
+}
+router4.post("/heartbeat/register", (req, res) => {
+  const { url, id } = req.body;
+  if (!url || !id) {
+    res.status(400).json({ error: "Missing url or id in body" });
+    return;
+  }
+  portalUrl = url;
+  vmId = id;
+  if (heartbeatInterval) clearInterval(heartbeatInterval);
+  if (usageReportInterval) clearInterval(usageReportInterval);
+  sendHeartbeat();
+  heartbeatInterval = setInterval(sendHeartbeat, 6e4);
+  reportUsageToPortal();
+  usageReportInterval = setInterval(reportUsageToPortal, 5 * 60 * 1e3);
+  res.json({ status: "registered", portalUrl, vmId, heartbeatMs: 6e4, usageReportMs: 3e5 });
+});
+var heartbeat_default = router4;
+
+// src/routes/skills.ts
+var import_express5 = require("express");
+var import_child_process3 = require("child_process");
+var import_util3 = require("util");
+var import_promises2 = require("fs/promises");
+var import_path2 = require("path");
+var execAsync3 = (0, import_util3.promisify)(import_child_process3.exec);
+var router5 = (0, import_express5.Router)();
+var SKILLS_DIRS = [
+  "/usr/local/lib/node_modules/openclaw/skills",
+  (0, import_path2.join)(process.env.HOME || "/root", ".openclaw/workspace/skills"),
+  (0, import_path2.join)(process.env.HOME || "/root", ".agents/skills")
+];
+router5.get("/skills", async (_req, res) => {
+  try {
+    try {
+      const { stdout } = await execAsync3("openclaw skill list --json 2>/dev/null || openclaw skill list 2>/dev/null");
+      if (stdout.trim()) {
+        try {
+          const skills2 = JSON.parse(stdout.trim());
+          res.json({ skills: skills2 });
+          return;
+        } catch {
+          const skills2 = stdout.trim().split("\n").filter(Boolean).map((name) => ({ name: name.trim() }));
+          res.json({ skills: skills2 });
+          return;
+        }
+      }
+    } catch {
+    }
+    const skills = [];
+    for (const dir of SKILLS_DIRS) {
+      try {
+        const entries = await (0, import_promises2.readdir)(dir, { withFileTypes: true });
+        for (const entry of entries) {
+          if (entry.isDirectory()) {
+            skills.push({ name: entry.name, path: (0, import_path2.join)(dir, entry.name) });
+          }
+        }
+      } catch {
+      }
+    }
+    res.json({ skills });
+  } catch (err) {
+    res.status(500).json({ error: "Failed to list skills", details: err.message });
+  }
+});
+router5.post("/skills/install", async (req, res) => {
+  const { name } = req.body;
+  if (!name || typeof name !== "string") {
+    res.status(400).json({ error: "Missing or invalid skill name" });
+    return;
+  }
+  if (!/^[a-zA-Z0-9_-]+$/.test(name)) {
+    res.status(400).json({ error: "Invalid skill name format" });
+    return;
+  }
+  try {
+    const { stdout, stderr } = await execAsync3(`openclaw skill install ${name}`, { timeout: 6e4 });
+    res.json({ status: "installed", name, output: stdout.trim() || stderr.trim() });
+  } catch (err) {
+    res.status(500).json({ error: "Failed to install skill", details: err.stderr || err.message });
+  }
+});
+router5.post("/skills/remove", async (req, res) => {
+  const { name } = req.body;
+  if (!name || typeof name !== "string") {
+    res.status(400).json({ error: "Missing or invalid skill name" });
+    return;
+  }
+  if (!/^[a-zA-Z0-9_-]+$/.test(name)) {
+    res.status(400).json({ error: "Invalid skill name format" });
+    return;
+  }
+  try {
+    const { stdout, stderr } = await execAsync3(`openclaw skill remove ${name}`, { timeout: 3e4 });
+    res.json({ status: "removed", name, output: stdout.trim() || stderr.trim() });
+  } catch (err) {
+    res.status(500).json({ error: "Failed to remove skill", details: err.stderr || err.message });
+  }
+});
+var skills_default = router5;
+
+// src/routes/messaging.ts
+var import_express6 = require("express");
+var import_child_process4 = require("child_process");
+var import_util4 = require("util");
+var execAsync4 = (0, import_util4.promisify)(import_child_process4.exec);
+var router6 = (0, import_express6.Router)();
+var VALID_PLATFORMS = ["whatsapp", "telegram", "signal", "discord", "slack"];
+var CLAW_USER = process.env.OPENCLAW_USER || "claw";
+async function runAsClaw(cmd, timeoutMs = 3e4) {
+  return execAsync4(`su - ${CLAW_USER} -c '${cmd.replace(/'/g, "'\\''")}'`, { timeout: timeoutMs });
+}
+async function setupTelegram(config) {
+  if (!config.botToken || typeof config.botToken !== "string") {
+    throw new Error("Missing botToken for Telegram setup");
+  }
+  await runAsClaw(`openclaw channels add --channel telegram --token ${config.botToken}`);
+  try {
+    await execAsync4("systemctl restart openclaw-sidecar", { timeout: 15e3 });
+    await new Promise((r) => setTimeout(r, 5e3));
+  } catch {
+    try {
+      await runAsClaw("openclaw gateway restart");
+    } catch {
+    }
+  }
+  return { status: "configured" };
+}
+async function setupWhatsApp(_config) {
+  try {
+    const { stdout } = await runAsClaw("openclaw channels status --channel whatsapp 2>/dev/null", 1e4);
+    if (stdout.toLowerCase().includes("connected") || stdout.toLowerCase().includes("active") || stdout.toLowerCase().includes("ready")) {
+      return { status: "connected" };
+    }
+  } catch {
+  }
+  try {
+    await runAsClaw("openclaw channels add --channel whatsapp");
+  } catch {
+  }
+  try {
+    await execAsync4("systemctl restart openclaw-sidecar", { timeout: 15e3 });
+    await new Promise((r) => setTimeout(r, 5e3));
+  } catch {
+  }
+  try {
+    const { stdout } = await runAsClaw("openclaw channels login --channel whatsapp --json 2>/dev/null", 3e4);
+    try {
+      const data = JSON.parse(stdout.trim());
+      if (data.qr) return { status: "pairing", qr: data.qr };
+      if (data.pairingCode) return { status: "pairing", pairingCode: data.pairingCode };
+    } catch {
+      const trimmed = stdout.trim();
+      if (trimmed.length > 20) return { status: "pairing", qr: trimmed };
+    }
+  } catch {
+  }
+  return { status: "pending" };
+}
+router6.post("/messaging/setup", async (req, res) => {
+  const { platform, config } = req.body;
+  if (!platform || !VALID_PLATFORMS.includes(platform)) {
+    res.status(400).json({ error: `Invalid platform. Must be one of: ${VALID_PLATFORMS.join(", ")}` });
+    return;
+  }
+  try {
+    let result;
+    switch (platform) {
+      case "telegram":
+        result = await setupTelegram(config || {});
+        break;
+      case "whatsapp":
+        result = await setupWhatsApp(config || {});
+        break;
+      default:
+        if (config?.token) {
+          await runAsClaw(`openclaw channels add --channel ${platform} --token ${config.token}`);
+        } else {
+          await runAsClaw(`openclaw channels add --channel ${platform}`);
+        }
+        try {
+          await execAsync4("systemctl restart openclaw-sidecar", { timeout: 15e3 });
+          await new Promise((r) => setTimeout(r, 3e3));
+        } catch {
+        }
+        result = { status: "configured" };
+        break;
+    }
+    res.json({ platform, ...result });
+  } catch (err) {
+    res.status(500).json({ error: `Failed to setup ${platform}`, details: err.message });
+  }
+});
+router6.get("/messaging/status", async (_req, res) => {
+  try {
+    const platforms = {};
+    try {
+      const { stdout } = await runAsClaw("openclaw channels list --json 2>/dev/null", 1e4);
+      const data = JSON.parse(stdout.trim());
+      const channels = Array.isArray(data) ? data : data.channels || [];
+      for (const ch of channels) {
+        const name = (ch.channel || ch.name || "").toLowerCase();
+        if (VALID_PLATFORMS.includes(name)) {
+          platforms[name] = {
+            configured: true,
+            connected: ch.connected !== void 0 ? ch.connected : ch.status === "connected"
+          };
+        }
+      }
+    } catch {
+    }
+    res.json({ platforms });
+  } catch (err) {
+    res.status(500).json({ error: "Failed to get messaging status", details: err.message });
+  }
+});
+router6.get("/messaging/whatsapp/qr", async (_req, res) => {
+  try {
+    try {
+      const { stdout } = await runAsClaw("openclaw channels status --channel whatsapp 2>/dev/null", 5e3);
+      if (stdout.toLowerCase().includes("connected") || stdout.toLowerCase().includes("ready")) {
+        res.json({ status: "connected" });
+        return;
+      }
+    } catch {
+    }
+    try {
+      const { stdout } = await runAsClaw("openclaw channels login --channel whatsapp --json 2>/dev/null", 15e3);
+      const data = JSON.parse(stdout.trim());
+      if (data.qr) {
+        res.json({ status: "pairing", qr: data.qr });
+        return;
+      }
+      if (data.pairingCode) {
+        res.json({ status: "pairing", pairingCode: data.pairingCode });
+        return;
+      }
+    } catch {
+    }
+    res.json({ status: "pending" });
+  } catch (err) {
+    res.status(500).json({ error: "Failed to get WhatsApp QR", details: err.message });
+  }
+});
+var messaging_default = router6;
+
+// src/index.ts
+var app = (0, import_express7.default)();
+var PORT = parseInt(process.env.PORT || "8787", 10);
+app.use(import_express7.default.json());
+app.use(authMiddleware);
+app.use(health_default);
+app.use(openclaw_default);
+app.use(heartbeat_default);
+app.use(skills_default);
+app.use(messaging_default);
+app.use(usage_default);
+app.listen(PORT, "0.0.0.0", () => {
+  console.log(`[sidecar] listening on port ${PORT}`);
+});
+var index_default = app;

--- a/apps/sidecar/package-lock.json
+++ b/apps/sidecar/package-lock.json
@@ -1,0 +1,1514 @@
+{
+  "name": "@handsoff/sidecar",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@handsoff/sidecar",
+      "version": "0.1.0",
+      "dependencies": {
+        "express": "^4.21.0"
+      },
+      "devDependencies": {
+        "@types/express": "^4.17.21",
+        "@types/node": "^20.11.0",
+        "tsx": "^4.7.0",
+        "typescript": "^5.3.3"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
+      "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
+      "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
+      "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
+      "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
+      "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
+      "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
+      "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
+      "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
+      "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
+      "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
+      "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
+      "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
+      "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
+      "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
+      "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
+      "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
+      "integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
+      "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
+      "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
+      "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
+      "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/express": {
+      "version": "4.17.25",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
+      "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
+        "@types/serve-static": "^1"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "4.19.8",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.8.tgz",
+      "integrity": "sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/mime": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.37",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
+      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "1.15.10",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.10.tgz",
+      "integrity": "sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*",
+        "@types/send": "<1"
+      }
+    },
+    "node_modules/@types/serve-static/node_modules/@types/send": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.6.tgz",
+      "integrity": "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.4",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
+      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.14.0",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
+      "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.4",
+        "@esbuild/android-arm": "0.27.4",
+        "@esbuild/android-arm64": "0.27.4",
+        "@esbuild/android-x64": "0.27.4",
+        "@esbuild/darwin-arm64": "0.27.4",
+        "@esbuild/darwin-x64": "0.27.4",
+        "@esbuild/freebsd-arm64": "0.27.4",
+        "@esbuild/freebsd-x64": "0.27.4",
+        "@esbuild/linux-arm": "0.27.4",
+        "@esbuild/linux-arm64": "0.27.4",
+        "@esbuild/linux-ia32": "0.27.4",
+        "@esbuild/linux-loong64": "0.27.4",
+        "@esbuild/linux-mips64el": "0.27.4",
+        "@esbuild/linux-ppc64": "0.27.4",
+        "@esbuild/linux-riscv64": "0.27.4",
+        "@esbuild/linux-s390x": "0.27.4",
+        "@esbuild/linux-x64": "0.27.4",
+        "@esbuild/netbsd-arm64": "0.27.4",
+        "@esbuild/netbsd-x64": "0.27.4",
+        "@esbuild/openbsd-arm64": "0.27.4",
+        "@esbuild/openbsd-x64": "0.27.4",
+        "@esbuild/openharmony-arm64": "0.27.4",
+        "@esbuild/sunos-x64": "0.27.4",
+        "@esbuild/win32-arm64": "0.27.4",
+        "@esbuild/win32-ia32": "0.27.4",
+        "@esbuild/win32-x64": "0.27.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
+      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.3",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.14.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.7.tgz",
+      "integrity": "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    }
+  }
+}

--- a/apps/sidecar/src/routes/messaging.ts
+++ b/apps/sidecar/src/routes/messaging.ts
@@ -1,8 +1,6 @@
 import { Router, Request, Response } from 'express';
-import { exec } from 'child_process';
+import { exec, spawn } from 'child_process';
 import { promisify } from 'util';
-import { readFile, writeFile, mkdir } from 'fs/promises';
-import { join } from 'path';
 
 const execAsync = promisify(exec);
 const router = Router();
@@ -10,21 +8,12 @@ const router = Router();
 type Platform = 'whatsapp' | 'telegram' | 'signal' | 'discord' | 'slack';
 const VALID_PLATFORMS: Platform[] = ['whatsapp', 'telegram', 'signal', 'discord', 'slack'];
 
-const OPENCLAW_CONFIG_PATH = join(process.env.HOME || '/root', '.openclaw/openclaw.json');
+// Home dir for the claw user (OpenClaw runs as this user)
+const CLAW_USER = process.env.OPENCLAW_USER || 'claw';
 
-async function readOpenclawConfig(): Promise<Record<string, any>> {
-  try {
-    const raw = await readFile(OPENCLAW_CONFIG_PATH, 'utf-8');
-    return JSON.parse(raw);
-  } catch {
-    return {};
-  }
-}
-
-async function writeOpenclawConfig(config: Record<string, any>): Promise<void> {
-  const dir = join(process.env.HOME || '/root', '.openclaw');
-  await mkdir(dir, { recursive: true });
-  await writeFile(OPENCLAW_CONFIG_PATH, JSON.stringify(config, null, 2), 'utf-8');
+/** Run a command as the claw user */
+async function runAsClaw(cmd: string, timeoutMs = 30_000): Promise<{ stdout: string; stderr: string }> {
+  return execAsync(`su - ${CLAW_USER} -c '${cmd.replace(/'/g, "'\\''")}'`, { timeout: timeoutMs });
 }
 
 async function setupTelegram(config: { botToken: string }): Promise<{ status: string }> {
@@ -32,101 +21,59 @@ async function setupTelegram(config: { botToken: string }): Promise<{ status: st
     throw new Error('Missing botToken for Telegram setup');
   }
 
-  const clawConfig = await readOpenclawConfig();
-  if (!clawConfig.plugins) clawConfig.plugins = {};
-  if (!clawConfig.plugins.entries) clawConfig.plugins.entries = {};
-  clawConfig.plugins.entries.telegram = {
-    enabled: true,
-    config: { botToken: config.botToken },
-  };
-  await writeOpenclawConfig(clawConfig);
+  // Use openclaw channels add to configure the Telegram bot
+  await runAsClaw(`openclaw channels add --channel telegram --token ${config.botToken}`);
 
-  // Restart openclaw to pick up new config
+  // Restart the gateway to pick up the new channel
   try {
-    await execAsync('systemctl restart openclaw');
+    await execAsync('systemctl restart openclaw-sidecar', { timeout: 15_000 });
+    // Wait for restart
+    await new Promise(r => setTimeout(r, 5000));
   } catch {
-    try { await execAsync('openclaw gateway restart'); } catch {}
+    // If systemctl fails, try restarting via openclaw CLI
+    try { await runAsClaw('openclaw gateway restart'); } catch {}
   }
 
   return { status: 'configured' };
 }
 
-async function setupWhatsApp(_config: Record<string, any>): Promise<{ status: string; qr?: string; pairingCode?: string }> {
+async function setupWhatsApp(_config: Record<string, unknown>): Promise<{ status: string; qr?: string; pairingCode?: string }> {
   // First check if already connected
   try {
-    const { stdout } = await execAsync('openclaw whatsapp status 2>/dev/null', { timeout: 10_000 });
-    if (stdout.includes('connected') || stdout.includes('active')) {
+    const { stdout } = await runAsClaw('openclaw channels status --channel whatsapp 2>/dev/null', 10_000);
+    if (stdout.toLowerCase().includes('connected') || stdout.toLowerCase().includes('active') || stdout.toLowerCase().includes('ready')) {
       return { status: 'connected' };
     }
   } catch {}
 
-  // Enable WhatsApp in OpenClaw config first
-  const clawConfig = await readOpenclawConfig();
-  if (!clawConfig.plugins) clawConfig.plugins = {};
-  if (!clawConfig.plugins.entries) clawConfig.plugins.entries = {};
-  if (!clawConfig.plugins.entries.whatsapp) {
-    clawConfig.plugins.entries.whatsapp = { enabled: true, config: {} };
-    await writeOpenclawConfig(clawConfig);
-    // Restart to pick up WhatsApp plugin
-    try {
-      await execAsync('systemctl restart openclaw', { timeout: 15_000 });
-      // Wait for restart
-      await new Promise(r => setTimeout(r, 3000));
-    } catch {
-      try { await execAsync('openclaw gateway restart', { timeout: 15_000 }); } catch {}
-    }
+  // Enable WhatsApp channel if not already configured
+  try {
+    await runAsClaw('openclaw channels add --channel whatsapp');
+  } catch {
+    // May already be configured
   }
 
-  // Try to get QR code
-  // OpenClaw outputs QR as a text string that needs to be rendered into a QR image
+  // Restart to ensure WhatsApp plugin is loaded
   try {
-    const { stdout, stderr } = await execAsync('openclaw whatsapp pair --json 2>/dev/null', { timeout: 30_000 });
+    await execAsync('systemctl restart openclaw-sidecar', { timeout: 15_000 });
+    await new Promise(r => setTimeout(r, 5000));
+  } catch {}
 
-    // Parse the output — openclaw should return JSON with qr field
+  // Try to get QR code via the login command
+  try {
+    const { stdout } = await runAsClaw('openclaw channels login --channel whatsapp --json 2>/dev/null', 30_000);
     try {
       const data = JSON.parse(stdout.trim());
-      if (data.qr) {
-        return { status: 'pairing', qr: data.qr };
-      }
-      if (data.pairingCode) {
-        return { status: 'pairing', pairingCode: data.pairingCode };
-      }
+      if (data.qr) return { status: 'pairing', qr: data.qr };
+      if (data.pairingCode) return { status: 'pairing', pairingCode: data.pairingCode };
     } catch {
-      // If not JSON, the stdout might be the raw QR string
-      if (stdout.trim().length > 20) {
-        return { status: 'pairing', qr: stdout.trim() };
-      }
+      // Not JSON, try to use raw output
+      const trimmed = stdout.trim();
+      if (trimmed.length > 20) return { status: 'pairing', qr: trimmed };
     }
+  } catch {}
 
-    // Check stderr for QR data too
-    if (stderr && stderr.trim().length > 20) {
-      return { status: 'pairing', qr: stderr.trim() };
-    }
-
-    return { status: 'pending' };
-  } catch {
-    // If the command fails, WhatsApp might need more time to initialize
-    return { status: 'pending' };
-  }
-}
-
-async function setupGeneric(platform: string, config: Record<string, any>): Promise<{ status: string }> {
-  const clawConfig = await readOpenclawConfig();
-  if (!clawConfig.plugins) clawConfig.plugins = {};
-  if (!clawConfig.plugins.entries) clawConfig.plugins.entries = {};
-  clawConfig.plugins.entries[platform] = {
-    enabled: true,
-    config,
-  };
-  await writeOpenclawConfig(clawConfig);
-
-  try {
-    await execAsync('systemctl restart openclaw');
-  } catch {
-    try { await execAsync('openclaw gateway restart'); } catch {}
-  }
-
-  return { status: 'configured' };
+  return { status: 'pending' };
 }
 
 router.post('/messaging/setup', async (req: Request, res: Response) => {
@@ -137,23 +84,28 @@ router.post('/messaging/setup', async (req: Request, res: Response) => {
     return;
   }
 
-  if (!config || typeof config !== 'object') {
-    res.status(400).json({ error: 'Missing config object' });
-    return;
-  }
-
   try {
-    let result: { status: string; qr?: string };
+    let result: { status: string; qr?: string; pairingCode?: string };
 
     switch (platform) {
       case 'telegram':
-        result = await setupTelegram(config);
+        result = await setupTelegram(config || {});
         break;
       case 'whatsapp':
-        result = await setupWhatsApp(config);
+        result = await setupWhatsApp(config || {});
         break;
       default:
-        result = await setupGeneric(platform, config);
+        // For other platforms, try generic channels add
+        if (config?.token) {
+          await runAsClaw(`openclaw channels add --channel ${platform} --token ${config.token}`);
+        } else {
+          await runAsClaw(`openclaw channels add --channel ${platform}`);
+        }
+        try {
+          await execAsync('systemctl restart openclaw-sidecar', { timeout: 15_000 });
+          await new Promise(r => setTimeout(r, 3000));
+        } catch {}
+        result = { status: 'configured' };
         break;
     }
 
@@ -165,21 +117,24 @@ router.post('/messaging/setup', async (req: Request, res: Response) => {
 
 router.get('/messaging/status', async (_req: Request, res: Response) => {
   try {
-    const config = await readOpenclawConfig();
-    const entries = config?.plugins?.entries || {};
-    const platforms: Record<string, { enabled: boolean; connected: boolean }> = {};
+    const platforms: Record<string, { configured: boolean; connected: boolean }> = {};
 
-    for (const p of VALID_PLATFORMS) {
-      const entry = entries[p];
-      if (entry) {
-        let connected = false;
-        try {
-          const { stdout } = await execAsync(`openclaw ${p} status 2>/dev/null`, { timeout: 5_000 });
-          connected = stdout.toLowerCase().includes('connected') || stdout.toLowerCase().includes('active');
-        } catch {}
-
-        platforms[p] = { enabled: !!entry.enabled, connected };
+    // Use openclaw channels list to check configured channels
+    try {
+      const { stdout } = await runAsClaw('openclaw channels list --json 2>/dev/null', 10_000);
+      const data = JSON.parse(stdout.trim());
+      const channels = Array.isArray(data) ? data : data.channels || [];
+      for (const ch of channels) {
+        const name = (ch.channel || ch.name || '').toLowerCase();
+        if (VALID_PLATFORMS.includes(name as Platform)) {
+          platforms[name] = {
+            configured: true,
+            connected: ch.connected !== undefined ? ch.connected : ch.status === 'connected',
+          };
+        }
       }
+    } catch {
+      // Channels list failed, return empty
     }
 
     res.json({ platforms });
@@ -188,66 +143,29 @@ router.get('/messaging/status', async (_req: Request, res: Response) => {
   }
 });
 
-// Dedicated WhatsApp QR polling endpoint — wizard calls this repeatedly
-// QR codes expire every ~20 seconds, so fresh codes are needed
+// WhatsApp QR polling endpoint
 router.get('/messaging/whatsapp/qr', async (_req: Request, res: Response) => {
   try {
-    // Check if already connected
+    // Check if connected
     try {
-      const { stdout } = await execAsync('openclaw whatsapp status 2>/dev/null', { timeout: 5_000 });
-      if (stdout.includes('connected') || stdout.includes('active')) {
+      const { stdout } = await runAsClaw('openclaw channels status --channel whatsapp 2>/dev/null', 5_000);
+      if (stdout.toLowerCase().includes('connected') || stdout.toLowerCase().includes('ready')) {
         res.json({ status: 'connected' });
         return;
       }
     } catch {}
 
-    // Get current QR
+    // Get fresh QR
     try {
-      const { stdout } = await execAsync('openclaw whatsapp pair --json 2>/dev/null', { timeout: 15_000 });
+      const { stdout } = await runAsClaw('openclaw channels login --channel whatsapp --json 2>/dev/null', 15_000);
       const data = JSON.parse(stdout.trim());
-      if (data.qr) {
-        res.json({ status: 'pairing', qr: data.qr });
-        return;
-      }
-      if (data.pairingCode) {
-        res.json({ status: 'pairing', pairingCode: data.pairingCode });
-        return;
-      }
+      if (data.qr) { res.json({ status: 'pairing', qr: data.qr }); return; }
+      if (data.pairingCode) { res.json({ status: 'pairing', pairingCode: data.pairingCode }); return; }
     } catch {}
 
     res.json({ status: 'pending' });
   } catch (err: any) {
     res.status(500).json({ error: 'Failed to get WhatsApp QR', details: err.message });
-  }
-});
-
-// Individual platform status check
-router.get('/messaging/status/:platform', async (req: Request, res: Response) => {
-  const { platform } = req.params;
-
-  if (!VALID_PLATFORMS.includes(platform as Platform)) {
-    res.status(400).json({ error: 'Invalid platform' });
-    return;
-  }
-
-  try {
-    const config = await readOpenclawConfig();
-    const entry = config?.plugins?.entries?.[platform];
-
-    if (!entry?.enabled) {
-      res.json({ configured: false, connected: false });
-      return;
-    }
-
-    let connected = false;
-    try {
-      const { stdout } = await execAsync(`openclaw ${platform} status 2>/dev/null`, { timeout: 5_000 });
-      connected = stdout.toLowerCase().includes('connected') || stdout.toLowerCase().includes('active');
-    } catch {}
-
-    res.json({ configured: true, connected });
-  } catch (err: any) {
-    res.status(500).json({ error: err.message });
   }
 });
 

--- a/apps/web/src/app/api/messaging/status/route.ts
+++ b/apps/web/src/app/api/messaging/status/route.ts
@@ -2,7 +2,7 @@ import { createClient } from '@/lib/supabase/server';
 import { getSession } from '@/lib/auth/session';
 import { NextResponse } from 'next/server';
 
-const SIDECAR_PORT = 8787;
+const SIDECAR_PORT = 8788;
 
 export async function GET() {
   try {

--- a/apps/web/src/lib/messaging/setup.ts
+++ b/apps/web/src/lib/messaging/setup.ts
@@ -10,7 +10,7 @@ export interface MessagingSetupResult {
   error?: string;
 }
 
-const SIDECAR_PORT = 8787;
+const SIDECAR_PORT = 8788;
 
 /**
  * Call the sidecar on the user's VM to configure a messaging platform.

--- a/apps/web/src/lib/providers/cloud-init.ts
+++ b/apps/web/src/lib/providers/cloud-init.ts
@@ -47,7 +47,7 @@ write_files:
     permissions: "0644"
     content: |
       [Unit]
-      Description=OpenClaw Sidecar Agent
+      Description=OpenClaw Gateway
       After=network-online.target
       Wants=network-online.target
       [Service]
@@ -55,6 +55,25 @@ write_files:
       User=${user}
       EnvironmentFile=/etc/shiftworker/sidecar.env
       ExecStart=/usr/bin/openclaw gateway run --bind lan --port 8787 --allow-unconfigured
+      Restart=always
+      RestartSec=5
+      [Install]
+      WantedBy=multi-user.target
+  - path: /etc/systemd/system/shiftworker-sidecar.service
+    permissions: "0644"
+    content: |
+      [Unit]
+      Description=ShiftWorker Sidecar API
+      After=openclaw-sidecar.service
+      Wants=openclaw-sidecar.service
+      [Service]
+      Type=simple
+      User=root
+      EnvironmentFile=/etc/shiftworker/sidecar.env
+      Environment=PORT=8788
+      Environment=OPENCLAW_USER=${user}
+      WorkingDirectory=/opt/shiftworker/sidecar
+      ExecStart=/usr/bin/node dist/sidecar.cjs
       Restart=always
       RestartSec=5
       [Install]
@@ -89,6 +108,7 @@ write_files:
       ufw allow 443/tcp
       ufw allow 3000/tcp
       ufw allow 8787/tcp
+      ufw allow 8788/tcp
       ufw --force enable
       curl -fsSL https://deb.nodesource.com/setup_${nodeVersion}.x | bash -
       apt-get install -y nodejs
@@ -97,8 +117,17 @@ write_files:
       su - ${user} -c "openclaw gateway install" || true
       # Configure gateway for LAN binding (required for sidecar to accept remote connections)
       python3 /opt/shiftworker/patch-config.py ${user}
+      # Install ShiftWorker sidecar from GitHub
+      mkdir -p /opt/shiftworker/sidecar
+      cd /opt/shiftworker/sidecar
+      curl -sf -L "https://raw.githubusercontent.com/jemustain/openclaw-saas/main/apps/sidecar/dist/sidecar.cjs" -o dist/sidecar.cjs || true
+      mkdir -p dist
+      echo '{"dependencies":{"express":"^4.21.0"}}' > package.json
+      npm install --production 2>/dev/null
+      # Start services
       systemctl daemon-reload
       systemctl enable --now openclaw-sidecar
+      systemctl enable --now shiftworker-sidecar
       source /etc/shiftworker/sidecar.env
       curl -sf -X POST "$PORTAL_URL/api/instances/$INSTANCE_ID/phone-home" \\
         -H "Authorization: Bearer $SIDECAR_TOKEN" \\

--- a/apps/web/src/lib/vm/provisioning-steps.ts
+++ b/apps/web/src/lib/vm/provisioning-steps.ts
@@ -254,7 +254,7 @@ export async function advanceProvisioning(assistant: Assistant): Promise<Assista
                 properties: {
                   priority: 1030, protocol: 'Tcp', access: 'Allow', direction: 'Inbound',
                   sourceAddressPrefix: '*', sourcePortRange: '*',
-                  destinationAddressPrefix: '*', destinationPortRange: '8787',
+                  destinationAddressPrefix: '*', destinationPortRange: '8787-8788',
                 },
               },
             ],


### PR DESCRIPTION
Builds and deploys the sidecar API that handles messenger configuration on user VMs.

**Sidecar API (port 8788):**
- `POST /messaging/setup` - Configure a messenger (Telegram bot token, WhatsApp QR)
- `GET /messaging/status` - Check which messengers are configured/connected
- `GET /messaging/whatsapp/qr` - Poll for fresh WhatsApp QR codes
- `GET /health` - Health check with system stats
- Auth via Bearer token (SIDECAR_TOKEN)

**Telegram flow:**
1. Portal creates bot via BotFather automation
2. Portal calls sidecar with bot token
3. Sidecar runs `openclaw channels add --channel telegram --token ...`
4. Sidecar restarts gateway to activate

**WhatsApp flow:**
1. Portal calls sidecar to initiate pairing
2. Sidecar runs `openclaw channels login --channel whatsapp --json`
3. Returns QR code for user to scan
4. Portal polls for connection status

**Deployment:**
- Sidecar bundled as single CJS file (sidecar.cjs, 20kb)
- Cloud-init downloads from GitHub, installs express, runs as systemd service
- Runs on port 8788 (gateway stays on 8787)
- NSG allows 8787-8788 range