### PR TITLE
Redesign: Single Page Command Center Dashboard

### DIFF
--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -1,0 +1,2 @@
+.vercel
+.env*.local

--- a/apps/web/src/app/dashboard/components/connections-badges.tsx
+++ b/apps/web/src/app/dashboard/components/connections-badges.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { MessengerSetupModal } from "./messenger-setup-modal";
+
+const MESSENGER_CONFIG: Record<string, { name: string; icon: string }> = {
+  telegram: { name: "Telegram", icon: "💬" },
+  whatsapp: { name: "WhatsApp", icon: "📱" },
+  discord: { name: "Discord", icon: "🎮" },
+  slack: { name: "Slack", icon: "💼" },
+  signal: { name: "Signal", icon: "🔒" },
+};
+
+const PROVIDER_LABELS: Record<string, string> = {
+  oracle: "Oracle Cloud",
+  azure: "Azure",
+  digitalocean: "DigitalOcean",
+};
+
+interface MessengerStatus {
+  messenger: string;
+  connected: boolean;
+  configured: boolean;
+}
+
+interface ConnectionsBadgesProps {
+  hosting?: string;
+  providerConnected?: boolean;
+  messengers?: string[];
+}
+
+export function ConnectionsBadges({
+  hosting,
+  providerConnected = false,
+  messengers = [],
+}: ConnectionsBadgesProps) {
+  const [statuses, setStatuses] = useState<MessengerStatus[]>([]);
+  const [setupModal, setSetupModal] = useState<string | null>(null);
+
+  const fetchStatus = useCallback(async () => {
+    try {
+      const res = await fetch("/api/messaging/status");
+      if (res.ok) {
+        const data = await res.json();
+        const platforms = data.platforms ?? {};
+        setStatuses(
+          Object.entries(platforms).map(([key, val]: [string, any]) => ({
+            messenger: key,
+            connected: val.connected ?? false,
+            configured: val.configured ?? false,
+          }))
+        );
+      }
+    } catch {}
+  }, []);
+
+  useEffect(() => {
+    if (messengers.length > 0) {
+      fetchStatus();
+      const id = setInterval(fetchStatus, 30_000);
+      return () => clearInterval(id);
+    }
+  }, [messengers.length, fetchStatus]);
+
+  const providerActive = hosting === "oracle" || providerConnected;
+
+  return (
+    <>
+      <div className="flex flex-wrap gap-2">
+        {messengers.map((m) => {
+          const config = MESSENGER_CONFIG[m];
+          if (!config) return null;
+          const s = statuses.find((x) => x.messenger === m);
+          const connected = s?.connected ?? false;
+
+          return (
+            <button
+              key={m}
+              onClick={() => !connected && setSetupModal(m)}
+              className={`inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-medium transition-colors ${
+                connected
+                  ? "bg-green-900/30 text-green-400 border border-green-800/50"
+                  : "bg-slate-800 text-slate-400 border border-slate-700 hover:border-slate-600 hover:text-slate-300 cursor-pointer"
+              }`}
+            >
+              <span>{config.icon}</span>
+              <span>{config.name}</span>
+              {connected ? (
+                <span className="text-green-400">✓</span>
+              ) : (
+                <span className="text-slate-500">Set up</span>
+              )}
+            </button>
+          );
+        })}
+
+        {messengers.length === 0 && (
+          <span className="text-xs text-slate-500">No messengers configured</span>
+        )}
+
+        {/* Cloud provider badge */}
+        {hosting && (
+          <span
+            className={`inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-medium border ${
+              providerActive
+                ? "bg-slate-800/50 text-slate-400 border-slate-700"
+                : "bg-slate-800/50 text-slate-500 border-slate-700/50"
+            }`}
+          >
+            ☁️ {PROVIDER_LABELS[hosting] ?? hosting}
+            {providerActive && <span className="text-green-500">✓</span>}
+          </span>
+        )}
+      </div>
+
+      {setupModal && (
+        <MessengerSetupModal
+          messenger={setupModal}
+          onClose={() => {
+            setSetupModal(null);
+            fetchStatus();
+          }}
+          onConnected={() => fetchStatus()}
+        />
+      )}
+    </>
+  );
+}

