### PR TITLE
feat: billing page, fix checkout redirect & secure portal route

### DIFF
--- a/apps/web/src/app/api/auth/me/route.ts
+++ b/apps/web/src/app/api/auth/me/route.ts
@@ -15,7 +15,18 @@ export async function GET() {
     .eq('id', session.userId)
     .single();
 
-  return NextResponse.json({ user: user ?? { email: session.email, name: session.name } });
+  const { data: subscription } = await supabase
+    .from('subscriptions')
+    .select('stripe_customer_id, stripe_subscription_id, plan, status, current_period_end')
+    .eq('user_id', session.userId)
+    .single();
+
+  return NextResponse.json({
+    user: {
+      ...(user ?? { email: session.email, name: session.name }),
+      subscription: subscription ?? null,
+    },
+  });
 }
 
 export async function PATCH(request: NextRequest) {

--- a/apps/web/src/app/api/stripe/checkout/route.ts
+++ b/apps/web/src/app/api/stripe/checkout/route.ts
@@ -16,6 +16,7 @@ export async function POST(req: NextRequest) {
 
     const body = await req.json().catch(() => ({}));
     const plan: PlanKey = body.plan ?? "pro";
+    const returnUrl: string | undefined = body.returnUrl;
 
     const planConfig = PLANS[plan];
     if (!planConfig || !planConfig.stripePriceId) {
@@ -28,8 +29,12 @@ export async function POST(req: NextRequest) {
       customer_email: session.email,
       metadata: { userId: session.userId, plan },
       line_items: [{ price: planConfig.stripePriceId, quantity: 1 }],
-      success_url: `${process.env.NEXT_PUBLIC_APP_URL}/dashboard?upgraded=true`,
-      cancel_url: `${process.env.NEXT_PUBLIC_APP_URL}/dashboard`,
+      success_url: returnUrl
+        ? `${process.env.NEXT_PUBLIC_APP_URL}${returnUrl}`
+        : `${process.env.NEXT_PUBLIC_APP_URL}/dashboard?upgraded=true`,
+      cancel_url: returnUrl
+        ? `${process.env.NEXT_PUBLIC_APP_URL}/onboarding`
+        : `${process.env.NEXT_PUBLIC_APP_URL}/dashboard`,
     });
 
     return NextResponse.json({ url: checkoutSession.url });

--- a/apps/web/src/app/api/stripe/portal/route.ts
+++ b/apps/web/src/app/api/stripe/portal/route.ts
@@ -1,29 +1,39 @@
 import { NextRequest, NextResponse } from "next/server";
 import { stripe } from "@/lib/stripe/client";
+import { getSession } from "@/lib/auth/session";
+import { createClient } from "@/lib/supabase/server";
 
 /**
  * POST /api/stripe/portal
- * Body: { customerId: string }
- *
- * Creates a Stripe Customer Portal session and returns the URL.
+ * Creates a Stripe Customer Portal session for the authenticated user.
  */
 export async function POST(req: NextRequest) {
   try {
-    const { customerId } = (await req.json()) as { customerId: string };
+    const session = await getSession();
+    if (!session) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
 
-    if (!customerId) {
+    const supabase: any = createClient();
+    const { data: subscription } = await supabase
+      .from("subscriptions")
+      .select("stripe_customer_id")
+      .eq("user_id", session.userId)
+      .single();
+
+    if (!subscription?.stripe_customer_id) {
       return NextResponse.json(
-        { error: "customerId is required" },
-        { status: 400 },
+        { error: "No subscription found" },
+        { status: 404 },
       );
     }
 
-    const session = await stripe.billingPortal.sessions.create({
-      customer: customerId,
-      return_url: `${process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000"}/billing`,
+    const portalSession = await stripe.billingPortal.sessions.create({
+      customer: subscription.stripe_customer_id,
+      return_url: `${process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000"}/dashboard/billing`,
     });
 
-    return NextResponse.json({ url: session.url });
+    return NextResponse.json({ url: portalSession.url });
   } catch (err: unknown) {
     console.error("Stripe portal error:", err);
     const message = err instanceof Error ? err.message : "Internal error";

--- a/apps/web/src/app/dashboard/billing/page.tsx
+++ b/apps/web/src/app/dashboard/billing/page.tsx
@@ -1,0 +1,162 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+interface Subscription {
+  stripe_customer_id: string;
+  stripe_subscription_id: string;
+  plan: string;
+  status: string;
+  current_period_end: string;
+}
+
+export default function BillingPage() {
+  const [plan, setPlan] = useState('free');
+  const [subscription, setSubscription] = useState<Subscription | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [portalLoading, setPortalLoading] = useState(false);
+  const [checkoutLoading, setCheckoutLoading] = useState(false);
+
+  useEffect(() => {
+    fetch('/api/auth/me')
+      .then((res) => res.json())
+      .then((data) => {
+        if (data.user) {
+          setPlan(data.user.plan ?? 'free');
+          setSubscription(data.user.subscription ?? null);
+        }
+      })
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, []);
+
+  async function openPortal() {
+    setPortalLoading(true);
+    try {
+      const res = await fetch('/api/stripe/portal', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      });
+      const data = await res.json();
+      if (data.url) window.location.href = data.url;
+    } catch {
+      // ignore
+    } finally {
+      setPortalLoading(false);
+    }
+  }
+
+  async function handleUpgrade() {
+    setCheckoutLoading(true);
+    try {
+      const res = await fetch('/api/stripe/checkout', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ plan: 'pro' }),
+      });
+      const data = await res.json();
+      if (data.url) window.location.href = data.url;
+    } catch {
+      // ignore
+    } finally {
+      setCheckoutLoading(false);
+    }
+  }
+
+  const isPro = plan === 'pro' || plan === 'Pro';
+  const isActive = subscription?.status === 'active' || subscription?.status === 'trialing';
+  const nextBilling = subscription?.current_period_end
+    ? new Date(subscription.current_period_end).toLocaleDateString('en-US', {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+      })
+    : null;
+
+  if (loading) {
+    return (
+      <div className="max-w-2xl space-y-8">
+        <h1 className="text-2xl font-bold text-white">Billing</h1>
+        <div className="rounded-xl border border-slate-800 bg-slate-900/50 p-6">
+          <p className="text-sm text-slate-400">Loading…</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-2xl space-y-8">
+      <h1 className="text-2xl font-bold text-white">Billing</h1>
+
+      {/* Current Plan */}
+      <section className="space-y-4 rounded-xl border border-slate-800 bg-slate-900/50 p-6">
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-white">Current Plan</h2>
+          {isPro && isActive && (
+            <span className="rounded-full bg-emerald-500/20 px-3 py-1 text-xs font-medium text-emerald-400">
+              Active
+            </span>
+          )}
+        </div>
+
+        <div className="space-y-1">
+          <p className="text-2xl font-bold text-white">
+            {isPro ? 'Pro' : 'Free'}
+            {isPro && <span className="ml-2 text-base font-normal text-slate-400">$12/mo</span>}
+          </p>
+          {isPro ? (
+            <p className="text-sm text-slate-400">
+              All messengers, pro skills, priority support
+            </p>
+          ) : (
+            <p className="text-sm text-slate-400">
+              Basic features included
+            </p>
+          )}
+        </div>
+
+        {isPro && nextBilling && (
+          <div className="rounded-lg border border-slate-700 bg-slate-800/50 p-4">
+            <p className="text-sm text-slate-400">Next billing date</p>
+            <p className="text-sm font-medium text-white">{nextBilling}</p>
+          </div>
+        )}
+
+        {isPro ? (
+          <button
+            onClick={openPortal}
+            disabled={portalLoading}
+            className="rounded-lg bg-violet-600 px-5 py-2 text-sm font-medium text-white hover:bg-violet-500 disabled:opacity-50 transition"
+          >
+            {portalLoading ? 'Loading…' : 'Manage Subscription'}
+          </button>
+        ) : (
+          <div className="space-y-3">
+            <div className="rounded-lg border border-violet-500/30 bg-violet-500/10 p-4">
+              <p className="text-sm font-medium text-violet-300">Upgrade to Pro — $12/mo</p>
+              <p className="text-xs text-slate-400 mt-1">
+                Unlock all messengers, pro skills, and priority support.
+              </p>
+            </div>
+            <button
+              onClick={handleUpgrade}
+              disabled={checkoutLoading}
+              className="rounded-lg bg-violet-600 px-5 py-2 text-sm font-medium text-white hover:bg-violet-500 disabled:opacity-50 transition"
+            >
+              {checkoutLoading ? 'Loading…' : 'Upgrade to Pro'}
+            </button>
+          </div>
+        )}
+      </section>
+
+      {/* Help */}
+      <section className="rounded-xl border border-slate-800 bg-slate-900/50 p-6">
+        <h2 className="text-lg font-semibold text-white mb-2">Need help?</h2>
+        <p className="text-sm text-slate-400">
+          To cancel or change your subscription, click &quot;Manage Subscription&quot; above to access
+          the Stripe Customer Portal. You can update payment methods, change plans, or cancel anytime.
+        </p>
+      </section>
+    </div>
+  );
+}

--- a/apps/web/src/app/onboarding/wizard.tsx
+++ b/apps/web/src/app/onboarding/wizard.tsx
@@ -1028,7 +1028,7 @@ export default function OnboardingWizard() {
                   const res = await fetch('/api/stripe/checkout', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ plan: 'pro' }),
+                    body: JSON.stringify({ plan: 'pro', returnUrl: '/onboarding?step=4&upgraded=true' }),
                   });
                   const data = await res.json();
                   if (data.url) {


### PR DESCRIPTION
## Changes

### 1. Fix Stripe checkout redirect for onboarding flow
- Added `returnUrl` parameter to `POST /api/stripe/checkout`
- Wizard now passes `returnUrl: '/onboarding?step=4&upgraded=true'` so users return to the messenger selection step after Stripe payment instead of `/dashboard`
- Cancel URL also adapts based on context (onboarding vs dashboard)

### 2. Create billing page (`/dashboard/billing`)
- Shows current plan (Free/Pro) with Active badge for active subscriptions
- Displays next billing date from `current_period_end`
- "Manage Subscription" button opens Stripe Customer Portal (Pro users)
- "Upgrade to Pro" button with pricing (Free users)
- Added subscription data to `GET /api/auth/me` response

### 3. Fix portal route security
- **Previously:** accepted arbitrary `customerId` from request body (any user could access any customer's portal)
- **Now:** authenticates via `getSession()`, looks up `stripe_customer_id` from the subscriptions table
- Return URL updated to `/dashboard/billing`