### PR TITLE
fix: Use actual user plan for skill tier checks

### DIFF
--- a/apps/web/src/app/dashboard/skills/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/skills/[id]/page.tsx
@@ -18,8 +18,20 @@ export default function SkillDetailPage() {
   const [loading, setLoading] = useState(true);
   const [actionInProgress, setActionInProgress] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [userTier, setUserTier] = useState<SkillTier>("free");
 
-  const userTier: SkillTier = "free";
+  // Fetch user plan
+  useEffect(() => {
+    fetch("/api/auth/me")
+      .then((res) => res.ok ? res.json() : null)
+      .then((data) => {
+        const plan = data?.user?.plan ?? data?.user?.subscription?.plan;
+        if (plan === "pro" || plan === "starter") {
+          setUserTier(plan as SkillTier);
+        }
+      })
+      .catch(() => {});
+  }, []);
 
   const fetchStatus = useCallback(async () => {
     try {
@@ -82,7 +94,8 @@ export default function SkillDetailPage() {
     );
   }
 
-  const locked = skill.tier !== "free" && userTier === "free";
+  const tierRank: Record<SkillTier, number> = { free: 0, starter: 1, pro: 2 };
+  const locked = tierRank[skill.tier] > tierRank[userTier];
 
   return (
     <div className="min-h-screen bg-gray-950 text-gray-100 px-4 py-8 sm:px-6 lg:px-8 max-w-3xl mx-auto">

--- a/apps/web/src/app/dashboard/skills/page.tsx
+++ b/apps/web/src/app/dashboard/skills/page.tsx
@@ -23,9 +23,20 @@ export default function SkillsPage() {
   const [loading, setLoading] = useState(true);
   const [actionInProgress, setActionInProgress] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [userTier, setUserTier] = useState<SkillTier>("free");
 
-  // TODO: get from user session; for now assume free
-  const userTier: SkillTier = "free";
+  // Fetch user plan
+  useEffect(() => {
+    fetch("/api/auth/me")
+      .then((res) => res.ok ? res.json() : null)
+      .then((data) => {
+        const plan = data?.user?.plan ?? data?.user?.subscription?.plan;
+        if (plan === "pro" || plan === "starter") {
+          setUserTier(plan as SkillTier);
+        }
+      })
+      .catch(() => {});
+  }, []);
 
   const fetchInstalled = useCallback(async () => {
     try {
@@ -62,7 +73,8 @@ export default function SkillsPage() {
   }, [search, category]);
 
   async function toggleSkill(id: string, tier: SkillTier) {
-    if (tier !== "free" && userTier === "free") return;
+    const tierRank: Record<SkillTier, number> = { free: 0, starter: 1, pro: 2 };
+    if (tierRank[tier] > tierRank[userTier]) return;
     if (actionInProgress) return;
 
     const isInstalled = installedSkills.has(id);
@@ -160,7 +172,8 @@ export default function SkillsPage() {
       ) : (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
           {filtered.map((skill) => {
-            const locked = skill.tier !== "free" && userTier === "free";
+            const tierRank: Record<SkillTier, number> = { free: 0, starter: 1, pro: 2 };
+            const locked = tierRank[skill.tier] > tierRank[userTier];
             const isInstalled = installedSkills.has(skill.id);
             const isBusy = actionInProgress === skill.id;
 


### PR DESCRIPTION
The skills pages had `userTier` hardcoded to `"free"`, so Pro users were seeing 'Upgrade to unlock' on Starter/Pro skills.

**Changes:**
- Both `/dashboard/skills` and `/dashboard/skills/[id]` now fetch the user's actual plan from `/api/auth/me`
- Added proper tier hierarchy (`free < starter < pro`) for lock checks
- Pro users can now access all skills, Starter users can access free + starter skills