### PR TITLE
Redesign: Bento grid dashboard with messenger mini-cards

### DIFF
--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -1,0 +1,2 @@
+.vercel
+.env*.local

--- a/apps/web/src/app/dashboard/components/ai-model-card.tsx
+++ b/apps/web/src/app/dashboard/components/ai-model-card.tsx
@@ -25,7 +25,7 @@ export function AiModelCard({
   const label = provider ? PROVIDER_LABELS[provider] ?? provider : null;
 
   return (
-    <div className="rounded-xl border border-slate-800 bg-slate-900 p-6">
+    <div className="rounded-2xl border border-slate-800 bg-slate-900 p-6 transition-all duration-200 hover:scale-[1.01] hover:border-slate-700">
       <h2 className="text-lg font-semibold text-white mb-1">AI Model</h2>
 
       {configured ? (

--- a/apps/web/src/app/dashboard/components/assistant-card.tsx
+++ b/apps/web/src/app/dashboard/components/assistant-card.tsx
@@ -289,7 +289,7 @@ export function AssistantCard({ assistant }: { assistant: Assistant | null }) {
   // Destroying state - show progress
   if (destroying) {
     return (
-      <div className="rounded-xl border border-slate-800 bg-slate-900 p-6">
+      <div className="rounded-2xl border border-slate-800 bg-gradient-to-br from-slate-900 to-slate-800/80 p-6 transition-all duration-200 hover:scale-[1.01] hover:border-slate-700">
         <h2 className="text-lg font-semibold text-white mb-4">Your Assistant</h2>
 
         <div className="flex items-center gap-2 mb-4">
@@ -329,7 +329,7 @@ export function AssistantCard({ assistant }: { assistant: Assistant | null }) {
   // Provisioning state - show progress
   if (provisioning || status === "provisioning") {
     return (
-      <div className="rounded-xl border border-slate-800 bg-slate-900 p-6">
+      <div className="rounded-2xl border border-slate-800 bg-gradient-to-br from-slate-900 to-slate-800/80 p-6 transition-all duration-200 hover:scale-[1.01] hover:border-slate-700">
         <h2 className="text-lg font-semibold text-white mb-4">Your Assistant</h2>
 
         <div className="flex items-center gap-2 mb-4">
@@ -374,7 +374,7 @@ export function AssistantCard({ assistant }: { assistant: Assistant | null }) {
 
   // Normal states
   return (
-    <div className="rounded-xl border border-slate-800 bg-slate-900 p-6">
+    <div className="rounded-2xl border border-slate-800 bg-gradient-to-br from-slate-900 to-slate-800/80 p-6 transition-all duration-200 hover:scale-[1.01] hover:border-slate-700">
       <h2 className="text-lg font-semibold text-white mb-4">Your Assistant</h2>
 
       <div className="flex items-center gap-2 mb-4">

--- a/apps/web/src/app/dashboard/components/messenger-mini-card.tsx
+++ b/apps/web/src/app/dashboard/components/messenger-mini-card.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import {
+  MessageCircle,
+  Send,
+  Hash,
+  MessageSquare,
+  Shield,
+} from "lucide-react";
+import { MessengerSetupModal } from "./messenger-setup-modal";
+
+const MESSENGER_CONFIG: Record<
+  string,
+  {
+    name: string;
+    icon: typeof MessageCircle;
+    color: string;
+  }
+> = {
+  whatsapp: { name: "WhatsApp", icon: MessageCircle, color: "text-green-400" },
+  telegram: { name: "Telegram", icon: Send, color: "text-blue-400" },
+  slack: { name: "Slack", icon: Hash, color: "text-purple-400" },
+  discord: { name: "Discord", icon: MessageSquare, color: "text-indigo-400" },
+  signal: { name: "Signal", icon: Shield, color: "text-blue-300" },
+};
+
+interface MessengerMiniCardProps {
+  messengerKey: string;
+  initialConnected?: boolean;
+  initialConfigured?: boolean;
+}
+
+export function MessengerMiniCard({
+  messengerKey,
+  initialConnected = false,
+  initialConfigured = false,
+}: MessengerMiniCardProps) {
+  const [connected, setConnected] = useState(initialConnected);
+  const [configured, setConfigured] = useState(initialConfigured);
+  const [showModal, setShowModal] = useState(false);
+
+  const config = MESSENGER_CONFIG[messengerKey];
+  if (!config) return null;
+
+  const Icon = config.icon;
+
+  const fetchStatus = useCallback(async () => {
+    try {
+      const res = await fetch("/api/messaging/status");
+      if (res.ok) {
+        const data = await res.json();
+        const platform = data.platforms?.[messengerKey];
+        if (platform) {
+          setConnected(platform.connected ?? false);
+          setConfigured(platform.configured ?? false);
+        }
+      }
+    } catch {
+      // silently fail
+    }
+  }, [messengerKey]);
+
+  useEffect(() => {
+    fetchStatus();
+    const interval = setInterval(fetchStatus, 30_000);
+    return () => clearInterval(interval);
+  }, [fetchStatus]);
+
+  const statusDot = connected
+    ? "bg-green-500"
+    : configured
+      ? "bg-amber-400"
+      : "bg-slate-600";
+
+  const statusText = connected
+    ? "Connected"
+    : configured
+      ? "Configured"
+      : "Set up →";
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => {
+          if (!connected) setShowModal(true);
+        }}
+        className={`rounded-2xl border border-slate-800 bg-slate-900 p-4 text-left transition-all duration-200 hover:scale-[1.01] hover:border-slate-700 ${
+          !connected ? "cursor-pointer" : "cursor-default"
+        }`}
+      >
+        <div className="flex items-center gap-3">
+          <Icon className={`h-5 w-5 ${config.color}`} />
+          <div className="flex-1 min-w-0">
+            <p className="text-sm font-medium text-white">{config.name}</p>
+            <div className="flex items-center gap-1.5 mt-0.5">
+              <span
+                className={`h-2 w-2 rounded-full ${statusDot} flex-shrink-0`}
+              />
+              <span className="text-xs text-slate-400">{statusText}</span>
+            </div>
+          </div>
+        </div>
+      </button>
+
+      {showModal && (
+        <MessengerSetupModal
+          messenger={messengerKey}
+          onClose={() => {
+            setShowModal(false);
+            fetchStatus();
+          }}
+          onConnected={() => {
+            fetchStatus();
+          }}
+        />
+      )}
+    </>
+  );
+}

--- a/apps/web/src/app/dashboard/components/plan-card.tsx
+++ b/apps/web/src/app/dashboard/components/plan-card.tsx
@@ -38,7 +38,7 @@ export function PlanCard({ plan }: { plan: PlanKey }) {
   }
 
   return (
-    <div className="rounded-xl border border-slate-800 bg-slate-900 p-6">
+    <div className="rounded-2xl border border-slate-800 bg-slate-900 p-6 transition-all duration-200 hover:scale-[1.01] hover:border-slate-700">
       <h2 className="text-lg font-semibold text-white mb-1">Your Plan</h2>
       <p className="text-2xl font-bold text-indigo-400 mb-4">
         {info.name}

--- a/apps/web/src/app/dashboard/components/usage-card.tsx
+++ b/apps/web/src/app/dashboard/components/usage-card.tsx
@@ -39,7 +39,7 @@ export function UsageCard() {
   const pct = limit ? Math.min((messagesUsed / limit) * 100, 100) : 0;
 
   return (
-    <div className="rounded-xl border border-slate-800 bg-slate-900 p-6">
+    <div className="rounded-2xl border border-slate-800 bg-slate-900 p-6 transition-all duration-200 hover:scale-[1.01] hover:border-slate-700">
       <h2 className="text-lg font-semibold text-white mb-4">
         Today&apos;s Usage
       </h2>

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -4,11 +4,13 @@ import { getSession } from "@/lib/auth/session";
 import { createClient } from "@/lib/supabase/server";
 import { AssistantCard } from "./components/assistant-card";
 import { UsageCard } from "./components/usage-card";
-import { ConnectionsCard } from "./components/connections-card";
 import { PlanCard } from "./components/plan-card";
 import { AiModelCard } from "./components/ai-model-card";
 import { UpgradeBanner } from "./components/upgrade-banner";
+import { MessengerMiniCard } from "./components/messenger-mini-card";
 import type { PlanKey } from "@/lib/stripe/config";
+
+const MESSENGER_KEYS = ["whatsapp", "telegram", "slack", "discord", "signal"];
 
 async function DashboardContent({
   searchParams,
@@ -53,41 +55,37 @@ async function DashboardContent({
     plan = profile?.plan ?? "free";
   }
 
-  const hosting: string | undefined = user?.provider_preference ?? undefined;
-  const messengers: string[] = user?.messengers ?? [];
   const aiProvider: string | null = user?.ai_provider ?? null;
   const aiApiKey: string | null = user?.ai_api_key ?? null;
 
-  // Check provider token connections (Azure + DO need OAuth)
-  let providerConnected = false;
-  if (hosting === "oracle") {
-    providerConnected = true; // We manage Oracle — always active
-  } else if (hosting) {
-    const { data: token } = await supabase
-      .from("provider_tokens")
-      .select("id")
-      .eq("user_id", session.userId)
-      .eq("provider", hosting)
-      .single();
-    providerConnected = !!token;
-  }
+  // Derive first name from session
+  const firstName =
+    session.email?.split("@")[0]?.split(".")[0] ??
+    "there";
+  const greeting = `Hey, ${firstName.charAt(0).toUpperCase()}${firstName.slice(1)}`;
 
   return (
     <div className="min-h-screen bg-slate-950 px-4 py-8 sm:px-6 lg:px-8">
       <div className="mx-auto max-w-5xl">
         {upgraded && <UpgradeBanner />}
-        <h1 className="text-3xl font-bold text-white mb-8">Dashboard</h1>
+        <p className="text-xl font-medium text-white mb-8">{greeting}</p>
 
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-          <AssistantCard assistant={assistant ?? null} />
-          <UsageCard />
-          <ConnectionsCard
-            hosting={hosting}
-            providerConnected={providerConnected}
-            messengers={messengers}
-          />
-          <PlanCard plan={plan} />
+        {/* Bento Grid */}
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          {/* Assistant — spans 2 cols, 2 rows */}
+          <div className="md:col-span-2 md:row-span-2">
+            <AssistantCard assistant={assistant ?? null} />
+          </div>
+
+          {/* Right column stack */}
           <AiModelCard provider={aiProvider} apiKey={aiApiKey} />
+          <PlanCard plan={plan} />
+          <UsageCard />
+
+          {/* Messenger mini-cards — 2x2 grid below assistant area */}
+          {MESSENGER_KEYS.map((key) => (
+            <MessengerMiniCard key={key} messengerKey={key} />
+          ))}
         </div>
       </div>
     </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "openclaw-saas-v3",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
## Changes

**Bento Grid Layout** — Apple-style mixed card sizes for visual hierarchy.

### Layout (desktop `md:grid-cols-3`)
- **Assistant card**: spans 2 cols + 2 rows, diagonal gradient bg (`from-slate-900 to-slate-800/80`)
- **Right column**: AI Model → Plan → Usage cards stacked
- **Below assistant**: Individual messenger mini-cards

### New: Messenger Mini-Cards
- Each messenger (WhatsApp, Telegram, Slack, Discord, Signal) gets its own card
- Lucide icons, green/gray status dots, click-to-setup opens existing `MessengerSetupModal`
- Replaces the old `ConnectionsCard` on the dashboard

### Styling
- All cards: `rounded-2xl`, `hover:scale-[1.01]`, `hover:border-slate-700`
- Greeting replaces Dashboard h1: "Hey, {firstName}"
- Build passes ✅