### PR TITLE
feat: manual Telegram bot token entry (fallback when BotFather not configured)

### DIFF
--- a/apps/web/src/app/api/messaging/setup/route.ts
+++ b/apps/web/src/app/api/messaging/setup/route.ts
@@ -2,6 +2,7 @@ import { createClient } from '@/lib/supabase/server';
 import { getSession } from '@/lib/auth/session';
 import {
   setupTelegramForAssistant,
+  setupTelegramWithToken,
   setupWhatsAppForAssistant,
 } from '@/lib/messaging/setup';
 import { NextResponse } from 'next/server';
@@ -14,10 +15,11 @@ export async function POST(request: Request) {
     }
 
     const body = await request.json();
-    const { platform, assistantId, displayName } = body as {
+    const { platform, assistantId, displayName, botToken } = body as {
       platform: string;
       assistantId?: string;
       displayName?: string;
+      botToken?: string;
     };
 
     if (!platform) {
@@ -52,11 +54,19 @@ export async function POST(request: Request) {
     let result;
     switch (platform) {
       case 'telegram':
-        result = await setupTelegramForAssistant(
-          targetAssistantId!,
-          session.userId,
-          displayName,
-        );
+        if (botToken) {
+          // Manual token submission - configure sidecar directly
+          result = await setupTelegramWithToken(
+            targetAssistantId!,
+            botToken,
+          );
+        } else {
+          result = await setupTelegramForAssistant(
+            targetAssistantId!,
+            session.userId,
+            displayName,
+          );
+        }
         break;
       case 'whatsapp':
         result = await setupWhatsAppForAssistant(targetAssistantId!);

--- a/apps/web/src/app/onboarding/wizard.tsx
+++ b/apps/web/src/app/onboarding/wizard.tsx
@@ -492,11 +492,12 @@ export default function OnboardingWizard() {
     onReady?: (platform: string, link: string) => void;
   }) => {
     const info = MESSENGER_SETUP_INFO[messengerId];
-    const [status, setStatus] = useState<'waiting' | 'setting-up' | 'ready' | 'connected' | 'failed'>('waiting');
+    const [status, setStatus] = useState<'waiting' | 'setting-up' | 'ready' | 'connected' | 'failed' | 'manual-token'>('waiting');
     const [botLink, setBotLink] = useState<string | null>(null);
     const [qrCode, setQrCode] = useState<string | null>(null);
     const [error, setError] = useState<string | null>(null);
     const [qrExpired, setQrExpired] = useState(false);
+    const [manualToken, setManualToken] = useState('');
 
     const triggerSetup = useCallback(async () => {
       setStatus('setting-up');
@@ -516,8 +517,12 @@ export default function OnboardingWizard() {
         const data = await res.json();
 
         if (data.error) {
-          setError(data.error);
-          setStatus('failed');
+          if (data.error === 'manual_setup_required') {
+            setStatus('manual-token');
+          } else {
+            setError(data.error);
+            setStatus('failed');
+          }
         } else if (data.botLink) {
           setBotLink(data.botLink);
           setStatus('ready');
@@ -584,6 +589,7 @@ export default function OnboardingWizard() {
       status === 'setting-up' ? 'bg-amber-500/20 text-amber-400' :
       status === 'connected' ? 'bg-violet-500/20 text-violet-400' :
       status === 'failed' ? 'bg-red-500/20 text-red-400' :
+      status === 'manual-token' ? 'bg-blue-500/20 text-blue-400' :
       'bg-green-500/20 text-green-400';
 
     const badgeLabel =
@@ -591,6 +597,7 @@ export default function OnboardingWizard() {
       status === 'setting-up' ? 'Setting up…' :
       status === 'connected' ? 'Connected' :
       status === 'failed' ? 'Failed' :
+      status === 'manual-token' ? 'Setup' :
       'Ready';
 
     return (
@@ -679,6 +686,59 @@ export default function OnboardingWizard() {
         {/* Ready state — generic (no link, no QR) */}
         {status === 'ready' && !botLink && !qrCode && (
           <p className="text-xs text-slate-300">{info.readyMsg}</p>
+        )}
+
+        {/* Manual token entry (Telegram) */}
+        {status === 'manual-token' && messengerId === 'telegram' && (
+          <div className="space-y-3">
+            <div className="text-xs text-slate-300 space-y-1">
+              <p>Create a Telegram bot in 3 steps:</p>
+              <ol className="list-decimal ml-4 space-y-0.5">
+                <li>Open <a href="https://t.me/BotFather" target="_blank" rel="noopener noreferrer" className="text-blue-400 underline">@BotFather</a> in Telegram</li>
+                <li>Send <code className="bg-slate-800 px-1 rounded">/newbot</code> and follow the prompts</li>
+                <li>Copy the bot token and paste it below</li>
+              </ol>
+            </div>
+            <input
+              type="text"
+              value={manualToken}
+              onChange={(e) => setManualToken(e.target.value)}
+              placeholder="Paste bot token (e.g. 123456:ABC-DEF...)"
+              className="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-violet-500"
+            />
+            <button
+              type="button"
+              disabled={!manualToken.includes(':')}
+              onClick={async () => {
+                setStatus('setting-up');
+                setError(null);
+                try {
+                  const res = await fetch('/api/messaging/setup', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ platform: 'telegram', botToken: manualToken }),
+                  });
+                  const data = await res.json();
+                  if (data.status === 'configured') {
+                    setStatus('connected');
+                    if (data.botLink) {
+                      setBotLink(data.botLink);
+                      onReady?.('telegram', data.botLink);
+                    }
+                  } else if (data.error) {
+                    setError(data.error);
+                    setStatus('failed');
+                  }
+                } catch {
+                  setError('Failed to connect bot');
+                  setStatus('failed');
+                }
+              }}
+              className="w-full text-center rounded-lg bg-blue-600 hover:bg-blue-500 disabled:opacity-50 disabled:cursor-not-allowed py-2.5 text-sm font-medium transition"
+            >
+              Connect Bot
+            </button>
+          </div>
         )}
 
         {/* Connected state */}

--- a/apps/web/src/lib/messaging/setup.ts
+++ b/apps/web/src/lib/messaging/setup.ts
@@ -93,23 +93,91 @@ export async function setupTelegramForAssistant(
   }
 
   try {
-    // Create bot via BotFather
-    const bot = await createTelegramBot(userId, displayName);
+    // Check if BotFather automation is configured
+    const hasBotFactory = !!(process.env.TELEGRAM_API_ID && process.env.TELEGRAM_API_HASH && process.env.TELEGRAM_SESSION_STRING);
 
-    // Configure sidecar
-    await callSidecar(
-      assistant.ip_address,
-      assistant.sidecar_token,
-      'telegram',
-      { botToken: bot.botToken },
-    );
+    if (hasBotFactory) {
+      // Create bot via BotFather automation
+      const bot = await createTelegramBot(userId, displayName);
 
-    // Store bot details in assistant record
+      // Configure sidecar
+      await callSidecar(
+        assistant.ip_address,
+        assistant.sidecar_token,
+        'telegram',
+        { botToken: bot.botToken },
+      );
+
+      // Store bot details in assistant record
+      await (supabase as any)
+        .from('assistants')
+        .update({
+          telegram_bot_username: bot.botUsername,
+          telegram_bot_token: bot.botToken,
+          updated_at: new Date().toISOString(),
+        })
+        .eq('id', assistantId);
+
+      return {
+        platform: 'telegram',
+        status: 'configured',
+        botUsername: bot.botUsername,
+        botLink: `https://t.me/${bot.botUsername}`,
+      };
+    } else {
+      // BotFather automation not configured - return manual setup instructions
+      return {
+        platform: 'telegram',
+        status: 'pending',
+        error: 'manual_setup_required',
+      };
+    }
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { platform: 'telegram', status: 'failed', error: message };
+  }
+}
+
+/**
+ * Set up Telegram with a user-provided bot token.
+ * Skips BotFather automation - user creates their own bot.
+ */
+export async function setupTelegramWithToken(
+  assistantId: string,
+  botToken: string,
+): Promise<MessagingSetupResult> {
+  const supabase = createClient();
+
+  const { data: assistant } = await (supabase as any)
+    .from('assistants')
+    .select('ip_address, sidecar_token')
+    .eq('id', assistantId)
+    .single();
+
+  if (!assistant?.ip_address || !assistant?.sidecar_token) {
+    return { platform: 'telegram', status: 'pending', error: 'VM not ready yet' };
+  }
+
+  try {
+    await callSidecar(assistant.ip_address, assistant.sidecar_token, 'telegram', { botToken });
+
+    // Extract bot username from token (format: <id>:<hash>)
+    // We can get it from the Telegram getMe API
+    let botUsername = '';
+    try {
+      const meRes = await fetch(`https://api.telegram.org/bot${botToken}/getMe`);
+      const meData = await meRes.json();
+      if (meData.ok && meData.result?.username) {
+        botUsername = meData.result.username;
+      }
+    } catch {}
+
+    // Store in DB
     await (supabase as any)
       .from('assistants')
       .update({
-        telegram_bot_username: bot.botUsername,
-        telegram_bot_token: bot.botToken,
+        telegram_bot_token: botToken,
+        ...(botUsername ? { telegram_bot_username: botUsername } : {}),
         updated_at: new Date().toISOString(),
       })
       .eq('id', assistantId);
@@ -117,8 +185,7 @@ export async function setupTelegramForAssistant(
     return {
       platform: 'telegram',
       status: 'configured',
-      botUsername: bot.botUsername,
-      botLink: `https://t.me/${bot.botUsername}`,
+      ...(botUsername ? { botUsername, botLink: `https://t.me/${botUsername}` } : {}),
     };
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
When Telegram API credentials aren't set, the wizard shows a manual bot setup flow:
1. Instructions to create a bot via @BotFather
2. Token paste field
3. One-click connect that configures the sidecar

Also adds `setupTelegramWithToken()` which:
- Calls the sidecar to run `openclaw channels add --channel telegram --token ...`
- Verifies the token via Telegram's getMe API
- Stores bot details in the DB