### PR TITLE
fix: disable dashboard actions while provisioning

### DIFF
--- a/apps/web/src/app/dashboard/components/ai-model-card.tsx
+++ b/apps/web/src/app/dashboard/components/ai-model-card.tsx
@@ -17,9 +17,11 @@ function maskKey(key: string): string {
 export function AiModelCard({
   provider,
   apiKey,
+  disabled = false,
 }: {
   provider?: string | null;
   apiKey?: string | null;
+  disabled?: boolean;
 }) {
   const configured = !!provider && !!apiKey;
   const label = provider ? PROVIDER_LABELS[provider] ?? provider : null;
@@ -44,12 +46,18 @@ export function AiModelCard({
         </>
       )}
 
-      <Link
-        href="/settings/ai"
-        className="inline-block rounded-lg bg-indigo-600 px-4 py-2 text-sm text-white hover:bg-indigo-500"
-      >
-        {configured ? "Change" : "Set up AI provider"}
-      </Link>
+      {disabled ? (
+        <span className="inline-block rounded-lg bg-slate-700 px-4 py-2 text-sm text-slate-500 cursor-not-allowed">
+          {configured ? "Change" : "Set up AI provider"}
+        </span>
+      ) : (
+        <Link
+          href="/settings/ai"
+          className="inline-block rounded-lg bg-indigo-600 px-4 py-2 text-sm text-white hover:bg-indigo-500"
+        >
+          {configured ? "Change" : "Set up AI provider"}
+        </Link>
+      )}
     </div>
   );
 }

--- a/apps/web/src/app/dashboard/components/connections-card.tsx
+++ b/apps/web/src/app/dashboard/components/connections-card.tsx
@@ -23,10 +23,12 @@ interface MessengerStatus {
 
 interface ConnectionsCardProps {
   messengers?: string[];
+  disabled?: boolean;
 }
 
 export function ConnectionsCard({
   messengers = [],
+  disabled = false,
 }: ConnectionsCardProps) {
   const [messengerStatuses, setMessengerStatuses] = useState<
     MessengerStatus[]
@@ -131,7 +133,7 @@ export function ConnectionsCard({
                     )}
                     <button
                       type="button"
-                      disabled={disconnecting === m}
+                      disabled={disconnecting === m || disabled}
                       onClick={() => handleDisconnect(m)}
                       className="rounded-md bg-red-900/50 px-3 py-1 text-xs text-red-400 hover:bg-red-900/80 disabled:opacity-50"
                     >
@@ -142,8 +144,9 @@ export function ConnectionsCard({
                 {!connected && configured && (
                   <button
                     type="button"
+                    disabled={disabled}
                     onClick={() => setSetupModal(m)}
-                    className="rounded-md bg-amber-600 px-3 py-1 text-xs text-white hover:bg-amber-500"
+                    className="rounded-md bg-amber-600 px-3 py-1 text-xs text-white hover:bg-amber-500 disabled:opacity-50 disabled:cursor-not-allowed"
                   >
                     Reconnect
                   </button>
@@ -151,8 +154,9 @@ export function ConnectionsCard({
                 {!connected && !configured && (
                   <button
                     type="button"
+                    disabled={disabled}
                     onClick={() => setSetupModal(m)}
-                    className="rounded-md bg-slate-800 px-3 py-1 text-xs text-slate-400 hover:bg-slate-700"
+                    className="rounded-md bg-slate-800 px-3 py-1 text-xs text-slate-400 hover:bg-slate-700 disabled:opacity-50 disabled:cursor-not-allowed"
                   >
                     Set up
                   </button>

--- a/apps/web/src/app/dashboard/components/quick-actions.tsx
+++ b/apps/web/src/app/dashboard/components/quick-actions.tsx
@@ -5,12 +5,14 @@ import Link from "next/link";
 interface QuickActionsProps {
   ipAddress?: string | null;
   isActive: boolean;
+  disabled?: boolean;
 }
 
-export function QuickActions({ ipAddress, isActive }: QuickActionsProps) {
+export function QuickActions({ ipAddress, isActive, disabled }: QuickActionsProps) {
+  const disableAll = disabled || !isActive;
   return (
     <div className="flex flex-wrap gap-3">
-      {isActive && ipAddress ? (
+      {isActive && ipAddress && !disabled ? (
         <a
           href={`http://${ipAddress}:8787`}
           target="_blank"
@@ -27,13 +29,20 @@ export function QuickActions({ ipAddress, isActive }: QuickActionsProps) {
         </span>
       )}
 
-      <Link
-        href="/dashboard/settings"
-        className="inline-flex items-center gap-2 rounded-full bg-slate-800 px-5 py-2 text-sm font-medium text-slate-200 hover:bg-slate-700 transition-colors"
-      >
-        <span className="text-base">⚙</span>
-        Settings
-      </Link>
+      {disableAll ? (
+        <span className="inline-flex items-center gap-2 rounded-full bg-slate-800 px-5 py-2 text-sm font-medium text-slate-500 cursor-not-allowed">
+          <span className="text-base">⚙</span>
+          Settings
+        </span>
+      ) : (
+        <Link
+          href="/dashboard/settings"
+          className="inline-flex items-center gap-2 rounded-full bg-slate-800 px-5 py-2 text-sm font-medium text-slate-200 hover:bg-slate-700 transition-colors"
+        >
+          <span className="text-base">⚙</span>
+          Settings
+        </Link>
+      )}
 
       <span className="inline-flex items-center gap-2 rounded-full bg-slate-800 px-5 py-2 text-sm font-medium text-slate-500 cursor-not-allowed">
         <span className="text-base">📋</span>

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -56,6 +56,7 @@ async function DashboardContent({
   const aiApiKey: string | null = user?.ai_api_key ?? null;
 
   const isActive = assistant?.status === "active";
+  const isProvisioning = assistant?.status === "provisioning" || assistant?.status === "destroying";
 
   return (
     <div className="min-h-screen bg-slate-950 px-4 py-8 sm:px-6 lg:px-8">
@@ -69,18 +70,19 @@ async function DashboardContent({
         <QuickActions
           ipAddress={assistant?.ip_address}
           isActive={isActive}
+          disabled={isProvisioning}
         />
 
         {/* Three-column grid */}
         <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
           {/* Col 1: Connections */}
           <div>
-            <ConnectionsCard messengers={messengers} />
+            <ConnectionsCard messengers={messengers} disabled={isProvisioning} />
           </div>
 
           {/* Col 2: AI Model + Usage stacked */}
           <div className="space-y-6">
-            <AiModelCard provider={aiProvider} apiKey={aiApiKey} />
+            <AiModelCard provider={aiProvider} apiKey={aiApiKey} disabled={isProvisioning} />
             <UsageCard />
           </div>
 


### PR DESCRIPTION
Disables Quick Actions, Connections setup buttons, and AI Model link when assistant is provisioning or destroying.