### PR TITLE
Polish AI Model onboarding step and add dashboard card

### DIFF
--- a/apps/web/src/app/dashboard/components/ai-model-card.tsx
+++ b/apps/web/src/app/dashboard/components/ai-model-card.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import Link from "next/link";
+
+const PROVIDER_LABELS: Record<string, string> = {
+  gemini: "Google Gemini",
+  openai: "OpenAI",
+  anthropic: "Anthropic",
+  "github-copilot": "GitHub Copilot",
+};
+
+function maskKey(key: string): string {
+  if (!key || key.length < 8) return "••••••••";
+  return key.slice(0, 4) + "••••" + key.slice(-4);
+}
+
+export function AiModelCard({
+  provider,
+  apiKey,
+}: {
+  provider?: string | null;
+  apiKey?: string | null;
+}) {
+  const configured = !!provider && !!apiKey;
+  const label = provider ? PROVIDER_LABELS[provider] ?? provider : null;
+
+  return (
+    <div className="rounded-xl border border-slate-800 bg-slate-900 p-6">
+      <h2 className="text-lg font-semibold text-white mb-1">AI Model</h2>
+
+      {configured ? (
+        <>
+          <p className="text-2xl font-bold text-indigo-400 mb-2">{label}</p>
+          <p className="text-sm text-slate-400 mb-4 font-mono">
+            Key: {maskKey(apiKey!)}
+          </p>
+        </>
+      ) : (
+        <>
+          <p className="text-sm text-slate-400 mb-4">
+            Not configured yet. Connect an AI provider so your assistant can
+            think.
+          </p>
+        </>
+      )}
+
+      <Link
+        href="/settings/ai"
+        className="inline-block rounded-lg bg-indigo-600 px-4 py-2 text-sm text-white hover:bg-indigo-500"
+      >
+        {configured ? "Change" : "Set up AI provider"}
+      </Link>
+    </div>
+  );
+}

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -6,6 +6,7 @@ import { AssistantCard } from "./components/assistant-card";
 import { UsageCard } from "./components/usage-card";
 import { ConnectionsCard } from "./components/connections-card";
 import { PlanCard } from "./components/plan-card";
+import { AiModelCard } from "./components/ai-model-card";
 import { UpgradeBanner } from "./components/upgrade-banner";
 import type { PlanKey } from "@/lib/stripe/config";
 
