### PR TITLE
feat: add messenger disconnect flow

### DIFF
--- a/apps/sidecar/src/routes/messaging.ts
+++ b/apps/sidecar/src/routes/messaging.ts
@@ -115,6 +115,32 @@ router.post('/messaging/setup', async (req: Request, res: Response) => {
   }
 });
 
+router.post('/messaging/teardown', async (req: Request, res: Response) => {
+  const { platform } = req.body;
+
+  if (!platform || !VALID_PLATFORMS.includes(platform)) {
+    res.status(400).json({ error: `Invalid platform. Must be one of: ${VALID_PLATFORMS.join(', ')}` });
+    return;
+  }
+
+  try {
+    // Remove the channel via openclaw CLI
+    await runAsClaw(`openclaw channels remove --channel ${platform}`);
+
+    // Restart gateway to apply changes
+    try {
+      await execAsync('systemctl restart openclaw-sidecar', { timeout: 15_000 });
+      await new Promise(r => setTimeout(r, 3000));
+    } catch {
+      try { await runAsClaw('openclaw gateway restart'); } catch {}
+    }
+
+    res.json({ status: 'removed', platform });
+  } catch (err: any) {
+    res.status(500).json({ error: `Failed to teardown ${platform}`, details: err.message });
+  }
+});
+
 router.get('/messaging/status', async (_req: Request, res: Response) => {
   try {
     const platforms: Record<string, { configured: boolean; connected: boolean }> = {};

--- a/apps/web/src/app/api/messaging/disconnect/route.ts
+++ b/apps/web/src/app/api/messaging/disconnect/route.ts
@@ -1,0 +1,63 @@
+import { createClient } from '@/lib/supabase/server';
+import { getSession } from '@/lib/auth/session';
+import { disconnectMessenger } from '@/lib/messaging/setup';
+import { NextResponse } from 'next/server';
+
+export async function POST(request: Request) {
+  try {
+    const session = await getSession();
+    if (!session) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const body = await request.json();
+    const { platform, assistantId } = body as {
+      platform: string;
+      assistantId?: string;
+    };
+
+    if (!platform) {
+      return NextResponse.json(
+        { error: 'platform is required' },
+        { status: 400 },
+      );
+    }
+
+    // Find the assistant — use provided ID or get the user's active one
+    const supabase: any = createClient();
+    let targetAssistantId = assistantId;
+    if (!targetAssistantId) {
+      const { data: assistant } = await supabase
+        .from('assistants')
+        .select('id')
+        .eq('user_id', session.userId)
+        .in('status', ['active', 'provisioning'])
+        .order('created_at', { ascending: false })
+        .limit(1)
+        .single();
+
+      if (!assistant) {
+        return NextResponse.json(
+          { error: 'No active assistant found' },
+          { status: 404 },
+        );
+      }
+      targetAssistantId = assistant.id;
+    }
+
+    const result = await disconnectMessenger(targetAssistantId!, platform);
+
+    if (!result.success) {
+      return NextResponse.json(
+        { error: result.error },
+        { status: 400 },
+      );
+    }
+
+    return NextResponse.json(result);
+  } catch (err: unknown) {
+    console.error('Messaging disconnect error:', err);
+    const message = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/apps/web/src/app/dashboard/components/connections-card.tsx
+++ b/apps/web/src/app/dashboard/components/connections-card.tsx
@@ -42,6 +42,7 @@ export function ConnectionsCard({
     MessengerStatus[]
   >([]);
   const [setupModal, setSetupModal] = useState<string | null>(null);
+  const [disconnecting, setDisconnecting] = useState<string | null>(null);
 
   const fetchMessengerStatus = useCallback(async () => {
     try {
@@ -62,6 +63,26 @@ export function ConnectionsCard({
       return () => clearInterval(interval);
     }
   }, [messengers.length, fetchMessengerStatus]);
+
+  const handleDisconnect = async (messengerKey: string) => {
+    setDisconnecting(messengerKey);
+    try {
+      const res = await fetch('/api/messaging/disconnect', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ platform: messengerKey }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        console.error('Disconnect failed:', data.error);
+      }
+    } catch (err) {
+      console.error('Disconnect error:', err);
+    } finally {
+      setDisconnecting(null);
+      fetchMessengerStatus();
+    }
+  };
 
   const providerConfig = hosting ? PROVIDER_CONFIG[hosting] : null;
 
@@ -147,15 +168,27 @@ export function ConnectionsCard({
                     ● {statusLabel}
                   </span>
                 </div>
-                {connected && botLink && (
-                  <a
-                    href={botLink}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="rounded-md bg-slate-800 px-3 py-1 text-xs text-slate-300 hover:bg-slate-700"
-                  >
-                    Open
-                  </a>
+                {connected && (
+                  <div className="flex items-center gap-2">
+                    {botLink && (
+                      <a
+                        href={botLink}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="rounded-md bg-slate-800 px-3 py-1 text-xs text-slate-300 hover:bg-slate-700"
+                      >
+                        Open
+                      </a>
+                    )}
+                    <button
+                      type="button"
+                      disabled={disconnecting === m}
+                      onClick={() => handleDisconnect(m)}
+                      className="rounded-md bg-red-900/50 px-3 py-1 text-xs text-red-400 hover:bg-red-900/80 disabled:opacity-50"
+                    >
+                      {disconnecting === m ? 'Disconnecting…' : 'Disconnect'}
+                    </button>
+                  </div>
                 )}
                 {!connected && configured && (
                   <button

--- a/apps/web/src/lib/messaging/setup.ts
+++ b/apps/web/src/lib/messaging/setup.ts
@@ -1,4 +1,4 @@
-import { createTelegramBot } from './telegram-bot-factory';
+import { createTelegramBot, deleteTelegramBot } from './telegram-bot-factory';
 import { createClient } from '../supabase/server';
 
 export interface MessagingSetupResult {
@@ -248,4 +248,118 @@ export async function setupWhatsAppForAssistant(
     const message = err instanceof Error ? err.message : String(err);
     return { platform: 'whatsapp', status: 'failed', error: message };
   }
+}
+
+/**
+ * Call the sidecar teardown endpoint to remove a messaging channel.
+ */
+async function callSidecarTeardown(
+  ipAddress: string,
+  sidecarToken: string,
+  platform: string,
+): Promise<void> {
+  const url = `http://${ipAddress}:${SIDECAR_PORT}/messaging/teardown`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${sidecarToken}`,
+    },
+    body: JSON.stringify({ platform }),
+    signal: AbortSignal.timeout(35_000),
+  });
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    throw new Error(`Sidecar ${platform} teardown failed (${res.status}): ${body}`);
+  }
+}
+
+export interface DisconnectResult {
+  success: boolean;
+  platform: string;
+  error?: string;
+}
+
+/**
+ * Disconnect a messaging platform from an assistant.
+ * Deletes the bot (for Telegram), tears down the sidecar channel, and clears DB.
+ * Errors in BotFather deletion are non-fatal — DB and sidecar are still cleaned up.
+ */
+export async function disconnectMessenger(
+  assistantId: string,
+  platform: string,
+): Promise<DisconnectResult> {
+  const supabase = await createClient();
+
+  const { data: assistant } = await (supabase as any)
+    .from('assistants')
+    .select('ip_address, sidecar_token, telegram_bot_username, telegram_bot_token')
+    .eq('id', assistantId)
+    .single();
+
+  if (!assistant) {
+    return { success: false, platform, error: 'Assistant not found' };
+  }
+
+  const errors: string[] = [];
+
+  if (platform === 'telegram') {
+    // Delete bot via BotFather (best-effort)
+    if (assistant.telegram_bot_username) {
+      try {
+        await deleteTelegramBot(assistant.telegram_bot_username);
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        errors.push(`BotFather delete failed: ${msg}`);
+      }
+    }
+
+    // Teardown sidecar channel (best-effort)
+    if (assistant.ip_address && assistant.sidecar_token) {
+      try {
+        await callSidecarTeardown(assistant.ip_address, assistant.sidecar_token, 'telegram');
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        errors.push(`Sidecar teardown failed: ${msg}`);
+      }
+    }
+
+    // Clear DB
+    await (supabase as any)
+      .from('assistants')
+      .update({
+        telegram_bot_username: null,
+        telegram_bot_token: null,
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', assistantId);
+  } else if (platform === 'whatsapp') {
+    // Teardown sidecar channel (best-effort)
+    if (assistant.ip_address && assistant.sidecar_token) {
+      try {
+        await callSidecarTeardown(assistant.ip_address, assistant.sidecar_token, 'whatsapp');
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        errors.push(`Sidecar teardown failed: ${msg}`);
+      }
+    }
+
+    // Clear DB
+    await (supabase as any)
+      .from('assistants')
+      .update({
+        whatsapp_connected: false,
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', assistantId);
+  } else {
+    return { success: false, platform, error: `Unsupported platform: ${platform}` };
+  }
+
+  return {
+    success: true,
+    platform,
+    ...(errors.length > 0 ? { error: errors.join('; ') } : {}),
+  };
 }

--- a/apps/web/src/lib/messaging/telegram-bot-factory.ts
+++ b/apps/web/src/lib/messaging/telegram-bot-factory.ts
@@ -113,8 +113,16 @@ export async function createTelegramBot(
         'Your personal AI assistant powered by ShiftWorker. I can manage your email, calendar, browse the web, and much more.',
     });
     await sleep(1000);
+
+    // Disable group privacy so bot can see all messages, not just @mentions
+    await tg.sendMessage(botFather, { message: '/setprivacy' });
+    await sleep(1000);
+    await tg.sendMessage(botFather, { message: `@${botUsername}` });
+    await sleep(1000);
+    await tg.sendMessage(botFather, { message: 'Disable' });
+    await sleep(1000);
   } catch {
-    // Non-critical — bot works without description
+    // Non-critical — bot works without description/privacy changes
   }
 
   return { botUsername, botToken, botDisplayName: botName };


### PR DESCRIPTION
## Changes

### 1. /setprivacy in bot creation
Disables group privacy mode after creating a bot via BotFather, so the bot can see all messages in groups (not just @mentions).

### 2. Disconnect API endpoint
`POST /api/messaging/disconnect` — accepts `{ platform, assistantId? }`, handles auth, delegates to `disconnectMessenger()`.

### 3. disconnectMessenger() in setup.ts
Core disconnect logic:
- **Telegram**: deletes bot via BotFather (best-effort), tears down sidecar channel, clears DB fields
- **WhatsApp**: tears down sidecar channel, clears DB
- Errors in BotFather deletion are non-fatal — DB and sidecar are always cleaned up

### 4. Sidecar teardown endpoint
`POST /messaging/teardown` — runs `openclaw channels remove` and restarts gateway.

### 5. Disconnect button in dashboard
Red/danger-styled button shown when a messenger is connected. Shows loading state while disconnecting, refreshes status after.