### PR TITLE
fix: add env() helper that trims all environment variables

### DIFF
--- a/apps/web/src/app/api/stripe/checkout/route.ts
+++ b/apps/web/src/app/api/stripe/checkout/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { stripe } from "@/lib/stripe/client";
 import { PLANS, PlanKey } from "@/lib/stripe/config";
 import { getSession } from "@/lib/auth/session";
+import { env } from "@/lib/env";
 
 /**
  * POST /api/stripe/checkout
@@ -23,6 +24,8 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: "Invalid plan" }, { status: 400 });
     }
 
+    const appUrl = env("NEXT_PUBLIC_APP_URL") || "http://localhost:3000";
+
     const checkoutSession = await stripe.checkout.sessions.create({
       mode: "subscription",
       payment_method_types: ["card"],
@@ -30,11 +33,11 @@ export async function POST(req: NextRequest) {
       metadata: { userId: session.userId, plan },
       line_items: [{ price: planConfig.stripePriceId, quantity: 1 }],
       success_url: returnUrl
-        ? `${process.env.NEXT_PUBLIC_APP_URL}${returnUrl}`
-        : `${process.env.NEXT_PUBLIC_APP_URL}/dashboard?upgraded=true`,
+        ? `${appUrl}${returnUrl}`
+        : `${appUrl}/dashboard?upgraded=true`,
       cancel_url: returnUrl
-        ? `${process.env.NEXT_PUBLIC_APP_URL}/onboarding`
-        : `${process.env.NEXT_PUBLIC_APP_URL}/dashboard`,
+        ? `${appUrl}/onboarding`
+        : `${appUrl}/dashboard`,
     });
 
     return NextResponse.json({ url: checkoutSession.url });

--- a/apps/web/src/app/api/stripe/portal/route.ts
+++ b/apps/web/src/app/api/stripe/portal/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { stripe } from "@/lib/stripe/client";
 import { getSession } from "@/lib/auth/session";
 import { createClient } from "@/lib/supabase/server";
+import { env } from "@/lib/env";
 
 /**
  * POST /api/stripe/portal
@@ -30,7 +31,7 @@ export async function POST(req: NextRequest) {
 
     const portalSession = await stripe.billingPortal.sessions.create({
       customer: subscription.stripe_customer_id,
-      return_url: `${process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000"}/dashboard/billing`,
+      return_url: `${env("NEXT_PUBLIC_APP_URL") || "http://localhost:3000"}/dashboard/billing`,
     });
 
     return NextResponse.json({ url: portalSession.url });

--- a/apps/web/src/app/api/stripe/webhook/route.ts
+++ b/apps/web/src/app/api/stripe/webhook/route.ts
@@ -6,6 +6,7 @@ import { createClient } from "@/lib/supabase/server";
 import { resumeAssistant } from "@/lib/vm/lifecycle";
 import { handleCancellation } from "@/lib/billing/cancellation";
 import { onSubscriptionConfirmed, onPaymentFailed as sendPaymentFailedEmail } from "@/lib/email/triggers";
+import { env } from "@/lib/env";
 
 /**
  * POST /api/stripe/webhook
@@ -15,8 +16,9 @@ import { onSubscriptionConfirmed, onPaymentFailed as sendPaymentFailedEmail } fr
 export async function POST(req: NextRequest) {
   const body = await req.text();
   const sig = req.headers.get("stripe-signature");
+  const webhookSecret = env("STRIPE_WEBHOOK_SECRET");
 
-  if (!sig || !process.env.STRIPE_WEBHOOK_SECRET) {
+  if (!sig || !webhookSecret) {
     return NextResponse.json(
       { error: "Missing signature or webhook secret" },
       { status: 400 },
@@ -28,7 +30,7 @@ export async function POST(req: NextRequest) {
     event = stripe.webhooks.constructEvent(
       body,
       sig,
-      process.env.STRIPE_WEBHOOK_SECRET,
+      webhookSecret,
     );
   } catch (err) {
     console.error("Webhook signature verification failed:", err);

--- a/apps/web/src/lib/auth/google.ts
+++ b/apps/web/src/lib/auth/google.ts
@@ -1,11 +1,13 @@
+import { envRequired } from '../env';
+
 const GOOGLE_AUTH_URL = 'https://accounts.google.com/o/oauth2/v2/auth';
 const GOOGLE_TOKEN_URL = 'https://oauth2.googleapis.com/token';
 const GOOGLE_USERINFO_URL = 'https://www.googleapis.com/oauth2/v2/userinfo';
 
 export function getGoogleAuthURL(redirectPath?: string): string {
   const params = new URLSearchParams({
-    client_id: process.env.GOOGLE_CLIENT_ID!,
-    redirect_uri: process.env.GOOGLE_REDIRECT_URI!,
+    client_id: envRequired('GOOGLE_CLIENT_ID'),
+    redirect_uri: envRequired('GOOGLE_REDIRECT_URI'),
     response_type: 'code',
     scope: 'openid email profile',
     access_type: 'offline',
@@ -21,9 +23,9 @@ export async function exchangeCodeForTokens(code: string) {
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
     body: new URLSearchParams({
       code,
-      client_id: process.env.GOOGLE_CLIENT_ID!,
-      client_secret: process.env.GOOGLE_CLIENT_SECRET!,
-      redirect_uri: process.env.GOOGLE_REDIRECT_URI!,
+      client_id: envRequired('GOOGLE_CLIENT_ID'),
+      client_secret: envRequired('GOOGLE_CLIENT_SECRET'),
+      redirect_uri: envRequired('GOOGLE_REDIRECT_URI'),
       grant_type: 'authorization_code',
     }),
   });

--- a/apps/web/src/lib/auth/session.ts
+++ b/apps/web/src/lib/auth/session.ts
@@ -1,5 +1,6 @@
 import { SignJWT, jwtVerify } from 'jose';
 import { cookies } from 'next/headers';
+import { envRequired } from '../env';
 
 export interface Session {
   userId: string;
@@ -11,9 +12,7 @@ const COOKIE_NAME = 'session';
 const EXPIRY = '30d';
 
 function getSecret() {
-  const secret = process.env.SESSION_SECRET;
-  if (!secret) throw new Error('SESSION_SECRET is not set');
-  return new TextEncoder().encode(secret);
+  return new TextEncoder().encode(envRequired('SESSION_SECRET'));
 }
 
 export async function createSession(payload: Session): Promise<string> {

--- a/apps/web/src/lib/email/send.ts
+++ b/apps/web/src/lib/email/send.ts
@@ -1,9 +1,10 @@
 import { Resend } from 'resend';
+import { env } from '../env';
 
 // Lazy init to avoid build crashes when RESEND_API_KEY isn't set
 const resend = new Proxy({} as Resend, {
   get(_, prop) {
-    const instance = new Resend(process.env.RESEND_API_KEY);
+    const instance = new Resend(env('RESEND_API_KEY'));
     return (instance as unknown as Record<string | symbol, unknown>)[prop];
   },
 });
@@ -11,7 +12,7 @@ const resend = new Proxy({} as Resend, {
 const FROM_EMAIL = 'ShiftWorker <hello@shiftworker.ai>';
 
 export async function sendEmail(to: string, subject: string, html: string) {
-  if (!process.env.RESEND_API_KEY) {
+  if (!env('RESEND_API_KEY')) {
     console.warn('[email] RESEND_API_KEY not set, skipping email to', to);
     return null;
   }

--- a/apps/web/src/lib/env.ts
+++ b/apps/web/src/lib/env.ts
@@ -1,0 +1,19 @@
+/**
+ * Safe environment variable accessor.
+ * Always trims whitespace/newlines to guard against
+ * values set with trailing \n (common with piped CLI input).
+ */
+export function env(name: string): string | undefined {
+  return process.env[name]?.trim() || undefined;
+}
+
+/**
+ * Required environment variable - throws if missing.
+ */
+export function envRequired(name: string): string {
+  const value = env(name);
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value;
+}

