### PR TITLE
feat: add sidecar auto-update via hourly cron

### DIFF
--- a/apps/sidecar/dist/sidecar.cjs
+++ b/apps/sidecar/dist/sidecar.cjs
@@ -55,8 +55,17 @@ var import_express = require("express");
 var import_os = __toESM(require("os"));
 var import_child_process = require("child_process");
 var import_util = require("util");
+var import_crypto = require("crypto");
+var import_fs = require("fs");
+var import_path = require("path");
 var execAsync = (0, import_util.promisify)(import_child_process.exec);
 var router = (0, import_express.Router)();
+var sidecarHash = "unknown";
+try {
+  const content = (0, import_fs.readFileSync)((0, import_path.resolve)(__dirname, "../sidecar.cjs"));
+  sidecarHash = (0, import_crypto.createHash)("sha256").update(content).digest("hex").slice(0, 12);
+} catch {
+}
 async function getDiskUsage() {
   try {
     const { stdout } = await execAsync("df -h / | tail -1 | awk '{print $2,$3,$4,$5}'");
@@ -109,6 +118,7 @@ router.get("/health", async (_req, res) => {
   res.json({
     status: "ok",
     uptime: process.uptime(),
+    sidecarVersion: sidecarHash,
     cpu: getCpuUsage(),
     memory: getMemoryUsage(),
     disk,
@@ -184,7 +194,7 @@ var import_express4 = require("express");
 // src/routes/usage.ts
 var import_express3 = require("express");
 var import_promises = require("fs/promises");
-var import_path = require("path");
+var import_path2 = require("path");
 var router3 = (0, import_express3.Router)();
 var USAGE_FILE = process.env.USAGE_FILE || "/var/lib/shiftworker/usage.json";
 function todayKey() {
@@ -199,7 +209,7 @@ async function readUsageStore() {
   }
 }
 async function writeUsageStore(store) {
-  await (0, import_promises.mkdir)((0, import_path.dirname)(USAGE_FILE), { recursive: true });
+  await (0, import_promises.mkdir)((0, import_path2.dirname)(USAGE_FILE), { recursive: true });
   await (0, import_promises.writeFile)(USAGE_FILE, JSON.stringify(store, null, 2), "utf-8");
 }
 function getOrCreateToday(store) {
@@ -372,13 +382,13 @@ var import_express5 = require("express");
 var import_child_process3 = require("child_process");
 var import_util3 = require("util");
 var import_promises2 = require("fs/promises");
-var import_path2 = require("path");
+var import_path3 = require("path");
 var execAsync3 = (0, import_util3.promisify)(import_child_process3.exec);
 var router5 = (0, import_express5.Router)();
 var SKILLS_DIRS = [
   "/usr/local/lib/node_modules/openclaw/skills",
-  (0, import_path2.join)(process.env.HOME || "/root", ".openclaw/workspace/skills"),
-  (0, import_path2.join)(process.env.HOME || "/root", ".agents/skills")
+  (0, import_path3.join)(process.env.HOME || "/root", ".openclaw/workspace/skills"),
+  (0, import_path3.join)(process.env.HOME || "/root", ".agents/skills")
 ];
 router5.get("/skills", async (_req, res) => {
   try {
@@ -403,7 +413,7 @@ router5.get("/skills", async (_req, res) => {
         const entries = await (0, import_promises2.readdir)(dir, { withFileTypes: true });
         for (const entry of entries) {
           if (entry.isDirectory()) {
-            skills.push({ name: entry.name, path: (0, import_path2.join)(dir, entry.name) });
+            skills.push({ name: entry.name, path: (0, import_path3.join)(dir, entry.name) });
           }
         }
       } catch {

--- a/apps/sidecar/scripts/auto-update.sh
+++ b/apps/sidecar/scripts/auto-update.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# ShiftWorker Sidecar Auto-Update
+# Runs via cron every hour. Downloads latest sidecar.cjs from GitHub,
+# compares checksum, and restarts if changed.
+
+set -euo pipefail
+
+SIDECAR_DIR="/opt/shiftworker/sidecar"
+SIDECAR_FILE="$SIDECAR_DIR/dist/sidecar.cjs"
+GITHUB_URL="https://raw.githubusercontent.com/jemustain/openclaw-saas/main/apps/sidecar/dist/sidecar.cjs"
+TMP_FILE="/tmp/sidecar-update.cjs"
+LOG_TAG="sidecar-update"
+
+# Download latest
+if ! curl -sf -L "$GITHUB_URL" -o "$TMP_FILE" 2>/dev/null; then
+  logger -t "$LOG_TAG" "Failed to download latest sidecar - skipping update"
+  rm -f "$TMP_FILE"
+  exit 0
+fi
+
+# Compare checksums
+CURRENT_HASH=""
+NEW_HASH=""
+if [ -f "$SIDECAR_FILE" ]; then
+  CURRENT_HASH=$(sha256sum "$SIDECAR_FILE" 2>/dev/null | cut -d' ' -f1)
+fi
+NEW_HASH=$(sha256sum "$TMP_FILE" 2>/dev/null | cut -d' ' -f1)
+
+if [ "$CURRENT_HASH" = "$NEW_HASH" ]; then
+  # No changes
+  rm -f "$TMP_FILE"
+  exit 0
+fi
+
+# Update
+logger -t "$LOG_TAG" "New sidecar version detected (${NEW_HASH:0:12}), updating..."
+mkdir -p "$SIDECAR_DIR/dist"
+cp "$TMP_FILE" "$SIDECAR_FILE"
+rm -f "$TMP_FILE"
+
+# Restart sidecar service
+if systemctl is-active --quiet shiftworker-sidecar 2>/dev/null; then
+  systemctl restart shiftworker-sidecar
+  logger -t "$LOG_TAG" "Sidecar restarted successfully"
+elif systemctl is-active --quiet openclaw-sidecar 2>/dev/null; then
+  systemctl restart openclaw-sidecar
+  logger -t "$LOG_TAG" "Sidecar restarted successfully"
+else
+  logger -t "$LOG_TAG" "Warning: No sidecar service found to restart"
+fi

--- a/apps/sidecar/src/routes/health.ts
+++ b/apps/sidecar/src/routes/health.ts
@@ -2,9 +2,18 @@ import { Router, Request, Response } from 'express';
 import os from 'os';
 import { exec } from 'child_process';
 import { promisify } from 'util';
+import { createHash } from 'crypto';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
 
 const execAsync = promisify(exec);
 const router = Router();
+
+let sidecarHash = 'unknown';
+try {
+  const content = readFileSync(resolve(__dirname, '../sidecar.cjs'));
+  sidecarHash = createHash('sha256').update(content).digest('hex').slice(0, 12);
+} catch {}
 
 async function getDiskUsage(): Promise<{ total: string; used: string; available: string; usePercent: string }> {
   try {
@@ -64,6 +73,7 @@ router.get('/health', async (_req: Request, res: Response) => {
   res.json({
     status: 'ok',
     uptime: process.uptime(),
+    sidecarVersion: sidecarHash,
     cpu: getCpuUsage(),
     memory: getMemoryUsage(),
     disk,

--- a/apps/web/src/lib/providers/cloud-init.ts
+++ b/apps/web/src/lib/providers/cloud-init.ts
@@ -123,6 +123,11 @@ write_files:
       curl -sf -L "https://raw.githubusercontent.com/jemustain/openclaw-saas/main/apps/sidecar/dist/sidecar.cjs" -o dist/sidecar.cjs
       echo '{"dependencies":{"express":"^4.21.0"}}' > package.json
       npm install --production 2>/dev/null
+      # Install sidecar auto-update script and cron job
+      curl -sf -L "https://raw.githubusercontent.com/jemustain/openclaw-saas/main/apps/sidecar/scripts/auto-update.sh" -o /opt/shiftworker/sidecar/auto-update.sh
+      chmod +x /opt/shiftworker/sidecar/auto-update.sh
+      echo "0 * * * * root /opt/shiftworker/sidecar/auto-update.sh" > /etc/cron.d/shiftworker-sidecar-update
+      chmod 644 /etc/cron.d/shiftworker-sidecar-update
       # Start services
       systemctl daemon-reload
       systemctl enable --now openclaw-sidecar


### PR DESCRIPTION
## Summary

Adds automatic sidecar updates on VMs via an hourly cron job.

### Changes

1. **`apps/sidecar/scripts/auto-update.sh`** — New script that downloads the latest `sidecar.cjs` from GitHub, compares SHA-256 checksums, and restarts the sidecar service only if the bundle changed.

2. **`apps/web/src/lib/providers/cloud-init.ts`** — Updated cloud-init to download the auto-update script and install a cron job (`/etc/cron.d/shiftworker-sidecar-update`) during VM provisioning.

3. **`apps/sidecar/src/routes/health.ts`** — Added `sidecarVersion` (first 12 chars of SHA-256 hash) to the health endpoint response for version tracking.

4. **`apps/sidecar/dist/sidecar.cjs`** — Rebuilt bundle with health endpoint changes.