### PR TITLE
redesign: dashboard v1 - hero + grid layout

### DIFF
--- a/apps/web/src/app/dashboard/components/assistant-card.tsx
+++ b/apps/web/src/app/dashboard/components/assistant-card.tsx
@@ -39,18 +39,29 @@ const PROVISION_STEPS: { phase: ProvisionPhase; label: string; atSec: number }[]
   { phase: "done", label: "Online", atSec: 0 },
 ];
 
-export function AssistantCard({ assistant }: { assistant: Assistant | null }) {
+function heroBorderClass(status: string): string {
+  switch (status) {
+    case "active":
+      return "border-2 border-transparent bg-clip-padding [background-image:linear-gradient(theme(colors.slate.900),theme(colors.slate.900)),linear-gradient(135deg,theme(colors.violet.500/0.4),theme(colors.indigo.500/0.4),theme(colors.violet.500/0.4))] [background-origin:border-box] [background-clip:padding-box,border-box]";
+    case "destroying":
+      return "border-2 border-transparent bg-clip-padding [background-image:linear-gradient(theme(colors.slate.900),theme(colors.slate.900)),linear-gradient(135deg,theme(colors.red.500/0.5),theme(colors.red.600/0.3),theme(colors.red.500/0.5))] [background-origin:border-box] [background-clip:padding-box,border-box]";
+    case "provisioning":
+      return "border-2 border-transparent bg-clip-padding [background-image:linear-gradient(theme(colors.slate.900),theme(colors.slate.900)),linear-gradient(135deg,theme(colors.yellow.500/0.4),theme(colors.amber.500/0.3),theme(colors.yellow.500/0.4))] [background-origin:border-box] [background-clip:padding-box,border-box]";
+    default:
+      return "border border-slate-800 bg-slate-900";
+  }
+}
+
+export function AssistantHero({ assistant }: { assistant: Assistant | null }) {
   const [loading, setLoading] = useState<string | null>(null);
   const [current, setCurrent] = useState(assistant);
   const [confirmDestroy, setConfirmDestroy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // Destroy progress state
   const [destroying, setDestroying] = useState(false);
   const [destroyElapsed, setDestroyElapsed] = useState(0);
   const [destroySteps, setDestroySteps] = useState<string[]>([]);
 
-  // Provision progress state
   const [provisioning, setProvisioning] = useState(
     assistant?.status === "provisioning"
   );
@@ -66,8 +77,6 @@ export function AssistantCard({ assistant }: { assistant: Assistant | null }) {
     const interval = setInterval(() => {
       const elapsed = Math.floor((Date.now() - start) / 1000);
       setDestroyElapsed(elapsed);
-
-      // Add milestone messages
       for (const step of DESTROY_STEPS) {
         if (step.phase !== "done" && elapsed >= step.atSec) {
           setDestroySteps((prev) =>
@@ -86,7 +95,6 @@ export function AssistantCard({ assistant }: { assistant: Assistant | null }) {
     const interval = setInterval(() => {
       const elapsed = Math.floor((Date.now() - start) / 1000);
       setProvisionElapsed(elapsed);
-
       for (const step of PROVISION_STEPS) {
         if (step.phase !== "done" && elapsed >= step.atSec) {
           setProvisionSteps((prev) =>
@@ -102,7 +110,6 @@ export function AssistantCard({ assistant }: { assistant: Assistant | null }) {
   useEffect(() => {
     if (!destroying) return;
     let cancelled = false;
-
     const poll = async () => {
       while (!cancelled) {
         await new Promise((r) => setTimeout(r, 3000));
@@ -117,17 +124,11 @@ export function AssistantCard({ assistant }: { assistant: Assistant | null }) {
             setDestroySteps((prev) => [...prev, "Done - assistant destroyed"]);
             return;
           }
-          if (a.status === "destroying") {
-            // Still in progress
-            continue;
-          }
-          // Unexpected state
+          if (a.status === "destroying") continue;
           setCurrent(a);
           setDestroying(false);
           return;
-        } catch {
-          // Network error, keep polling
-        }
+        } catch {}
       }
     };
     poll();
@@ -138,7 +139,6 @@ export function AssistantCard({ assistant }: { assistant: Assistant | null }) {
   useEffect(() => {
     if (!provisioning) return;
     let cancelled = false;
-
     const poll = async () => {
       while (!cancelled) {
         await new Promise((r) => setTimeout(r, 5000));
@@ -160,9 +160,7 @@ export function AssistantCard({ assistant }: { assistant: Assistant | null }) {
             setError("Provisioning failed. Please try again.");
             return;
           }
-        } catch {
-          // Keep polling
-        }
+        } catch {}
       }
     };
     poll();
@@ -176,7 +174,6 @@ export function AssistantCard({ assistant }: { assistant: Assistant | null }) {
     setDestroyElapsed(0);
     setDestroySteps(["Initiating shutdown..."]);
     setConfirmDestroy(false);
-
     try {
       const res = await fetch("/api/assistant/destroy", { method: "POST" });
       if (!res.ok) {
@@ -200,7 +197,6 @@ export function AssistantCard({ assistant }: { assistant: Assistant | null }) {
     setProvisioning(true);
     setProvisionElapsed(0);
     setProvisionSteps(["Starting provisioning..."]);
-
     try {
       const res = await fetch("/api/assistant/launch", { method: "POST" });
       if (!res.ok) {
@@ -284,189 +280,149 @@ export function AssistantCard({ assistant }: { assistant: Assistant | null }) {
   };
 
   const effectiveStatus = destroying ? "destroying" : provisioning ? "provisioning" : status;
-  const { label, dot } = statusConfig[effectiveStatus] ?? statusConfig.offline;
+  const { label: statusLabel, dot } = statusConfig[effectiveStatus] ?? statusConfig.offline;
 
-  // Destroying state - show progress
-  if (destroying) {
-    return (
-      <div className="rounded-xl border border-slate-800 bg-slate-900 p-6">
-        <h2 className="text-lg font-semibold text-white mb-4">Your Assistant</h2>
+  const showProgress = destroying || provisioning || status === "provisioning";
+  const progressSteps = destroying ? destroySteps : provisionSteps;
+  const progressElapsed = destroying ? destroyElapsed : provisionElapsed;
+  const progressHint = destroying ? "Typically takes 30-60 seconds" : "Typically takes 2-4 minutes";
 
-        <div className="flex items-center gap-2 mb-4">
-          <span className={`h-3 w-3 rounded-full ${dot}`} />
-          <span className="text-slate-100">{label}</span>
-          <span className="text-sm text-slate-500 ml-auto">{formatTime(destroyElapsed)}</span>
-        </div>
+  const providerLine = current?.provider
+    ? `Running on ${providerLabel(current.provider)}${current.region ? ` · ${current.region}` : ""}`
+    : null;
 
-        <p className="text-xs text-slate-500 mb-3">
-          Typically takes 30-60 seconds
-        </p>
-
-        <div className="space-y-2">
-          {destroySteps.map((step, i) => {
-            const isLast = i === destroySteps.length - 1;
-            const isDone = step.startsWith("Done");
-            return (
-              <div key={i} className="flex items-center gap-2 text-sm">
-                {isDone ? (
-                  <span className="w-4 h-4 text-green-400 flex-shrink-0">&#10003;</span>
-                ) : isLast ? (
-                  <span className="w-4 h-4 border-2 border-violet-400 border-t-transparent rounded-full animate-spin flex-shrink-0" />
-                ) : (
-                  <span className="w-4 h-4 text-green-400 flex-shrink-0">&#10003;</span>
-                )}
-                <span className={isLast && !isDone ? "text-white font-medium" : "text-slate-400"}>
-                  {step}
-                </span>
-              </div>
-            );
-          })}
-        </div>
-      </div>
-    );
-  }
-
-  // Provisioning state - show progress
-  if (provisioning || status === "provisioning") {
-    return (
-      <div className="rounded-xl border border-slate-800 bg-slate-900 p-6">
-        <h2 className="text-lg font-semibold text-white mb-4">Your Assistant</h2>
-
-        <div className="flex items-center gap-2 mb-4">
-          <span className="h-3 w-3 rounded-full bg-yellow-400 animate-pulse" />
-          <span className="text-slate-100">Provisioning</span>
-          <span className="text-sm text-slate-500 ml-auto">{formatTime(provisionElapsed)}</span>
-        </div>
-
-        <p className="text-xs text-slate-500 mb-3">
-          Typically takes 2-4 minutes
-        </p>
-
-        <div className="space-y-2">
-          {provisionSteps.map((step, i) => {
-            const isLast = i === provisionSteps.length - 1;
-            const isDone = step.includes("online") || step.includes("failed");
-            return (
-              <div key={i} className="flex items-center gap-2 text-sm">
-                {isDone ? (
-                  <span className={`w-4 h-4 flex-shrink-0 ${step.includes("failed") ? "text-red-400" : "text-green-400"}`}>
-                    {step.includes("failed") ? "✕" : "&#10003;"}
-                  </span>
-                ) : isLast ? (
-                  <span className="w-4 h-4 border-2 border-violet-400 border-t-transparent rounded-full animate-spin flex-shrink-0" />
-                ) : (
-                  <span className="w-4 h-4 text-green-400 flex-shrink-0">&#10003;</span>
-                )}
-                <span className={isLast && !isDone ? "text-white font-medium" : "text-slate-400"}>
-                  {step}
-                </span>
-              </div>
-            );
-          })}
-        </div>
-
-        {error && (
-          <p className="text-sm text-red-400 mt-3">{error}</p>
-        )}
-      </div>
-    );
-  }
-
-  // Normal states
   return (
-    <div className="rounded-xl border border-slate-800 bg-slate-900 p-6">
-      <h2 className="text-lg font-semibold text-white mb-4">Your Assistant</h2>
+    <div className={`rounded-2xl ${heroBorderClass(effectiveStatus)} p-6 sm:p-8 mb-6`}>
+      <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
+        {/* Left: Status info */}
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-3 mb-2">
+            <span className={`h-4 w-4 rounded-full ${dot} flex-shrink-0`} />
+            <h1 className="text-2xl sm:text-3xl font-bold text-white truncate">
+              Your Assistant
+            </h1>
+            <span className="text-sm font-medium text-slate-400 bg-slate-800 rounded-full px-3 py-0.5">
+              {statusLabel}
+            </span>
+          </div>
 
-      <div className="flex items-center gap-2 mb-4">
-        <span className={`h-3 w-3 rounded-full ${dot}`} />
-        <span className="text-slate-100">{label}</span>
-      </div>
+          {providerLine && (
+            <p className="text-sm text-slate-500 ml-7 mb-1">{providerLine}</p>
+          )}
 
-      {current?.provider && (
-        <p className="text-sm text-slate-400 mb-2">
-          Running on{" "}
-          <span className="text-slate-200">
-            {providerLabel(current.provider)}
-          </span>
-        </p>
-      )}
+          {current?.ip_address && status === "active" && (
+            <p className="text-sm text-slate-400 ml-7">
+              <span className="font-mono text-slate-300">{current.ip_address}</span>
+              {uptime() && (
+                <>
+                  <span className="text-slate-600 mx-2">·</span>
+                  <span className="text-slate-500">Uptime {uptime()}</span>
+                </>
+              )}
+            </p>
+          )}
 
-      {current?.ip_address && status === "active" && (
-        <p className="text-sm text-slate-400 mb-2">
-          Address:{" "}
-          <span className="text-slate-200 font-mono">{current.ip_address}</span>
-        </p>
-      )}
+          {/* Progress steps (provisioning/destroying) */}
+          {showProgress && (
+            <div className="mt-4 ml-7">
+              <p className="text-xs text-slate-500 mb-2">
+                {progressHint} — {formatTime(progressElapsed)}
+              </p>
+              <div className="space-y-1.5">
+                {progressSteps.map((step, i) => {
+                  const isLast = i === progressSteps.length - 1;
+                  const isDone = step.startsWith("Done") || step.includes("online");
+                  const isFailed = step.includes("failed");
+                  return (
+                    <div key={i} className="flex items-center gap-2 text-sm">
+                      {isDone ? (
+                        <span className="w-4 h-4 text-green-400 flex-shrink-0">✓</span>
+                      ) : isFailed ? (
+                        <span className="w-4 h-4 text-red-400 flex-shrink-0">✕</span>
+                      ) : isLast ? (
+                        <span className="w-4 h-4 border-2 border-violet-400 border-t-transparent rounded-full animate-spin flex-shrink-0" />
+                      ) : (
+                        <span className="w-4 h-4 text-green-400 flex-shrink-0">✓</span>
+                      )}
+                      <span className={isLast && !isDone && !isFailed ? "text-white font-medium" : "text-slate-400"}>
+                        {step}
+                      </span>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          )}
 
-      {uptime() && (
-        <p className="text-sm text-slate-400 mb-4">
-          Uptime: <span className="text-slate-200">{uptime()}</span>
-        </p>
-      )}
+          {error && (
+            <p className="text-sm text-red-400 mt-3 ml-7">{error}</p>
+          )}
+        </div>
 
-      {error && (
-        <p className="text-sm text-red-400 mb-3">{error}</p>
-      )}
-
-      <div className="flex flex-wrap gap-2 mt-2">
-        {status === "active" && (
-          <button
-            disabled={!!loading}
-            onClick={handleSuspend}
-            className="rounded-lg bg-slate-800 px-4 py-2 text-sm text-slate-200 hover:bg-slate-700 disabled:opacity-50"
-          >
-            {loading === "/api/assistant/suspend" ? "Suspending..." : "Suspend"}
-          </button>
-        )}
-
-        {status === "suspended" && (
-          <button
-            disabled={!!loading}
-            onClick={handleResume}
-            className="rounded-lg bg-indigo-600 px-4 py-2 text-sm text-white hover:bg-indigo-500 disabled:opacity-50"
-          >
-            {loading === "/api/assistant/launch" ? "Resuming..." : "Resume"}
-          </button>
-        )}
-
-        {current && status !== "destroying" && !confirmDestroy && (
-          <button
-            onClick={() => setConfirmDestroy(true)}
-            className="rounded-lg bg-red-900/50 px-4 py-2 text-sm text-red-300 hover:bg-red-900 disabled:opacity-50"
-          >
-            Destroy
-          </button>
-        )}
-
-        {confirmDestroy && (
-          <div className="flex items-center gap-2">
-            <span className="text-sm text-red-400">Are you sure?</span>
+        {/* Right: Action buttons as pills */}
+        <div className="flex flex-wrap items-center gap-2 sm:flex-shrink-0">
+          {status === "active" && !destroying && (
             <button
               disabled={!!loading}
-              onClick={handleDestroy}
-              className="rounded-lg bg-red-700 px-3 py-1.5 text-sm text-white hover:bg-red-600 disabled:opacity-50"
+              onClick={handleSuspend}
+              className="rounded-full bg-slate-800 px-5 py-2 text-sm font-medium text-slate-200 hover:bg-slate-700 disabled:opacity-50 transition-colors"
             >
-              Yes, destroy
+              {loading === "/api/assistant/suspend" ? "Suspending…" : "Suspend"}
             </button>
-            <button
-              onClick={() => setConfirmDestroy(false)}
-              className="rounded-lg bg-slate-800 px-3 py-1.5 text-sm text-slate-300 hover:bg-slate-700"
-            >
-              Cancel
-            </button>
-          </div>
-        )}
+          )}
 
-        {(!current || status === "offline") && !confirmDestroy && (
-          <button
-            disabled={!!loading}
-            onClick={handleLaunch}
-            className="rounded-lg bg-indigo-600 px-4 py-2 text-sm text-white hover:bg-indigo-500 disabled:opacity-50"
-          >
-            {loading === "/api/assistant/launch" ? "Launching..." : "Launch Assistant"}
-          </button>
-        )}
+          {status === "suspended" && (
+            <button
+              disabled={!!loading}
+              onClick={handleResume}
+              className="rounded-full bg-indigo-600 px-5 py-2 text-sm font-medium text-white hover:bg-indigo-500 disabled:opacity-50 transition-colors"
+            >
+              {loading === "/api/assistant/launch" ? "Resuming…" : "Resume"}
+            </button>
+          )}
+
+          {current && status !== "destroying" && !destroying && !confirmDestroy && (
+            <button
+              onClick={() => setConfirmDestroy(true)}
+              className="rounded-full bg-red-900/40 px-5 py-2 text-sm font-medium text-red-300 hover:bg-red-900/70 transition-colors"
+            >
+              Destroy
+            </button>
+          )}
+
+          {confirmDestroy && (
+            <div className="flex items-center gap-2">
+              <span className="text-sm text-red-400">Sure?</span>
+              <button
+                disabled={!!loading}
+                onClick={handleDestroy}
+                className="rounded-full bg-red-700 px-4 py-1.5 text-sm font-medium text-white hover:bg-red-600 disabled:opacity-50 transition-colors"
+              >
+                Yes, destroy
+              </button>
+              <button
+                onClick={() => setConfirmDestroy(false)}
+                className="rounded-full bg-slate-800 px-4 py-1.5 text-sm font-medium text-slate-300 hover:bg-slate-700 transition-colors"
+              >
+                Cancel
+              </button>
+            </div>
+          )}
+
+          {(!current || status === "offline") && !confirmDestroy && !provisioning && (
+            <button
+              disabled={!!loading}
+              onClick={handleLaunch}
+              className="rounded-full bg-indigo-600 px-6 py-2.5 text-sm font-medium text-white hover:bg-indigo-500 disabled:opacity-50 transition-colors"
+            >
+              {loading === "/api/assistant/launch" ? "Launching…" : "Launch Assistant"}
+            </button>
+          )}
+        </div>
       </div>
     </div>
   );
 }
+
+// Backward compat
+export { AssistantHero as AssistantCard };

--- a/apps/web/src/app/dashboard/components/connections-card.tsx
+++ b/apps/web/src/app/dashboard/components/connections-card.tsx
@@ -3,12 +3,6 @@
 import { useEffect, useState, useCallback } from "react";
 import { MessengerSetupModal } from "./messenger-setup-modal";
 
-const PROVIDER_CONFIG: Record<string, { name: string; icon: string }> = {
-  oracle: { name: "Oracle Cloud", icon: "" },
-  azure: { name: "Microsoft Azure", icon: "" },
-  digitalocean: { name: "DigitalOcean", icon: "" },
-};
-
 const MESSENGER_CONFIG: Record<
   string,
   { name: string; icon: string; color: string }
@@ -34,8 +28,6 @@ interface ConnectionsCardProps {
 }
 
 export function ConnectionsCard({
-  hosting,
-  providerConnected = false,
   messengers = [],
 }: ConnectionsCardProps) {
   const [messengerStatuses, setMessengerStatuses] = useState<
@@ -49,7 +41,6 @@ export function ConnectionsCard({
       const res = await fetch("/api/messaging/status");
       if (res.ok) {
         const data = await res.json();
-        // Transform platforms object to array format
         const platforms = data.platforms ?? {};
         const statuses: MessengerStatus[] = Object.entries(platforms).map(
           ([key, val]: [string, any]) => ({
@@ -61,9 +52,7 @@ export function ConnectionsCard({
         );
         setMessengerStatuses(statuses);
       }
-    } catch {
-      // silently fail
-    }
+    } catch {}
   }, []);
 
   useEffect(() => {
@@ -77,78 +66,29 @@ export function ConnectionsCard({
   const handleDisconnect = async (messengerKey: string) => {
     setDisconnecting(messengerKey);
     try {
-      const res = await fetch('/api/messaging/disconnect', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+      const res = await fetch("/api/messaging/disconnect", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ platform: messengerKey }),
       });
       if (!res.ok) {
         const data = await res.json().catch(() => ({}));
-        console.error('Disconnect failed:', data.error);
+        console.error("Disconnect failed:", data.error);
       }
     } catch (err) {
-      console.error('Disconnect error:', err);
+      console.error("Disconnect error:", err);
     } finally {
       setDisconnecting(null);
       fetchMessengerStatus();
     }
   };
 
-  const providerConfig = hosting ? PROVIDER_CONFIG[hosting] : null;
-
-  // Oracle is always active (we manage it), Azure/DO need OAuth
-  const needsOAuth = hosting === "azure" || hosting === "digitalocean";
-  const providerActive = hosting === "oracle" || providerConnected;
-
   return (
     <>
-      <div className="rounded-xl border border-slate-800 bg-slate-900 p-6">
-        <h2 className="text-lg font-semibold text-white mb-4">Connections</h2>
+      <div className="rounded-xl border border-slate-800 bg-slate-900 p-6 h-full">
+        <h2 className="text-lg font-semibold text-white mb-4">Messengers</h2>
 
         <div className="space-y-3">
-          {/* Cloud Provider */}
-          {providerConfig && (
-            <div className="flex items-center justify-between">
-              <div className="flex items-center gap-2">
-                <span>{providerConfig.icon}</span>
-                <span className="text-slate-300">{providerConfig.name}</span>
-                {providerActive ? (
-                  <span className="text-green-500 text-xs">● Active</span>
-                ) : (
-                  <span className="text-slate-600 text-xs">
-                    ● Not connected
-                  </span>
-                )}
-              </div>
-              {providerActive ? (
-                <span className="rounded-md bg-green-900/30 px-3 py-1 text-xs text-green-400">
-                  Active
-                </span>
-              ) : needsOAuth ? (
-                <a
-                  href={`/api/auth/${hosting}`}
-                  className="rounded-md bg-indigo-600 px-3 py-1 text-xs text-white hover:bg-indigo-500"
-                >
-                  Connect
-                </a>
-              ) : null}
-            </div>
-          )}
-
-          {!providerConfig && (
-            <div className="flex items-center gap-2">
-              <span className="text-slate-500 text-sm">
-                No cloud provider selected
-              </span>
-            </div>
-          )}
-
-          {/* Divider */}
-          {messengers.length > 0 && (
-            <div className="border-t border-slate-800 my-2" />
-          )}
-
-          {/* Messengers */}
           {messengers.map((m) => {
             const config = MESSENGER_CONFIG[m];
             if (!config) return null;
@@ -195,7 +135,7 @@ export function ConnectionsCard({
                       onClick={() => handleDisconnect(m)}
                       className="rounded-md bg-red-900/50 px-3 py-1 text-xs text-red-400 hover:bg-red-900/80 disabled:opacity-50"
                     >
-                      {disconnecting === m ? 'Disconnecting…' : 'Disconnect'}
+                      {disconnecting === m ? "Disconnecting…" : "Disconnect"}
                     </button>
                   </div>
                 )}
@@ -222,16 +162,11 @@ export function ConnectionsCard({
           })}
 
           {messengers.length === 0 && (
-            <div className="flex items-center gap-2">
-              <span className="text-slate-500 text-sm">
-                No messengers configured
-              </span>
-            </div>
+            <p className="text-slate-500 text-sm">No messengers configured</p>
           )}
         </div>
       </div>
 
-      {/* Messenger setup modal */}
       {setupModal && (
         <MessengerSetupModal
           messenger={setupModal}

--- a/apps/web/src/app/dashboard/components/quick-actions.tsx
+++ b/apps/web/src/app/dashboard/components/quick-actions.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import Link from "next/link";
+
+interface QuickActionsProps {
+  ipAddress: string | null;
+  status: string | null;
+}
+
+export function QuickActions({ ipAddress, status }: QuickActionsProps) {
+  const isActive = status === "active";
+
+  return (
+    <div className="flex flex-wrap items-center gap-3 mb-6">
+      {isActive && ipAddress && (
+        <a
+          href={`http://${ipAddress}:8787`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="rounded-full bg-slate-800 border border-slate-700 px-4 py-1.5 text-sm font-medium text-slate-200 hover:bg-slate-700 hover:border-slate-600 transition-colors"
+        >
+          Open Control Panel
+        </a>
+      )}
+      <Link
+        href="/settings"
+        className="rounded-full bg-slate-800 border border-slate-700 px-4 py-1.5 text-sm font-medium text-slate-200 hover:bg-slate-700 hover:border-slate-600 transition-colors"
+      >
+        Settings
+      </Link>
+      <button
+        disabled
+        className="rounded-full bg-slate-800/50 border border-slate-700/50 px-4 py-1.5 text-sm font-medium text-slate-500 cursor-not-allowed"
+      >
+        View Logs
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Dashboard Redesign: Hero + Grid

### Layout Changes
- **Full-width hero section** at top with assistant status, big status dot, IP, uptime, and cloud provider info
- **Quick actions bar** between hero and grid: Open Control Panel, Settings, View Logs (placeholder)
- **3-column responsive grid** (stacks to 1 on mobile):
  - Column 1: Messengers card
  - Column 2: AI Model + Usage (stacked)
  - Column 3: Plan card

### Styling
- Hero gets gradient border: violet/indigo (online), red (destroying), yellow (provisioning)
- Pill-style action buttons (Suspend/Resume/Destroy) in hero top-right
- Cloud provider moved to subtle subtitle in hero (e.g. 'Running on Microsoft Azure · southcentralus')
- Connections card simplified to messengers only
- All existing functionality preserved

### Files Changed
- `page.tsx` — new layout structure
- `assistant-card.tsx` — redesigned as full-width hero (`AssistantHero`)
- `connections-card.tsx` — messengers only, cloud provider section removed
- `quick-actions.tsx` — new component