--- a/apps/web/src/app/dashboard/components/plan-banner.tsx
+++ b/apps/web/src/app/dashboard/components/plan-banner.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { PLANS, type PlanKey } from "@/lib/stripe/config";
+
+const PLAN_LIMITS: Record<PlanKey, string> = {
+  free: "100 msgs/day · 8h/day · Basic skills",
+  pro: "Unlimited messages · 24/7 · All skills · Priority support",
+};
+
+export function PlanBanner({ plan }: { plan: PlanKey }) {
+  const info = PLANS[plan];
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleUpgrade() {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/stripe/checkout", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ plan: "pro" }),
+      });
+      const data = await res.json();
+      if (data.url) {
+        window.location.href = data.url;
+      } else {
+        setError(data.error ?? "Failed to create checkout");
+        setLoading(false);
+      }
+    } catch {
+      setError("Network error");
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-3 rounded-lg bg-slate-900/50 border border-slate-800 px-4 py-3">
+      <span className="text-sm font-semibold text-indigo-400">{info.name}</span>
+      {info.priceMonthly > 0 && (
+        <span className="text-xs text-slate-500">
+          ${(info.priceMonthly / 100).toFixed(0)}/mo
+        </span>
+      )}
+      <span className="text-xs text-slate-500">{PLAN_LIMITS[plan]}</span>
+
+      {error && <span className="text-xs text-red-400">{error}</span>}
+
+      <div className="ml-auto flex items-center gap-2">
+        {plan === "free" ? (
+          <button
+            onClick={handleUpgrade}
+            disabled={loading}
+            className="rounded-md bg-indigo-600 px-3 py-1 text-xs font-medium text-white hover:bg-indigo-500 disabled:opacity-50"
+          >
+            {loading ? "Redirecting…" : "Upgrade to Pro"}
+          </button>
+        ) : (
+          <Link
+            href="/api/stripe/portal"
+            className="text-xs text-indigo-400 hover:text-indigo-300"
+          >
+            Manage subscription →
+          </Link>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/dashboard/components/status-bar.tsx
+++ b/apps/web/src/app/dashboard/components/status-bar.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useState, useEffect } from "react";
+
+interface StatusBarProps {
+  status: string;
+  ipAddress?: string | null;
+  createdAt?: string | null;
+  plan: string;
+}
+
+function useUptime(createdAt: string | null | undefined, isActive: boolean) {
+  const [uptime, setUptime] = useState("");
+
+  useEffect(() => {
+    if (!createdAt || !isActive) {
+      setUptime("");
+      return;
+    }
+    const tick = () => {
+      const ms = Date.now() - new Date(createdAt).getTime();
+      if (ms < 0) { setUptime("0s"); return; }
+      const d = Math.floor(ms / 86_400_000);
+      const h = Math.floor((ms % 86_400_000) / 3_600_000);
+      const m = Math.floor((ms % 3_600_000) / 60_000);
+      const s = Math.floor((ms % 60_000) / 1000);
+      const parts: string[] = [];
+      if (d) parts.push(`${d}d`);
+      if (h) parts.push(`${h}h`);
+      if (m) parts.push(`${m}m`);
+      parts.push(`${s}s`);
+      setUptime(parts.join(" "));
+    };
+    tick();
+    const id = setInterval(tick, 1000);
+    return () => clearInterval(id);
+  }, [createdAt, isActive]);
+
+  return uptime;
+}
+
+const STATUS_MAP: Record<string, { label: string; dot: string }> = {
+  active: { label: "Online", dot: "bg-green-500 shadow-green-500/50 shadow-sm" },
+  provisioning: { label: "Provisioning", dot: "bg-yellow-400 animate-pulse" },
+  suspended: { label: "Suspended", dot: "bg-slate-500" },
+  destroying: { label: "Destroying", dot: "bg-red-400 animate-pulse" },
+  offline: { label: "Offline", dot: "bg-slate-600" },
+};
+
+export function StatusBar({ status, ipAddress, createdAt, plan }: StatusBarProps) {
+  const effective = status || "offline";
+  const { label, dot } = STATUS_MAP[effective] ?? STATUS_MAP.offline;
+  const uptime = useUptime(createdAt, effective === "active");
+
+  return (
+    <div className="sticky top-0 z-30 flex items-center gap-3 bg-slate-950/80 backdrop-blur-sm border-b border-slate-800 px-4 py-2 text-sm">
+      <span className={`h-2.5 w-2.5 rounded-full flex-shrink-0 ${dot}`} />
+      <span className="font-medium text-slate-100">{label}</span>
+
+      {ipAddress && effective === "active" && (
+        <span className="text-slate-500 font-mono text-xs">{ipAddress}</span>
+      )}
+
+      {uptime && (
+        <span className="text-slate-500 font-mono text-xs tabular-nums">
+          {uptime}
+        </span>
+      )}
+
+      <span className="ml-auto rounded-full bg-slate-800 px-2.5 py-0.5 text-xs font-medium text-slate-300 capitalize">
+        {plan}
+      </span>
+    </div>
+  );
+}

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -2,11 +2,12 @@ import { Suspense } from "react";
 import { redirect } from "next/navigation";
 import { getSession } from "@/lib/auth/session";
 import { createClient } from "@/lib/supabase/server";
+import { StatusBar } from "./components/status-bar";
 import { AssistantCard } from "./components/assistant-card";
+import { ConnectionsBadges } from "./components/connections-badges";
 import { UsageCard } from "./components/usage-card";
-import { ConnectionsCard } from "./components/connections-card";
-import { PlanCard } from "./components/plan-card";
 import { AiModelCard } from "./components/ai-model-card";
+import { PlanBanner } from "./components/plan-banner";
 import { UpgradeBanner } from "./components/upgrade-banner";
 import type { PlanKey } from "@/lib/stripe/config";
 
@@ -25,7 +26,7 @@ async function DashboardContent({
 
   const supabase: any = createClient();
 
-  // Fetch assistant status (include provider info)
+  // Fetch assistant status
   const { data: assistant } = await supabase
     .from("assistants")
     .select("id, status, ip_address, provider, region, created_at")
@@ -35,14 +36,13 @@ async function DashboardContent({
     .limit(1)
     .single();
 
-  // Fetch user record for plan, hosting preference, and messengers
+  // Fetch user record
   const { data: user } = await supabase
     .from("users")
     .select("plan, provider_preference, messengers, ai_provider, ai_api_key")
     .eq("id", session.userId)
     .single();
 
-  // Fallback to profiles table for plan if users table doesn't have it
   let plan: PlanKey = user?.plan ?? "free";
   if (!user?.plan) {
     const { data: profile } = await supabase
@@ -58,10 +58,9 @@ async function DashboardContent({
   const aiProvider: string | null = user?.ai_provider ?? null;
   const aiApiKey: string | null = user?.ai_api_key ?? null;
 
-  // Check provider token connections (Azure + DO need OAuth)
   let providerConnected = false;
   if (hosting === "oracle") {
-    providerConnected = true; // We manage Oracle — always active
+    providerConnected = true;
   } else if (hosting) {
     const { data: token } = await supabase
       .from("provider_tokens")
@@ -72,23 +71,65 @@ async function DashboardContent({
     providerConnected = !!token;
   }
 
-  return (
-    <div className="min-h-screen bg-slate-950 px-4 py-8 sm:px-6 lg:px-8">
-      <div className="mx-auto max-w-5xl">
-        {upgraded && <UpgradeBanner />}
-        <h1 className="text-3xl font-bold text-white mb-8">Dashboard</h1>
+  const assistantStatus = assistant?.status ?? "offline";
 
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+  return (
+    <div className="min-h-screen bg-slate-950">
+      {/* Sticky status bar */}
+      <StatusBar
+        status={assistantStatus}
+        ipAddress={assistant?.ip_address}
+        createdAt={assistant?.created_at}
+        plan={plan}
+      />
+
+      <div className="mx-auto max-w-4xl px-4 py-6 space-y-0">
+        {upgraded && <UpgradeBanner />}
+
+        {/* Section: Assistant */}
+        <section className="py-5">
+          <h2 className="text-xs font-bold uppercase tracking-wider text-slate-500 mb-3">
+            Assistant
+          </h2>
           <AssistantCard assistant={assistant ?? null} />
-          <UsageCard />
-          <ConnectionsCard
+        </section>
+
+        <div className="border-t border-slate-800" />
+
+        {/* Section: Connections */}
+        <section className="py-5">
+          <h2 className="text-xs font-bold uppercase tracking-wider text-slate-500 mb-3">
+            Connections
+          </h2>
+          <ConnectionsBadges
             hosting={hosting}
             providerConnected={providerConnected}
             messengers={messengers}
           />
-          <PlanCard plan={plan} />
-          <AiModelCard provider={aiProvider} apiKey={aiApiKey} />
-        </div>
+        </section>
+
+        <div className="border-t border-slate-800" />
+
+        {/* Section: Configuration */}
+        <section className="py-5">
+          <h2 className="text-xs font-bold uppercase tracking-wider text-slate-500 mb-3">
+            Configuration
+          </h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <AiModelCard provider={aiProvider} apiKey={aiApiKey} />
+            <UsageCard />
+          </div>
+        </section>
+
+        <div className="border-t border-slate-800" />
+
+        {/* Section: Plan */}
+        <section className="py-5">
+          <h2 className="text-xs font-bold uppercase tracking-wider text-slate-500 mb-3">
+            Plan
+          </h2>
+          <PlanBanner plan={plan} />
+        </section>
       </div>
     </div>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "openclaw-saas-v2",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
## Dashboard V2 — Command Center Design

Vertical sections with a monitoring dashboard feel.

### Changes
- **Sticky status bar** at top: green/yellow/red dot, status label, IP address, live uptime counter (ticks every second), plan badge
- **Assistant section**: full-width with provider/region/IP details, action buttons (existing AssistantCard)
- **Connections section**: horizontal row of compact messenger pills (icon + name + ✓ or "Set up"). Cloud provider as muted badge. Clicking "Set up" opens existing MessengerSetupModal
- **Configuration section**: side-by-side AI Model + Usage cards (with progress bars for free plan)
- **Plan section**: inline banner with plan name, limits summary, upgrade CTA

### New Components
- `status-bar.tsx` — client component with live uptime ticker
- `connections-badges.tsx` — compact pill-style messenger/provider badges
- `plan-banner.tsx` — inline plan banner replacing full card

### Design Details
- Section headings: `text-xs font-bold uppercase tracking-wider text-slate-500`
- Thin dividers (`border-slate-800`) between sections
- Max width `max-w-4xl` for focused single-column feel
- Build passes ✅