--- a/apps/web/src/lib/stripe/client.ts
+++ b/apps/web/src/lib/stripe/client.ts
@@ -1,13 +1,11 @@
 import Stripe from "stripe";
+import { envRequired } from "../env";
 
 let _stripe: Stripe | null = null;
 
 export function getStripe(): Stripe {
   if (!_stripe) {
-    if (!process.env.STRIPE_SECRET_KEY) {
-      throw new Error("STRIPE_SECRET_KEY is not set");
-    }
-    _stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
+    _stripe = new Stripe(envRequired("STRIPE_SECRET_KEY"), {
       apiVersion: "2026-02-25.clover",
       typescript: true,
     });

--- a/apps/web/src/lib/stripe/config.ts
+++ b/apps/web/src/lib/stripe/config.ts
@@ -21,7 +21,7 @@ export const PLANS = {
   pro: {
     name: "Pro",
     priceMonthly: 1200, // $12.00 in cents
-    stripePriceId: process.env.STRIPE_PRICE_PRO || "price_pro_placeholder",
+    stripePriceId: process.env.STRIPE_PRICE_PRO?.trim() || "price_pro_placeholder",
     features: [
       "24/7 — assistant never sleeps",
       "Unlimited messages",

--- a/apps/web/src/lib/supabase/server.ts
+++ b/apps/web/src/lib/supabase/server.ts
@@ -1,5 +1,6 @@
 import { createClient as createSupabaseClient } from '@supabase/supabase-js';
 import type { Database } from './types';
+import { envRequired } from '../env';
 
 /**
  * Server-side Supabase client for database queries.
@@ -7,7 +8,7 @@ import type { Database } from './types';
  */
 export function createClient() {
   return createSupabaseClient<Database>(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    envRequired('NEXT_PUBLIC_SUPABASE_URL'),
+    envRequired('SUPABASE_SERVICE_ROLE_KEY'),
   );
 }


### PR DESCRIPTION
## Problem
Every env var on Vercel had a trailing `\n` character. This broke:
- **Stripe webhook** - signature verification failed (webhook secret had \n)
- **Stripe checkout** - URLs were invalid (`https://shiftworker.ai\n/dashboard`)
- **Supabase** - connection URLs were malformed
- Potentially Google OAuth, Resend emails, session signing

## Root Cause
Env vars were set via `echo "value" | vercel env add` (adds newline) instead of `echo -n "value" | vercel env add`.

## Fix
Created `lib/env.ts` with `env()` and `envRequired()` helpers that always `.trim()` values. Updated all critical paths to use them. The app is now resilient to whitespace in env vars regardless of how they were set.