### PR TITLE
fix: expose Stripe checkout error detail

### DIFF
--- a/apps/web/src/app/api/stripe/checkout/route.ts
+++ b/apps/web/src/app/api/stripe/checkout/route.ts
@@ -38,10 +38,11 @@ export async function POST(req: NextRequest) {
     });
 
     return NextResponse.json({ url: checkoutSession.url });
-  } catch (error) {
+  } catch (error: any) {
     console.error("Stripe checkout error:", error);
+    const detail = error?.message ?? String(error);
     return NextResponse.json(
-      { error: "Failed to create checkout session" },
+      { error: "Failed to create checkout session", detail },
       { status: 500 },
     );
   }

--- a/apps/web/src/app/dashboard/components/plan-card.tsx
+++ b/apps/web/src/app/dashboard/components/plan-card.tsx
@@ -28,7 +28,7 @@ export function PlanCard({ plan }: { plan: PlanKey }) {
       if (data.url) {
         window.location.href = data.url;
       } else {
-        setError(data.error ?? "Failed to create checkout session");
+        setError(data.error ? `${data.error}${data.detail ? ': ' + data.detail : ''}` : "Failed to create checkout session");
         setLoading(false);
       }
     } catch (err) {


### PR DESCRIPTION
Shows the actual Stripe SDK error in the UI instead of a generic message. Needed for debugging the checkout failure.