### PR TITLE
feat: Email signup placeholder on sign-in page

### DIFF
--- a/apps/web/src/app/auth/signin/page.tsx
+++ b/apps/web/src/app/auth/signin/page.tsx
@@ -3,6 +3,7 @@
 import { Suspense } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
+import { Mail } from 'lucide-react';
 
 function GoogleIcon() {
   return (
@@ -45,6 +46,28 @@ function Inner() {
           <GoogleIcon />
           Continue with Google
         </a>
+
+        <div className="relative">
+          <div className="absolute inset-0 flex items-center">
+            <div className="w-full border-t border-gray-800" />
+          </div>
+          <div className="relative flex justify-center text-xs">
+            <span className="bg-gray-950 px-2 text-gray-500">or</span>
+          </div>
+        </div>
+
+        <div className="relative">
+          <button
+            disabled
+            className="w-full flex items-center justify-center rounded-lg border border-gray-800 bg-gray-900/50 px-4 py-2.5 text-sm text-gray-600 cursor-not-allowed"
+          >
+            <Mail className="w-5 h-5 mr-2" />
+            Continue with Email
+          </button>
+          <span className="absolute -top-2 right-3 bg-gray-950 px-2 text-[10px] font-medium text-gray-500 uppercase tracking-wider">
+            Coming Soon
+          </span>
+        </div>
       </div>
     </main>
   );


### PR DESCRIPTION
Adds a grayed-out 'Continue with Email' button with a 'Coming Soon' badge on the sign-in page, below the existing Google sign-in. Button is disabled and non-interactive - just a visual placeholder.