### PR TITLE
fix: add ws dependency to sidecar cloud-init

### DIFF
--- a/apps/web/src/lib/providers/cloud-init.ts
+++ b/apps/web/src/lib/providers/cloud-init.ts
@@ -121,7 +121,7 @@ write_files:
       mkdir -p /opt/shiftworker/sidecar/dist
       cd /opt/shiftworker/sidecar
       curl -sf -L "https://raw.githubusercontent.com/jemustain/openclaw-saas/main/apps/sidecar/dist/sidecar.cjs" -o dist/sidecar.cjs
-      echo '{"dependencies":{"express":"^4.21.0"}}' > package.json
+      echo '{"dependencies":{"express":"^4.21.0","ws":"^8.18.0"}}' > package.json
       npm install --production 2>/dev/null
       # Install sidecar auto-update script and cron job
       curl -sf -L "https://raw.githubusercontent.com/jemustain/openclaw-saas/main/apps/sidecar/scripts/auto-update.sh" -o /opt/shiftworker/sidecar/auto-update.sh


### PR DESCRIPTION
The sidecar bundle requires `ws` for WebSocket support (WhatsApp QR flow), but cloud-init only installed express. This caused `MODULE_NOT_FOUND` crashes on fresh VMs.

Adds `ws@^8.18.0` to the cloud-init package.json alongside express.