### PR TITLE
feat: Real account deletion

### DIFF
--- a/apps/web/src/app/api/account/delete/route.ts
+++ b/apps/web/src/app/api/account/delete/route.ts
@@ -1,0 +1,115 @@
+import { NextResponse } from 'next/server';
+import { getSession, destroySession } from '@/lib/auth/session';
+import { createClient } from '@/lib/supabase/server';
+import { destroyAssistant } from '@/lib/vm/lifecycle';
+import { stripe } from '@/lib/stripe/client';
+
+/**
+ * POST /api/account/delete
+ *
+ * Permanently deletes a user's account and all associated data:
+ * 1. Destroys active/suspended VMs
+ * 2. Cancels Stripe subscription immediately
+ * 3. Deletes all DB records (assistants, subscriptions, provider_tokens, usage_logs, telegram_pairings, users, waitlist)
+ * 4. Destroys the session
+ */
+export async function POST() {
+  try {
+    const session = await getSession();
+    if (!session) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const userId = session.userId;
+    const userEmail = session.email;
+    const supabase: any = createClient();
+
+    console.log(`Account deletion started: user=${userId} email=${userEmail}`);
+
+    // 1. Destroy any active/suspended assistants (VMs)
+    const { data: assistants } = await supabase
+      .from('assistants')
+      .select('id, status')
+      .eq('user_id', userId)
+      .in('status', ['active', 'suspended', 'provisioning']);
+
+    for (const assistant of assistants ?? []) {
+      try {
+        await destroyAssistant(assistant.id);
+        console.log(`Destroyed assistant ${assistant.id} during account deletion`);
+      } catch (err) {
+        console.error(`Failed to destroy assistant ${assistant.id}:`, err);
+        // Continue with deletion even if VM destroy fails
+      }
+    }
+
+    // 2. Cancel Stripe subscription immediately (no grace period)
+    const { data: subscription } = await supabase
+      .from('subscriptions')
+      .select('stripe_subscription_id, stripe_customer_id')
+      .eq('user_id', userId)
+      .single();
+
+    if (subscription?.stripe_subscription_id) {
+      try {
+        await stripe.subscriptions.cancel(subscription.stripe_subscription_id);
+        console.log(`Cancelled Stripe subscription ${subscription.stripe_subscription_id}`);
+      } catch (err) {
+        console.error(`Failed to cancel Stripe subscription:`, err);
+        // Continue - subscription may already be cancelled
+      }
+    }
+
+    // 3. Delete all user data from DB (order matters for foreign keys)
+    const tables = [
+      'telegram_pairings',
+      'usage_logs',
+      'assistants',
+      'subscriptions',
+      'provider_tokens',
+    ];
+
+    for (const table of tables) {
+      const { error } = await supabase
+        .from(table)
+        .delete()
+        .eq('user_id', userId);
+
+      if (error) {
+        console.error(`Failed to delete from ${table}:`, error.message);
+        // Continue with other tables
+      }
+    }
+
+    // Delete waitlist entry by email
+    if (userEmail) {
+      await supabase
+        .from('waitlist')
+        .delete()
+        .eq('email', userEmail.toLowerCase());
+    }
+
+    // Delete the user record last
+    const { error: userDeleteError } = await supabase
+      .from('users')
+      .delete()
+      .eq('id', userId);
+
+    if (userDeleteError) {
+      console.error(`Failed to delete user record:`, userDeleteError.message);
+    }
+
+    console.log(`Account deletion complete: user=${userId}`);
+
+    // 4. Destroy the session
+    await destroySession();
+
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    console.error('Account deletion failed:', err);
+    return NextResponse.json(
+      { error: 'Account deletion failed. Please contact support.' },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/src/app/dashboard/settings/page.tsx
+++ b/apps/web/src/app/dashboard/settings/page.tsx
@@ -39,6 +39,8 @@ export default function SettingsPage() {
   const [saved, setSaved] = useState(false);
   const [showDelete, setShowDelete] = useState(false);
   const [deleteConfirm, setDeleteConfirm] = useState('');
+  const [deleting, setDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
 
   useEffect(() => {
     fetch('/api/auth/me')
@@ -68,8 +70,21 @@ export default function SettingsPage() {
 
   async function handleDelete() {
     if (deleteConfirm !== 'DELETE') return;
-    await fetch('/api/auth/signout', { method: 'POST' });
-    router.push('/');
+    setDeleting(true);
+    setDeleteError(null);
+    try {
+      const res = await fetch('/api/account/delete', { method: 'POST' });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        setDeleteError(data.error ?? 'Deletion failed. Please try again.');
+        setDeleting(false);
+        return;
+      }
+      router.push('/');
+    } catch {
+      setDeleteError('Something went wrong. Please try again.');
+      setDeleting(false);
+    }
   }
 
   const inputClass = 'w-full rounded-lg border border-slate-700 bg-slate-800 px-4 py-2.5 text-sm text-white placeholder-slate-500 focus:border-violet-500 focus:outline-none';
@@ -127,7 +142,8 @@ export default function SettingsPage() {
       <section className="rounded-xl border border-slate-800 bg-slate-900/50 p-6 space-y-4">
         <h2 className="text-sm font-semibold text-slate-400 uppercase tracking-wider">Danger Zone</h2>
         <p className="text-sm text-slate-400">
-          Permanently delete your account and all associated data. This action cannot be undone.
+          Permanently delete your account and all associated data. This will destroy your assistant,
+          cancel any active subscription, and remove all your data. This action cannot be undone.
         </p>
         {!showDelete ? (
           <button
@@ -138,24 +154,29 @@ export default function SettingsPage() {
           </button>
         ) : (
           <div className="space-y-3 rounded-lg border border-red-800/50 bg-red-950/20 p-4">
+            {deleteError && (
+              <p className="text-sm text-red-400">{deleteError}</p>
+            )}
             <p className="text-sm text-slate-300">Type <code className="bg-slate-800 px-1.5 py-0.5 rounded text-red-400 text-xs font-mono">DELETE</code> to confirm:</p>
             <input
               value={deleteConfirm}
               onChange={(e) => setDeleteConfirm(e.target.value)}
               placeholder="DELETE"
-              className="w-full max-w-xs rounded-lg border border-red-800/50 bg-slate-900 px-4 py-2 text-sm text-white focus:outline-none focus:border-red-600"
+              disabled={deleting}
+              className="w-full max-w-xs rounded-lg border border-red-800/50 bg-slate-900 px-4 py-2 text-sm text-white focus:outline-none focus:border-red-600 disabled:opacity-50"
             />
             <div className="flex gap-3">
               <button
                 onClick={handleDelete}
-                disabled={deleteConfirm !== 'DELETE'}
+                disabled={deleteConfirm !== 'DELETE' || deleting}
                 className="rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-500 disabled:opacity-50 transition"
               >
-                Permanently Delete
+                {deleting ? 'Deleting...' : 'Permanently Delete'}
               </button>
               <button
-                onClick={() => { setShowDelete(false); setDeleteConfirm(''); }}
-                className="rounded-lg border border-slate-700 px-4 py-2 text-sm text-slate-300 hover:bg-slate-800 transition"
+                onClick={() => { setShowDelete(false); setDeleteConfirm(''); setDeleteError(null); }}
+                disabled={deleting}
+                className="rounded-lg border border-slate-700 px-4 py-2 text-sm text-slate-300 hover:bg-slate-800 transition disabled:opacity-50"
               >
                 Cancel
               </button>


### PR DESCRIPTION
The delete account button previously just signed the user out. Now it actually deletes everything:

1. **Destroys VMs** - any active/suspended assistants get destroyed
2. **Cancels Stripe** - subscription cancelled immediately (no grace period)
3. **Deletes all data** - telegram_pairings, usage_logs, assistants, subscriptions, provider_tokens, waitlist entry, and user record
4. **Signs out** - session destroyed, redirect to home

Also adds loading state and error handling to the delete confirmation UI.