### PR TITLE
fix: auto-approve first Telegram pairing (replaces open dmPolicy)

### DIFF
--- a/apps/sidecar/dist/sidecar.cjs
+++ b/apps/sidecar/dist/sidecar.cjs
@@ -532,19 +532,6 @@ async function setupTelegram(config) {
   }
   await runAsClaw(`openclaw channels add --channel telegram --token ${config.botToken}`);
   try {
-    const configPath = `${CLAW_HOME}/.openclaw/openclaw.json`;
-    const fs = require("fs");
-    const config_data = fs.existsSync(configPath) ? JSON.parse(fs.readFileSync(configPath, "utf8")) : {};
-    const channels = config_data.channels = config_data.channels || {};
-    const tg = channels.telegram = channels.telegram || {};
-    tg.dmPolicy = "open";
-    fs.writeFileSync(configPath, JSON.stringify(config_data, null, 2));
-    const { execSync } = require("child_process");
-    execSync(`chown ${CLAW_USER}:${CLAW_USER} ${configPath}`);
-  } catch (err) {
-    console.error("Failed to set dmPolicy:", err.message);
-  }
-  try {
     await execAsync4("systemctl restart openclaw-sidecar", { timeout: 15e3 });
     await new Promise((r) => setTimeout(r, 5e3));
   } catch {
@@ -553,7 +540,32 @@ async function setupTelegram(config) {
     } catch {
     }
   }
+  autoApproveFirstPairing("telegram", 10 * 6e4);
   return { status: "configured" };
+}
+function autoApproveFirstPairing(channel, windowMs) {
+  const deadline = Date.now() + windowMs;
+  const poll = async () => {
+    if (Date.now() > deadline) return;
+    try {
+      const { stdout } = await runAsClaw(
+        `openclaw pairing list ${channel} --json 2>/dev/null`,
+        1e4
+      );
+      const requests = JSON.parse(stdout.trim() || "[]");
+      if (Array.isArray(requests) && requests.length > 0) {
+        const code = requests[0].code ?? requests[0].pairingCode;
+        if (code) {
+          await runAsClaw(`openclaw pairing approve ${channel} ${code}`, 1e4);
+          console.log(`[auto-pair] Approved ${channel} pairing code ${code}`);
+          return;
+        }
+      }
+    } catch {
+    }
+    setTimeout(poll, 5e3);
+  };
+  setTimeout(poll, 3e3);
 }
 async function setupWhatsApp(_config) {
   if (whatsappCredentialsExist()) {

--- a/apps/sidecar/src/routes/messaging.ts
+++ b/apps/sidecar/src/routes/messaging.ts
@@ -90,26 +90,6 @@ async function setupTelegram(config: { botToken: string }): Promise<{ status: st
 
   await runAsClaw(`openclaw channels add --channel telegram --token ${config.botToken}`);
 
-  // Set dmPolicy to "open" so the bot owner doesn't need pairing approval.
-  // ShiftWorker bots are personal — the person who set it up is the only user.
-  try {
-    const configPath = `${CLAW_HOME}/.openclaw/openclaw.json`;
-    const fs = require('fs');
-    const config_data = fs.existsSync(configPath)
-      ? JSON.parse(fs.readFileSync(configPath, 'utf8'))
-      : {};
-    const channels = config_data.channels = config_data.channels || {};
-    const tg = channels.telegram = channels.telegram || {};
-    tg.dmPolicy = 'open';
-    fs.writeFileSync(configPath, JSON.stringify(config_data, null, 2));
-    // Fix ownership
-    const { execSync } = require('child_process');
-    execSync(`chown ${CLAW_USER}:${CLAW_USER} ${configPath}`);
-  } catch (err: any) {
-    console.error('Failed to set dmPolicy:', err.message);
-    // Non-fatal — bot still works, just requires manual pairing
-  }
-
   try {
     await execAsync('systemctl restart openclaw-sidecar', { timeout: 15_000 });
     await new Promise(r => setTimeout(r, 5000));
@@ -117,7 +97,43 @@ async function setupTelegram(config: { botToken: string }): Promise<{ status: st
     try { await runAsClaw('openclaw gateway restart'); } catch {}
   }
 
+  // Auto-approve the first Telegram pairing request within the next 10 minutes.
+  // This lets the bot owner pair seamlessly while keeping strangers blocked.
+  autoApproveFirstPairing('telegram', 10 * 60_000);
+
   return { status: 'configured' };
+}
+
+/**
+ * Poll `openclaw pairing list <channel>` and approve the first pending request.
+ * Stops after one approval or when the timeout window closes.
+ */
+function autoApproveFirstPairing(channel: string, windowMs: number) {
+  const deadline = Date.now() + windowMs;
+  const poll = async () => {
+    if (Date.now() > deadline) return; // window expired
+    try {
+      const { stdout } = await runAsClaw(
+        `openclaw pairing list ${channel} --json 2>/dev/null`,
+        10_000,
+      );
+      const requests = JSON.parse(stdout.trim() || '[]');
+      if (Array.isArray(requests) && requests.length > 0) {
+        const code = requests[0].code ?? requests[0].pairingCode;
+        if (code) {
+          await runAsClaw(`openclaw pairing approve ${channel} ${code}`, 10_000);
+          console.log(`[auto-pair] Approved ${channel} pairing code ${code}`);
+          return; // done
+        }
+      }
+    } catch {
+      // pairing list may not return JSON or may have no requests yet
+    }
+    // Retry in 5 seconds
+    setTimeout(poll, 5_000);
+  };
+  // Start polling after a short delay (give the user time to open the bot)
+  setTimeout(poll, 3_000);
 }
 
 async function setupWhatsApp(_config: Record<string, unknown>): Promise<{ platform: string; status: string; qr?: string; controlUiUrl?: string; error?: string }> {


### PR DESCRIPTION
**Reverts** the `dmPolicy: 'open'` approach from #141 (security hole - anyone could message the bot).

**New approach:** Keep default `pairing` policy. After Telegram setup, the sidecar polls `openclaw pairing list telegram` every 5 seconds for up to 10 minutes. When the owner messages the bot and gets a pairing code, the sidecar auto-approves it. Strangers who find the bot later still get blocked by pairing.

This gives a seamless owner experience without opening the bot to the world.