@@ -37,7 +38,7 @@ async function DashboardContent({
   // Fetch user record for plan, hosting preference, and messengers
   const { data: user } = await supabase
     .from("users")
-    .select("plan, provider_preference, messengers")
+    .select("plan, provider_preference, messengers, ai_provider, ai_api_key")
     .eq("id", session.userId)
     .single();
 
@@ -54,6 +55,8 @@ async function DashboardContent({
 
   const hosting: string | undefined = user?.provider_preference ?? undefined;
   const messengers: string[] = user?.messengers ?? [];
+  const aiProvider: string | null = user?.ai_provider ?? null;
+  const aiApiKey: string | null = user?.ai_api_key ?? null;
 
   // Check provider token connections (Azure + DO need OAuth)
   let providerConnected = false;
@@ -84,6 +87,7 @@ async function DashboardContent({
             messengers={messengers}
           />
           <PlanCard plan={plan} />
+          <AiModelCard provider={aiProvider} apiKey={aiApiKey} />
         </div>
       </div>
     </div>

--- a/apps/web/src/app/onboarding/wizard.tsx
+++ b/apps/web/src/app/onboarding/wizard.tsx
@@ -1348,8 +1348,8 @@ export default function OnboardingWizard() {
           <div className="space-y-6">
             <div className="text-center">
               <Key className="w-12 h-12 text-violet-500 mx-auto mb-4" />
-              <h2 className="text-2xl font-bold">Choose Your AI Model</h2>
-              <p className="text-slate-400 mt-2">Your server is ready! Now choose an AI model for your assistant. Bring your own API key from one of these providers.</p>
+              <h2 className="text-2xl font-bold">Connect an AI Provider</h2>
+              <p className="text-slate-400 mt-2">Your assistant needs a brain. Pick a provider and paste your API key — you can always change this later from your dashboard.</p>
             </div>
 
             <div className="grid gap-4">
@@ -1463,35 +1463,54 @@ export default function OnboardingWizard() {
 
             <div className="flex justify-between items-center">
               <BackBtn />
-              <PrimaryBtn onClick={async () => {
-                // Save AI config to database
-                try {
-                  await fetch('/api/onboarding', {
-                    method: 'PATCH',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ aiProvider, aiApiKey }),
-                  });
-                } catch { /* continue anyway */ }
-                // Configure OpenClaw on the VM via sidecar
-                try {
-                  await fetch('/api/assistant/configure-ai', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ provider: aiProvider, apiKey: aiApiKey }),
-                  });
-                } catch { /* continue anyway — can be configured from dashboard */ }
-                // Mark onboarding complete
-                try {
-                  await fetch('/api/onboarding', {
-                    method: 'PATCH',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ onboardingComplete: true }),
-                  });
-                } catch { /* ignore */ }
-                next();
-              }} disabled={!aiKeyVerified}>
-                Finish Setup <ArrowRight className="w-4 h-4" />
-              </PrimaryBtn>
+              <div className="flex items-center gap-4">
+                <PrimaryBtn onClick={async () => {
+                  // Save AI config to database
+                  try {
+                    await fetch('/api/onboarding', {
+                      method: 'PATCH',
+                      headers: { 'Content-Type': 'application/json' },
+                      body: JSON.stringify({ aiProvider, aiApiKey }),
+                    });
+                  } catch { /* continue anyway */ }
+                  // Configure OpenClaw on the VM via sidecar
+                  try {
+                    await fetch('/api/assistant/configure-ai', {
+                      method: 'POST',
+                      headers: { 'Content-Type': 'application/json' },
+                      body: JSON.stringify({ provider: aiProvider, apiKey: aiApiKey }),
+                    });
+                  } catch { /* continue anyway — can be configured from dashboard */ }
+                  // Mark onboarding complete
+                  try {
+                    await fetch('/api/onboarding', {
+                      method: 'PATCH',
+                      headers: { 'Content-Type': 'application/json' },
+                      body: JSON.stringify({ onboardingComplete: true }),
+                    });
+                  } catch { /* ignore */ }
+                  next();
+                }} disabled={!aiKeyVerified}>
+                  Next <ArrowRight className="w-4 h-4" />
+                </PrimaryBtn>
+                <button
+                  type="button"
+                  onClick={async () => {
+                    // Mark onboarding complete without AI config
+                    try {
+                      await fetch('/api/onboarding', {
+                        method: 'PATCH',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ onboardingComplete: true }),
+                      });
+                    } catch { /* ignore */ }
+                    next();
+                  }}
+                  className="text-sm text-slate-400 hover:text-slate-200 transition-colors underline underline-offset-2"
+                >
+                  Skip for now
+                </button>
+              </div>
             </div>
           </div>
         )}


### PR DESCRIPTION
## Changes

### Onboarding wizard (step 7 - AI Model)
- **Title**: 'Choose Your AI Model' → 'Connect an AI Provider'
- **Subtitle**: Rewritten to be warmer — mentions you can change it later from the dashboard
- **Button**: 'Finish Setup' → 'Next' (matches flow consistency)
- **Skip**: Added 'Skip for now' link that marks onboarding complete and advances to the Ready step, so users can set up AI later from the dashboard

### Dashboard - new AI Model card
- Created `ai-model-card.tsx` matching existing card styling (plan-card pattern)
- Shows current provider name and masked API key when configured
- Shows 'Not configured' prompt with setup button when not configured
- 'Change' button links to `/settings/ai` for inline editing
- Added to dashboard grid alongside existing cards
- Fetches `ai_provider` and `ai_api_key` from users table