### PR TITLE
fix: WhatsApp setup via Control UI redirect

### DIFF
--- a/apps/sidecar/dist/sidecar.cjs
+++ b/apps/sidecar/dist/sidecar.cjs
@@ -4184,22 +4184,31 @@ async function setupWhatsApp(_config) {
     }
   }
   try {
-    const result = await gatewayRpc(
-      "web.login.start",
-      { channel: "whatsapp" },
-      3e4
-    );
-    if (result.qrDataUrl) {
-      return { platform: "whatsapp", status: "pairing", qr: result.qrDataUrl };
-    }
-    return { platform: "whatsapp", status: "pending" };
-  } catch (err) {
-    return {
-      platform: "whatsapp",
-      status: "failed",
-      error: err.message || "Gateway not ready - please wait a moment and try again"
-    };
+    await runAsClaw("openclaw channels add --channel whatsapp 2>/dev/null", 1e4);
+  } catch {
   }
+  let gatewayToken = "";
+  try {
+    const { stdout } = await runAsClaw(`cat ${CLAW_HOME}/.openclaw/openclaw.json`, 5e3);
+    const config = JSON.parse(stdout.trim());
+    gatewayToken = config?.gateway?.auth?.token ?? "";
+  } catch {
+  }
+  const controlUiUrl = `http://${getLocalIp()}:8787${gatewayToken ? `/#token=${gatewayToken}` : ""}`;
+  return { platform: "whatsapp", status: "pairing", controlUiUrl };
+}
+function getLocalIp() {
+  try {
+    const { networkInterfaces } = require("os");
+    const nets = networkInterfaces();
+    for (const name of Object.keys(nets)) {
+      for (const net of nets[name] ?? []) {
+        if (net.family === "IPv4" && !net.internal) return net.address;
+      }
+    }
+  } catch {
+  }
+  return "127.0.0.1";
 }
 router6.post("/messaging/setup", async (req, res) => {
   const { platform, config } = req.body;

--- a/apps/sidecar/src/routes/messaging.ts
+++ b/apps/sidecar/src/routes/messaging.ts
@@ -100,7 +100,7 @@ async function setupTelegram(config: { botToken: string }): Promise<{ status: st
   return { status: 'configured' };
 }
 
-async function setupWhatsApp(_config: Record<string, unknown>): Promise<{ platform: string; status: string; qr?: string; error?: string }> {
+async function setupWhatsApp(_config: Record<string, unknown>): Promise<{ platform: string; status: string; qr?: string; controlUiUrl?: string; error?: string }> {
   // Check if already connected via credential files
   if (whatsappCredentialsExist()) {
     try {
@@ -111,26 +111,40 @@ async function setupWhatsApp(_config: Record<string, unknown>): Promise<{ platfo
     } catch {}
   }
 
-  // Use Gateway WebSocket to start WhatsApp login and get QR
+  // Ensure WhatsApp channel is added to OpenClaw config
   try {
-    const result = await gatewayRpc<{ qrDataUrl?: string; message: string }>(
-      'web.login.start',
-      { channel: 'whatsapp' },
-      30_000
-    );
-
-    if (result.qrDataUrl) {
-      return { platform: 'whatsapp', status: 'pairing', qr: result.qrDataUrl };
-    }
-
-    return { platform: 'whatsapp', status: 'pending' };
-  } catch (err: any) {
-    return {
-      platform: 'whatsapp',
-      status: 'failed',
-      error: err.message || 'Gateway not ready - please wait a moment and try again',
-    };
+    await runAsClaw('openclaw channels add --channel whatsapp 2>/dev/null', 10_000);
+  } catch {
+    // May already be configured
   }
+
+  // Read gateway token from config for Control UI auth
+  let gatewayToken = '';
+  try {
+    const { stdout } = await runAsClaw(`cat ${CLAW_HOME}/.openclaw/openclaw.json`, 5_000);
+    const config = JSON.parse(stdout.trim());
+    gatewayToken = config?.gateway?.auth?.token ?? '';
+  } catch {}
+
+  // Return the Control UI URL - gateway serves it on port 8787
+  // The Control UI has built-in WhatsApp QR login
+  const controlUiUrl = `http://${getLocalIp()}:8787${gatewayToken ? `/#token=${gatewayToken}` : ''}`;
+
+  return { platform: 'whatsapp', status: 'pairing', controlUiUrl };
+}
+
+/** Get the VM's public-facing IP for Control UI URL */
+function getLocalIp(): string {
+  try {
+    const { networkInterfaces } = require('os');
+    const nets = networkInterfaces();
+    for (const name of Object.keys(nets)) {
+      for (const net of nets[name] ?? []) {
+        if (net.family === 'IPv4' && !net.internal) return net.address;
+      }
+    }
+  } catch {}
+  return '127.0.0.1';
 }
 
 router.post('/messaging/setup', async (req: Request, res: Response) => {

--- a/apps/web/src/app/dashboard/components/messenger-setup-modal.tsx
+++ b/apps/web/src/app/dashboard/components/messenger-setup-modal.tsx
@@ -58,6 +58,7 @@ export function MessengerSetupModal({
   >("setting-up");
   const [botLink, setBotLink] = useState<string | null>(null);
   const [qrCode, setQrCode] = useState<string | null>(null);
+  const [controlUiUrl, setControlUiUrl] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [qrExpired, setQrExpired] = useState(false);
   const [manualToken, setManualToken] = useState("");
@@ -88,6 +89,9 @@ export function MessengerSetupModal({
         }
       } else if (data.botLink) {
         setBotLink(data.botLink);
+        setStatus("ready");
+      } else if (data.controlUiUrl) {
+        setControlUiUrl(data.controlUiUrl);
         setStatus("ready");
       } else if (data.qr) {
         setQrCode(data.qr);
@@ -258,8 +262,28 @@ export function MessengerSetupModal({
             </div>
           )}
 
+        {/* Ready - Control UI link (WhatsApp) */}
+        {status === "ready" && controlUiUrl && !qrCode && (
+          <div className="space-y-3 pt-2">
+            <p className="text-sm text-slate-300">
+              Your assistant&apos;s control panel has a built-in WhatsApp setup. Tap the button below, then go to <strong>Channels</strong> and connect WhatsApp.
+            </p>
+            <a
+              href={controlUiUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="block w-full text-center rounded-lg bg-green-600 hover:bg-green-500 py-3 text-sm font-medium transition text-white"
+            >
+              Open Control Panel
+            </a>
+            <p className="text-xs text-slate-500 text-center">
+              Opens your assistant&apos;s dashboard in a new tab
+            </p>
+          </div>
+        )}
+
         {/* Ready - generic (no link, no QR) */}
-        {status === "ready" && !botLink && !qrCode && (
+        {status === "ready" && !botLink && !qrCode && !controlUiUrl && (
           <p className="text-sm text-slate-300 text-center py-4">
             {info.setupInstructions}
           </p>

--- a/apps/web/src/app/onboarding/wizard.tsx
+++ b/apps/web/src/app/onboarding/wizard.tsx
@@ -513,6 +513,7 @@ export default function OnboardingWizard() {
     const [status, setStatus] = useState<'waiting' | 'setting-up' | 'ready' | 'connected' | 'failed' | 'manual-token'>('waiting');
     const [botLink, setBotLink] = useState<string | null>(null);
     const [qrCode, setQrCode] = useState<string | null>(null);
+    const [controlUiUrl, setControlUiUrl] = useState<string | null>(null);
     const [error, setError] = useState<string | null>(null);
     const [qrExpired, setQrExpired] = useState(false);
     const [manualToken, setManualToken] = useState('');
@@ -545,6 +546,9 @@ export default function OnboardingWizard() {
           setBotLink(data.botLink);
           setStatus('ready');
           onReady?.(messengerId, data.botLink);
+        } else if (data.controlUiUrl) {
+          setControlUiUrl(data.controlUiUrl);
+          setStatus('ready');
         } else if (data.qr) {
           setQrCode(data.qr);
           setStatus('ready');
@@ -669,6 +673,23 @@ export default function OnboardingWizard() {
               alt={`Scan QR code with ${info.title}`}
               className="w-48 h-48 mx-auto rounded-lg"
             />
+          </div>
+        )}
+
+        {/* Ready state — WhatsApp Control UI link */}
+        {status === 'ready' && controlUiUrl && !qrCode && (
+          <div className="space-y-2">
+            <p className="text-xs text-slate-300">
+              Open your assistant&apos;s control panel to connect WhatsApp. Go to <strong>Channels</strong> and scan the QR code.
+            </p>
+            <a
+              href={controlUiUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="block w-full text-center rounded-lg bg-green-600 hover:bg-green-500 py-3 text-sm font-medium transition"
+            >
+              Open Control Panel
+            </a>
           </div>
         )}
 

--- a/apps/web/src/lib/messaging/setup.ts
+++ b/apps/web/src/lib/messaging/setup.ts
@@ -7,6 +7,7 @@ export interface MessagingSetupResult {
   botUsername?: string;
   botLink?: string;
   qr?: string;
+  controlUiUrl?: string;
   error?: string;
 }
 
@@ -243,6 +244,7 @@ export async function setupWhatsAppForAssistant(
       platform: 'whatsapp',
       status: 'pending',
       qr: result.qr as string,
+      controlUiUrl: result.controlUiUrl as string | undefined,
     };
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
Instead of proxying the QR through the sidecar (which requires the gateway's challenge-response WS handshake), redirects users to the VM's built-in Control UI which has native WhatsApp QR login.

The sidecar now returns a `controlUiUrl` with the gateway auth token embedded. The wizard and dashboard modal show an 'Open Control Panel' button that opens the VM's Control UI in a new tab.