### PR TITLE
fix: dashboard connections card data format mismatch

### DIFF
--- a/apps/web/src/app/api/messaging/status/route.ts
+++ b/apps/web/src/app/api/messaging/status/route.ts
@@ -63,12 +63,13 @@ export async function GET() {
         );
         if (res.ok) {
           const live = await res.json();
+          const livePlatforms = live.platforms ?? live;
           // Merge live connection status
-          if (live.telegram?.connected !== undefined) {
-            platforms.telegram.connected = live.telegram.connected;
+          if (livePlatforms.telegram?.connected !== undefined) {
+            platforms.telegram.connected = livePlatforms.telegram.connected;
           }
-          if (live.whatsapp?.connected !== undefined) {
-            platforms.whatsapp.connected = live.whatsapp.connected;
+          if (livePlatforms.whatsapp?.connected !== undefined) {
+            platforms.whatsapp.connected = livePlatforms.whatsapp.connected;
           }
         }
       } catch {

--- a/apps/web/src/app/dashboard/components/connections-card.tsx
+++ b/apps/web/src/app/dashboard/components/connections-card.tsx
@@ -49,7 +49,17 @@ export function ConnectionsCard({
       const res = await fetch("/api/messaging/status");
       if (res.ok) {
         const data = await res.json();
-        setMessengerStatuses(data.statuses ?? []);
+        // Transform platforms object to array format
+        const platforms = data.platforms ?? {};
+        const statuses: MessengerStatus[] = Object.entries(platforms).map(
+          ([key, val]: [string, any]) => ({
+            messenger: key,
+            connected: val.connected ?? false,
+            configured: val.configured ?? false,
+            botLink: val.botLink ?? null,
+          })
+        );
+        setMessengerStatuses(statuses);
       }
     } catch {
       // silently fail
@@ -156,7 +166,7 @@ export function ConnectionsCard({
               statusLabel = "Connected";
             } else if (configured) {
               statusColor = "text-amber-400";
-              statusLabel = "Disconnected";
+              statusLabel = "Configured";
             }
 
             return (

--- a/apps/web/src/lib/supabase/types.ts
+++ b/apps/web/src/lib/supabase/types.ts
@@ -38,6 +38,7 @@ export interface User {
   timezone: string | null;
   window_start: number | null;
   onboarding_complete: boolean;
+  messengers: string[] | null;
   provider_preference: string | null;
   azure_subscription_id: string | null;
   created_at: string;


### PR DESCRIPTION
## Changes

- **connections-card.tsx**: Transform `data.platforms` object into array format instead of reading `data.statuses`
- **status/route.ts**: Fix sidecar response parsing to handle nested `platforms` key (`live.platforms?.telegram` vs `live.telegram`)
- **types.ts**: Add `messengers: string[] | null` to User interface
- Update configured-but-not-connected status label from "Disconnected" to "Configured" (yellow indicator)

## Status indicators
- 🟢 Connected — sidecar confirms bot is running
- 🟡 Configured — bot exists in DB but sidecar can't confirm
- ⚫ Not set up — no bot configured