### PR TITLE
fix: Stripe webhook crash + Telegram manual fallback

### DIFF
--- a/apps/web/src/app/api/stripe/webhook/route.ts
+++ b/apps/web/src/app/api/stripe/webhook/route.ts
@@ -92,22 +92,45 @@ async function handleCheckoutCompleted(session: Stripe.Checkout.Session) {
 
   const supabase: any = await createClient();
 
-  // Upsert subscription record
-  const { error: subError } = await supabase.from("subscriptions").upsert(
-    {
-      user_id: userId,
-      stripe_customer_id: customerId,
-      stripe_subscription_id: subscriptionId,
-      plan,
-      status: "active",
-      updated_at: new Date().toISOString(),
-    },
-    { onConflict: "user_id" },
-  );
+  // Insert or update subscription record.
+  // We avoid upsert({ onConflict: 'user_id' }) because the table may lack
+  // a unique constraint on user_id. Instead, check-then-insert/update.
+  const { data: existingSub } = await supabase
+    .from("subscriptions")
+    .select("id")
+    .eq("user_id", userId)
+    .maybeSingle();
 
-  if (subError) {
-    console.error("Failed to upsert subscription:", subError.message);
-    throw subError;
+  if (existingSub) {
+    const { error: subError } = await supabase
+      .from("subscriptions")
+      .update({
+        stripe_customer_id: customerId,
+        stripe_subscription_id: subscriptionId,
+        plan,
+        status: "active",
+        updated_at: new Date().toISOString(),
+      })
+      .eq("user_id", userId);
+    if (subError) {
+      console.error("Failed to update subscription:", subError.message);
+      throw subError;
+    }
+  } else {
+    const { error: subError } = await supabase
+      .from("subscriptions")
+      .insert({
+        user_id: userId,
+        stripe_customer_id: customerId,
+        stripe_subscription_id: subscriptionId,
+        plan,
+        status: "active",
+        updated_at: new Date().toISOString(),
+      });
+    if (subError) {
+      console.error("Failed to insert subscription:", subError.message);
+      throw subError;
+    }
   }
 
   // Update user's plan field

--- a/apps/web/src/lib/messaging/setup.ts
+++ b/apps/web/src/lib/messaging/setup.ts
@@ -95,7 +95,8 @@ export async function setupTelegramForAssistant(
 
   try {
     // Check if BotFather automation is configured
-    const hasBotFactory = !!(process.env.TELEGRAM_API_ID && process.env.TELEGRAM_API_HASH && process.env.TELEGRAM_SESSION_STRING);
+    const { env } = await import('../env');
+    const hasBotFactory = !!(env('TELEGRAM_API_ID') && env('TELEGRAM_API_HASH') && env('TELEGRAM_SESSION_STRING'));
 
     if (hasBotFactory) {
       // Create bot via BotFather automation

--- a/apps/web/src/lib/messaging/telegram-bot-factory.ts
+++ b/apps/web/src/lib/messaging/telegram-bot-factory.ts
@@ -8,9 +8,9 @@ interface BotCreationResult {
 }
 
 // Config from env
-const API_ID = parseInt(process.env.TELEGRAM_API_ID ?? '0', 10);
-const API_HASH = process.env.TELEGRAM_API_HASH ?? '';
-const SESSION_STRING = process.env.TELEGRAM_SESSION_STRING ?? '';
+const API_ID = parseInt((process.env.TELEGRAM_API_ID ?? '0').trim(), 10);
+const API_HASH = (process.env.TELEGRAM_API_HASH ?? '').trim();
+const SESSION_STRING = (process.env.TELEGRAM_SESSION_STRING ?? '').trim();
 
 // Singleton client
 let client: TelegramClient | null = null;

--- a/supabase/migrations/20260329_subscriptions_user_id_unique.sql
+++ b/supabase/migrations/20260329_subscriptions_user_id_unique.sql
@@ -1,0 +1,4 @@
+-- Add unique constraint on user_id so upsert works correctly.
+-- Each user should have at most one subscription record.
+ALTER TABLE subscriptions
+  ADD CONSTRAINT subscriptions_user_id_unique UNIQUE (user_id);


### PR DESCRIPTION
## Stripe webhook (the actual bug)
The `handleCheckoutCompleted` handler crashed with Postgres error `42P10: no unique constraint matching ON CONFLICT`. The `subscriptions` table was missing a unique constraint on `user_id`, so `upsert({ onConflict: 'user_id' })` always failed. This crashed the entire webhook handler, meaning the user's plan was never updated after payment.

**Fix:** Replaced upsert with explicit select-then-insert/update. Also added a migration SQL for the unique constraint.

## Telegram
BotFather automation was checking raw `process.env` values that could have whitespace, causing it to fall through to the manual setup path. Switched to trimmed values.