### PR TITLE
fix: phone-home sets ip_address to prevent VM-not-ready race

### DIFF
--- a/apps/web/src/app/api/assistant/status/route.ts
+++ b/apps/web/src/app/api/assistant/status/route.ts
@@ -26,12 +26,15 @@ export async function GET() {
 
     // If the assistant is mid-provisioning on Azure, advance one step.
     // Each step is a single API call that fits within the 10s timeout.
-    if (
-      assistant.status === 'provisioning' &&
+    // Also advance if status is 'active' but provisioning_step isn't done yet
+    // (race condition: phone-home set status before wait_vm fetched the IP).
+    const needsProvisioning =
       assistant.provider === 'azure' &&
       assistant.provisioning_step &&
-      assistant.provisioning_step !== 'done'
-    ) {
+      assistant.provisioning_step !== 'done' &&
+      (assistant.status === 'provisioning' || assistant.status === 'active');
+
+    if (needsProvisioning) {
       try {
         const updated = await advanceProvisioning(assistant);
         return NextResponse.json({ assistant: updated });

--- a/apps/web/src/app/api/instances/[instanceId]/phone-home/route.ts
+++ b/apps/web/src/app/api/instances/[instanceId]/phone-home/route.ts
@@ -35,15 +35,43 @@ export async function POST(
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
+  // Derive caller IP from the request (Vercel sets x-forwarded-for)
+  const callerIp =
+    request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
+    request.headers.get('x-real-ip') ||
+    null;
+
   if (record.status !== 'provisioning') {
-    // Already active or in another state — just acknowledge
+    // Already active - but backfill ip_address if missing (fixes race condition
+    // where phone-home arrived before the wait_vm step fetched the IP).
+    if (!record.ip_address && callerIp) {
+      await supabase
+        .from('assistants')
+        .update({
+          ip_address: callerIp,
+          provisioning_step: 'done',
+          updated_at: new Date().toISOString(),
+        })
+        .eq('id', instanceId);
+    }
     return NextResponse.json({ status: record.status });
   }
 
-  // Transition from provisioning → active
+  // Transition from provisioning -> active, set IP and mark provisioning done.
+  // This prevents a race where the frontend poll never runs wait_vm because
+  // status is already 'active'.
+  const updates: Record<string, any> = {
+    status: 'active',
+    provisioning_step: 'done',
+    updated_at: new Date().toISOString(),
+  };
+  if (callerIp) {
+    updates.ip_address = callerIp;
+  }
+
   const { error: updateError } = await supabase
     .from('assistants')
-    .update({ status: 'active', updated_at: new Date().toISOString() })
+    .update(updates)
     .eq('id', instanceId);
 
   if (updateError) {


### PR DESCRIPTION
## Problem
After onboarding, the WhatsApp QR modal shows "VM not ready yet" even though the Azure VM is running and both the OpenClaw gateway and sidecar are healthy.

**Root cause:** Race condition between phone-home and frontend polling.

1. Cloud-init finishes and the sidecar POSTs to `/api/instances/{id}/phone-home`
2. Phone-home sets `status = 'active'` but does NOT set `ip_address`
3. The frontend polls `/api/assistant/status`, but that only advances provisioning when `status === 'provisioning'`
4. Since status is already `active`, the `wait_vm` step (which fetches the public IP from Azure) never runs
5. `ip_address` stays null forever, and the QR endpoint returns "VM not ready"

## Fix
- **Phone-home** now extracts the caller IP from `x-forwarded-for` and sets `ip_address` + `provisioning_step = 'done'` in the same DB update
- **Phone-home** also backfills `ip_address` if the assistant is already `active` but missing an IP (handles reruns)
- **Status route** now advances provisioning for `active` assistants too (not just `provisioning`), as a fallback safety net