### PR TITLE
fix: Show cancellation state on billing page

### DIFF
--- a/apps/web/src/app/api/auth/me/route.ts
+++ b/apps/web/src/app/api/auth/me/route.ts
@@ -17,7 +17,7 @@ export async function GET() {
 
   const { data: subscription } = await supabase
     .from('subscriptions')
-    .select('stripe_customer_id, stripe_subscription_id, plan, status, current_period_end')
+    .select('stripe_customer_id, stripe_subscription_id, plan, status, current_period_end, cancel_at_period_end')
     .eq('user_id', session.userId)
     .single();
 

--- a/apps/web/src/app/api/stripe/webhook/route.ts
+++ b/apps/web/src/app/api/stripe/webhook/route.ts
@@ -192,11 +192,18 @@ async function handleSubscriptionUpdated(subscription: Stripe.Subscription) {
   const newPlan = plan ?? "free";
 
   // Update subscription
+  const rawSub = subscription as any;
+  const periodEnd = rawSub.current_period_end
+    ? new Date(rawSub.current_period_end * 1000).toISOString()
+    : null;
+
   const { error } = await supabase
     .from("subscriptions")
     .update({
       plan: newPlan,
       status: subscription.status,
+      cancel_at_period_end: subscription.cancel_at_period_end ?? false,
+      ...(periodEnd ? { current_period_end: periodEnd } : {}),
       updated_at: new Date().toISOString(),
     })
     .eq("stripe_subscription_id", subscription.id);

--- a/apps/web/src/app/dashboard/billing/page.tsx
+++ b/apps/web/src/app/dashboard/billing/page.tsx
@@ -8,6 +8,7 @@ interface Subscription {
   plan: string;
   status: string;
   current_period_end: string;
+  cancel_at_period_end: boolean;
 }
 
 export default function BillingPage() {
@@ -65,7 +66,9 @@ export default function BillingPage() {
 
   const isPro = plan === 'pro' || plan === 'Pro';
   const isActive = subscription?.status === 'active' || subscription?.status === 'trialing';
-  const nextBilling = subscription?.current_period_end
+  const isCancelling = isActive && subscription?.cancel_at_period_end === true;
+
+  const periodEndDate = subscription?.current_period_end
     ? new Date(subscription.current_period_end).toLocaleDateString('en-US', {
         year: 'numeric',
         month: 'long',
@@ -78,7 +81,7 @@ export default function BillingPage() {
       <div className="max-w-2xl space-y-8">
         <h1 className="text-2xl font-bold text-white">Billing</h1>
         <div className="rounded-xl border border-slate-800 bg-slate-900/50 p-6">
-          <p className="text-sm text-slate-400">Loading…</p>
+          <p className="text-sm text-slate-400">Loading...</p>
         </div>
       </div>
     );
@@ -92,9 +95,14 @@ export default function BillingPage() {
       <section className="space-y-4 rounded-xl border border-slate-800 bg-slate-900/50 p-6">
         <div className="flex items-center justify-between">
           <h2 className="text-lg font-semibold text-white">Current Plan</h2>
-          {isPro && isActive && (
-            <span className="rounded-full bg-emerald-500/20 px-3 py-1 text-xs font-medium text-emerald-400">
+          {isPro && isActive && !isCancelling && (
+            <span className="rounded-full bg-emerald-500/20 px-3 py-1 text-xs font-medium text-emerald-400 border border-emerald-500/30">
               Active
+            </span>
+          )}
+          {isCancelling && (
+            <span className="rounded-full bg-amber-500/20 px-3 py-1 text-xs font-medium text-amber-400 border border-amber-500/30">
+              Cancelling
             </span>
           )}
         </div>
@@ -115,10 +123,21 @@ export default function BillingPage() {
           )}
         </div>
 
-        {isPro && nextBilling && (
+        {/* Cancellation notice */}
+        {isCancelling && periodEndDate && (
+          <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 p-4">
+            <p className="text-sm font-medium text-amber-300">Your subscription has been cancelled</p>
+            <p className="text-sm text-slate-400 mt-1">
+              You&apos;ll continue to have Pro access until <span className="text-white font-medium">{periodEndDate}</span>. After that, your account will switch to the Free plan.
+            </p>
+          </div>
+        )}
+
+        {/* Next billing (only if not cancelling) */}
+        {isPro && isActive && !isCancelling && periodEndDate && (
           <div className="rounded-lg border border-slate-700 bg-slate-800/50 p-4">
             <p className="text-sm text-slate-400">Next billing date</p>
-            <p className="text-sm font-medium text-white">{nextBilling}</p>
+            <p className="text-sm font-medium text-white">{periodEndDate}</p>
           </div>
         )}
 
@@ -128,12 +147,12 @@ export default function BillingPage() {
             disabled={portalLoading}
             className="rounded-lg bg-violet-600 px-5 py-2 text-sm font-medium text-white hover:bg-violet-500 disabled:opacity-50 transition"
           >
-            {portalLoading ? 'Loading…' : 'Manage Subscription'}
+            {portalLoading ? 'Loading...' : isCancelling ? 'Reactivate Subscription' : 'Manage Subscription'}
           </button>
         ) : (
           <div className="space-y-3">
             <div className="rounded-lg border border-violet-500/30 bg-violet-500/10 p-4">
-              <p className="text-sm font-medium text-violet-300">Upgrade to Pro — $12/mo</p>
+              <p className="text-sm font-medium text-violet-300">Upgrade to Pro - $12/mo</p>
               <p className="text-xs text-slate-400 mt-1">
                 Unlock all messengers, pro skills, and priority support.
               </p>
@@ -143,7 +162,7 @@ export default function BillingPage() {
               disabled={checkoutLoading}
               className="rounded-lg bg-violet-600 px-5 py-2 text-sm font-medium text-white hover:bg-violet-500 disabled:opacity-50 transition"
             >
-              {checkoutLoading ? 'Loading…' : 'Upgrade to Pro'}
+              {checkoutLoading ? 'Loading...' : 'Upgrade to Pro'}
             </button>
           </div>
         )}

--- a/supabase/migrations/20260329_subscription_cancellation_fields.sql
+++ b/supabase/migrations/20260329_subscription_cancellation_fields.sql
@@ -1,0 +1,3 @@
+-- Add cancel_at_period_end and current_period_end to subscriptions
+ALTER TABLE public.subscriptions ADD COLUMN IF NOT EXISTS cancel_at_period_end boolean DEFAULT false;
+ALTER TABLE public.subscriptions ADD COLUMN IF NOT EXISTS current_period_end timestamptz;


### PR DESCRIPTION
When a user cancels via Stripe, the subscription stays active until the period ends. The billing page was still showing 'Active' with no indication of the pending cancellation.

**Changes:**
- New DB columns: `cancel_at_period_end` (boolean) and `current_period_end` (timestamptz) on subscriptions table
- Stripe webhook now stores these fields on `customer.subscription.updated`
- Billing page shows:
  - **Cancelling** badge (amber) instead of Active (green)
  - Notice: 'You'll continue to have Pro access until [date]'
  - Button changes to 'Reactivate Subscription'

**Migration required:** Run `20260329_subscription_cancellation_fields.sql` on the live DB before deploying.