### PR TITLE
fix: redirect to sign-in on stale session

### DIFF
--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -41,6 +41,11 @@ async function DashboardContent({
     .eq("id", session.userId)
     .single();
 
+  // Stale session (user deleted/DB wiped) - redirect to sign in
+  if (!user) {
+    redirect("/auth/signin");
+  }
+
   let plan: PlanKey = user?.plan ?? "free";
   if (!user?.plan) {
     const { data: profile } = await supabase


### PR DESCRIPTION
After DB wipes, stale session cookies cause 'Cannot coerce to single JSON object' errors. Now redirects to sign-in gracefully.