### PR TITLE
fix: capture WhatsApp QR from CLI and serve as SVG

### DIFF
--- a/apps/sidecar/dist/sidecar.cjs
+++ b/apps/sidecar/dist/sidecar.cjs
@@ -4187,6 +4187,14 @@ async function setupWhatsApp(_config) {
     await runAsClaw("openclaw channels add --channel whatsapp 2>/dev/null", 1e4);
   } catch {
   }
+  try {
+    const qrData = await captureWhatsAppQr();
+    if (qrData) {
+      return { platform: "whatsapp", status: "pairing", qr: qrData };
+    }
+  } catch (err) {
+    console.error("WhatsApp QR capture failed:", err.message);
+  }
   let gatewayToken = "";
   try {
     const { stdout } = await runAsClaw(`cat ${CLAW_HOME}/.openclaw/openclaw.json`, 5e3);
@@ -4196,6 +4204,102 @@ async function setupWhatsApp(_config) {
   }
   const controlUiUrl = `http://${getLocalIp()}:8787${gatewayToken ? `/#token=${gatewayToken}` : ""}`;
   return { platform: "whatsapp", status: "pairing", controlUiUrl };
+}
+async function captureWhatsAppQr() {
+  return new Promise((resolve2) => {
+    const child = (0, import_child_process4.exec)(
+      `su - ${CLAW_USER} -c 'openclaw channels login --channel whatsapp 2>&1'`,
+      { timeout: 25e3 }
+    );
+    let output = "";
+    let resolved = false;
+    child.stdout?.on("data", (chunk) => {
+      output += chunk;
+      if (!resolved && output.includes("\u2588") && output.split("\n").length > 10) {
+        setTimeout(() => {
+          if (!resolved) {
+            resolved = true;
+            child.kill();
+            const qrImage = terminalQrToDataUrl(output);
+            resolve2(qrImage);
+          }
+        }, 2e3);
+      }
+    });
+    child.on("close", () => {
+      if (!resolved) {
+        resolved = true;
+        if (output.includes("\u2588")) {
+          resolve2(terminalQrToDataUrl(output));
+        } else {
+          resolve2(null);
+        }
+      }
+    });
+    child.on("error", () => {
+      if (!resolved) {
+        resolved = true;
+        resolve2(null);
+      }
+    });
+    setTimeout(() => {
+      if (!resolved) {
+        resolved = true;
+        child.kill();
+        resolve2(output.includes("\u2588") ? terminalQrToDataUrl(output) : null);
+      }
+    }, 22e3);
+  });
+}
+function terminalQrToDataUrl(termOutput) {
+  const lines = termOutput.split("\n").filter((l) => l.includes("\u2588") || l.includes("\u2584") || l.includes("\u2580"));
+  if (lines.length < 5) return null;
+  const scale = 4;
+  const rows = [];
+  for (const line of lines) {
+    const topRow = [];
+    const bottomRow = [];
+    for (const ch of line) {
+      switch (ch) {
+        case "\u2588":
+          topRow.push(true);
+          bottomRow.push(true);
+          break;
+        case "\u2580":
+          topRow.push(true);
+          bottomRow.push(false);
+          break;
+        case "\u2584":
+          topRow.push(false);
+          bottomRow.push(true);
+          break;
+        case " ":
+          topRow.push(false);
+          bottomRow.push(false);
+          break;
+        default:
+          topRow.push(true);
+          bottomRow.push(true);
+          break;
+      }
+    }
+    rows.push(topRow);
+    rows.push(bottomRow);
+  }
+  if (rows.length === 0) return null;
+  const width = Math.max(...rows.map((r) => r.length));
+  const height = rows.length;
+  let rects = "";
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < (rows[y]?.length ?? 0); x++) {
+      if (rows[y][x]) {
+        rects += `<rect x="${x * scale}" y="${y * scale}" width="${scale}" height="${scale}" fill="black"/>`;
+      }
+    }
+  }
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${width * scale}" height="${height * scale}" viewBox="0 0 ${width * scale} ${height * scale}"><rect width="100%" height="100%" fill="white"/>${rects}</svg>`;
+  const b64 = Buffer.from(svg).toString("base64");
+  return `data:image/svg+xml;base64,${b64}`;
 }
 function getLocalIp() {
   try {

--- a/apps/sidecar/src/routes/messaging.ts
+++ b/apps/sidecar/src/routes/messaging.ts
@@ -118,7 +118,17 @@ async function setupWhatsApp(_config: Record<string, unknown>): Promise<{ platfo
     // May already be configured
   }
 
-  // Read gateway token from config for Control UI auth
+  // Capture QR from the CLI login command
+  try {
+    const qrData = await captureWhatsAppQr();
+    if (qrData) {
+      return { platform: 'whatsapp', status: 'pairing', qr: qrData };
+    }
+  } catch (err: any) {
+    console.error('WhatsApp QR capture failed:', err.message);
+  }
+
+  // Fallback: return Control UI URL
   let gatewayToken = '';
   try {
     const { stdout } = await runAsClaw(`cat ${CLAW_HOME}/.openclaw/openclaw.json`, 5_000);
@@ -126,14 +136,143 @@ async function setupWhatsApp(_config: Record<string, unknown>): Promise<{ platfo
     gatewayToken = config?.gateway?.auth?.token ?? '';
   } catch {}
 
-  // Return the Control UI URL - gateway serves it on port 8787
-  // The Control UI has built-in WhatsApp QR login
   const controlUiUrl = `http://${getLocalIp()}:8787${gatewayToken ? `/#token=${gatewayToken}` : ''}`;
-
   return { platform: 'whatsapp', status: 'pairing', controlUiUrl };
 }
 
-/** Get the VM's public-facing IP for Control UI URL */
+/**
+ * Capture QR code from `openclaw channels login --channel whatsapp` CLI output.
+ * The CLI prints a Unicode block QR code to the terminal. We capture the raw
+ * QR string from the output and use it to generate a data URL.
+ */
+async function captureWhatsAppQr(): Promise<string | null> {
+  return new Promise((resolve) => {
+    const child = exec(
+      `su - ${CLAW_USER} -c 'openclaw channels login --channel whatsapp 2>&1'`,
+      { timeout: 25_000 },
+    );
+
+    let output = '';
+    let resolved = false;
+
+    child.stdout?.on('data', (chunk: string) => {
+      output += chunk;
+      // The QR code is printed as Unicode block characters
+      // Look for the pattern of block characters that form the QR
+      if (!resolved && output.includes('█') && output.split('\n').length > 10) {
+        // Give it a moment to finish printing
+        setTimeout(() => {
+          if (!resolved) {
+            resolved = true;
+            child.kill();
+            // Convert the terminal QR to a simple data format
+            // The QR data URL is what the UI needs to display
+            const qrImage = terminalQrToDataUrl(output);
+            resolve(qrImage);
+          }
+        }, 2000);
+      }
+    });
+
+    child.on('close', () => {
+      if (!resolved) {
+        resolved = true;
+        if (output.includes('█')) {
+          resolve(terminalQrToDataUrl(output));
+        } else {
+          resolve(null);
+        }
+      }
+    });
+
+    child.on('error', () => {
+      if (!resolved) { resolved = true; resolve(null); }
+    });
+
+    // Timeout fallback
+    setTimeout(() => {
+      if (!resolved) {
+        resolved = true;
+        child.kill();
+        resolve(output.includes('█') ? terminalQrToDataUrl(output) : null);
+      }
+    }, 22_000);
+  });
+}
+
+/**
+ * Convert terminal Unicode QR code to an SVG data URL.
+ * The terminal output uses block characters (█, ▄, ▀, space) to represent
+ * the QR code. We convert these to a black/white pixel grid and render as SVG.
+ */
+function terminalQrToDataUrl(termOutput: string): string | null {
+  const lines = termOutput.split('\n').filter(l => l.includes('█') || l.includes('▄') || l.includes('▀'));
+  if (lines.length < 5) return null;
+
+  const scale = 4;
+  // Each line represents 2 rows of the QR code (top/bottom halves using ▀▄█ characters)
+  // █ = both top and bottom black
+  // ▀ = top black, bottom white
+  // ▄ = top white, bottom black
+  // space = both white
+
+  const rows: boolean[][] = [];
+
+  for (const line of lines) {
+    const topRow: boolean[] = [];
+    const bottomRow: boolean[] = [];
+
+    for (const ch of line) {
+      switch (ch) {
+        case '█':
+          topRow.push(true);
+          bottomRow.push(true);
+          break;
+        case '▀':
+          topRow.push(true);
+          bottomRow.push(false);
+          break;
+        case '▄':
+          topRow.push(false);
+          bottomRow.push(true);
+          break;
+        case ' ':
+          topRow.push(false);
+          bottomRow.push(false);
+          break;
+        default:
+          // Other characters treated as black
+          topRow.push(true);
+          bottomRow.push(true);
+          break;
+      }
+    }
+    rows.push(topRow);
+    rows.push(bottomRow);
+  }
+
+  if (rows.length === 0) return null;
+
+  const width = Math.max(...rows.map(r => r.length));
+  const height = rows.length;
+
+  // Build SVG
+  let rects = '';
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < (rows[y]?.length ?? 0); x++) {
+      if (rows[y][x]) {
+        rects += `<rect x="${x * scale}" y="${y * scale}" width="${scale}" height="${scale}" fill="black"/>`;
+      }
+    }
+  }
+
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${width * scale}" height="${height * scale}" viewBox="0 0 ${width * scale} ${height * scale}"><rect width="100%" height="100%" fill="white"/>${rects}</svg>`;
+
+  const b64 = Buffer.from(svg).toString('base64');
+  return `data:image/svg+xml;base64,${b64}`;
+}
+
+/** Get the VM's network IP */
 function getLocalIp(): string {
   try {
     const { networkInterfaces } = require('os');


### PR DESCRIPTION
Captures the QR code from openclaw channels login terminal output, parses the Unicode block characters into a pixel grid, and renders as an inline SVG data URL. Falls back to Control UI URL if capture fails.