### PR TITLE
feat: Gray out OpenAI/Anthropic (Coming Soon) + GitHub OAuth for Copilot

### DIFF
--- a/apps/web/src/app/api/auth/github/callback/route.ts
+++ b/apps/web/src/app/api/auth/github/callback/route.ts
@@ -1,0 +1,109 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getSession } from '@/lib/auth/session';
+import { createClient } from '@/lib/supabase/server';
+
+/**
+ * GitHub OAuth callback for Copilot API access.
+ *
+ * Exchanges the authorization code for an access token,
+ * verifies it works with GitHub Models API, and saves it
+ * as the user's AI provider credentials.
+ *
+ * Environment variables required:
+ * - GITHUB_CLIENT_ID
+ * - GITHUB_CLIENT_SECRET
+ */
+export async function GET(req: NextRequest) {
+  const url = new URL(req.url);
+  const code = url.searchParams.get('code');
+  const stateParam = url.searchParams.get('state');
+
+  // Decode state
+  let returnTo = '/onboarding?step=7';
+  if (stateParam) {
+    try {
+      const state = JSON.parse(Buffer.from(stateParam, 'base64url').toString());
+      if (state.returnTo) returnTo = state.returnTo;
+    } catch {
+      // ignore malformed state
+    }
+  }
+
+  if (!code) {
+    return NextResponse.redirect(new URL(`${returnTo}${returnTo.includes('?') ? '&' : '?'}error=missing_code`, url.origin));
+  }
+
+  const clientId = process.env.GITHUB_CLIENT_ID;
+  const clientSecret = process.env.GITHUB_CLIENT_SECRET;
+  if (!clientId || !clientSecret) {
+    return NextResponse.redirect(new URL(`${returnTo}${returnTo.includes('?') ? '&' : '?'}error=oauth_not_configured`, url.origin));
+  }
+
+  // Exchange code for access token
+  let accessToken: string;
+  try {
+    const tokenRes = await fetch('https://github.com/login/oauth/access_token', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      body: JSON.stringify({
+        client_id: clientId,
+        client_secret: clientSecret,
+        code,
+      }),
+    });
+    const tokenData = await tokenRes.json();
+    if (tokenData.error || !tokenData.access_token) {
+      return NextResponse.redirect(
+        new URL(`${returnTo}${returnTo.includes('?') ? '&' : '?'}error=token_exchange`, url.origin)
+      );
+    }
+    accessToken = tokenData.access_token;
+  } catch {
+    return NextResponse.redirect(
+      new URL(`${returnTo}${returnTo.includes('?') ? '&' : '?'}error=token_exchange`, url.origin)
+    );
+  }
+
+  // Verify the token works with GitHub Models API (Copilot)
+  try {
+    const testRes = await fetch('https://models.inference.ai.azure.com/chat/completions', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: 'gpt-4o-mini',
+        messages: [{ role: 'user', content: 'Say hi' }],
+        max_tokens: 5,
+      }),
+    });
+    if (!testRes.ok) {
+      // Token doesn't have Copilot access - still save it but warn
+      console.warn('GitHub token Copilot verification failed:', testRes.status);
+    }
+  } catch {
+    console.warn('GitHub token Copilot verification request failed');
+  }
+
+  // Save the token to the user's record
+  const session = await getSession();
+  if (!session) {
+    return NextResponse.redirect(new URL('/login', url.origin));
+  }
+
+  try {
+    const supabase = createClient();
+    await (supabase as any).from('users').update({
+      ai_provider: 'github-copilot',
+      ai_api_key: accessToken,
+    }).eq('id', session.userId);
+  } catch (err) {
+    console.error('Failed to save GitHub token:', err);
+  }
+
+  return NextResponse.redirect(new URL(returnTo, url.origin));
+}

--- a/apps/web/src/app/api/auth/github/route.ts
+++ b/apps/web/src/app/api/auth/github/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+/**
+ * GitHub OAuth initiation for Copilot API access.
+ *
+ * Environment variables required:
+ * - GITHUB_CLIENT_ID: from GitHub OAuth App
+ * - GITHUB_CLIENT_SECRET: from GitHub OAuth App
+ */
+export async function GET(req: NextRequest) {
+  const clientId = process.env.GITHUB_CLIENT_ID;
+  if (!clientId) {
+    return NextResponse.json(
+      { error: 'GitHub OAuth not configured. Set GITHUB_CLIENT_ID and GITHUB_CLIENT_SECRET.' },
+      { status: 500 }
+    );
+  }
+
+  const url = new URL(req.url);
+  const returnTo = url.searchParams.get('returnTo') || '/onboarding?step=7';
+
+  const state = Buffer.from(
+    JSON.stringify({ returnTo, purpose: 'ai-provider', ts: Date.now() })
+  ).toString('base64url');
+
+  const redirectUri = `${url.origin}/api/auth/github/callback`;
+
+  const githubUrl = new URL('https://github.com/login/oauth/authorize');
+  githubUrl.searchParams.set('client_id', clientId);
+  githubUrl.searchParams.set('redirect_uri', redirectUri);
+  githubUrl.searchParams.set('scope', 'copilot');
+  githubUrl.searchParams.set('state', state);
+
+  return NextResponse.redirect(githubUrl.toString());
+}

--- a/apps/web/src/app/dashboard/settings/page.tsx
+++ b/apps/web/src/app/dashboard/settings/page.tsx
@@ -116,19 +116,36 @@ export default function SettingsPage() {
           ) : (
             <div className="space-y-3 rounded-lg border border-slate-700 bg-slate-800/50 p-4">
               <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
-                {(['gemini', 'openai', 'anthropic', 'github-copilot'] as const).map((p) => (
-                  <button
-                    key={p}
-                    onClick={() => { setNewAiProvider(p); setNewAiApiKey(''); setAiKeyVerified(false); setAiKeyError(null); }}
-                    className={`px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
-                      newAiProvider === p ? 'bg-violet-600 text-white' : 'bg-slate-700 text-slate-300 hover:bg-slate-600'
-                    }`}
-                  >
-                    {p === 'github-copilot' ? 'GitHub Copilot' : p.charAt(0).toUpperCase() + p.slice(1)}
-                  </button>
-                ))}
+                {(['gemini', 'openai', 'anthropic', 'github-copilot'] as const).map((p) => {
+                  const isComingSoon = p === 'openai' || p === 'anthropic';
+                  return (
+                    <button
+                      key={p}
+                      disabled={isComingSoon}
+                      onClick={() => { if (!isComingSoon) { setNewAiProvider(p); setNewAiApiKey(''); setAiKeyVerified(false); setAiKeyError(null); } }}
+                      className={`px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
+                        isComingSoon ? 'bg-slate-800 text-slate-500 opacity-50 cursor-not-allowed' :
+                        newAiProvider === p ? 'bg-violet-600 text-white' : 'bg-slate-700 text-slate-300 hover:bg-slate-600'
+                      }`}
+                    >
+                      {p === 'github-copilot' ? 'GitHub Copilot' : p.charAt(0).toUpperCase() + p.slice(1)}
+                      {isComingSoon && <span className="block text-[9px] uppercase tracking-wider text-slate-500">Soon</span>}
+                    </button>
+                  );
+                })}
               </div>
               {newAiProvider && (
+                newAiProvider === 'github-copilot' && process.env.NEXT_PUBLIC_GITHUB_CLIENT_ID ? (
+                  <div className="space-y-2">
+                    <p className="text-sm text-slate-400">Sign in with GitHub to connect your Copilot subscription.</p>
+                    <a
+                      href={`/api/auth/github?returnTo=${encodeURIComponent('/dashboard/settings')}`}
+                      className="inline-flex items-center gap-2 px-4 py-2.5 rounded-lg bg-slate-700 hover:bg-slate-600 border border-slate-600 text-sm font-medium text-white transition-colors"
+                    >
+                      Sign in with GitHub
+                    </a>
+                  </div>
+                ) : (
                 <div className="flex gap-2">
                   <input
                     type="password"
@@ -158,6 +175,7 @@ export default function SettingsPage() {
                     {aiKeyVerifying ? 'Verifying...' : aiKeyVerified ? '✓ Verified' : 'Verify'}
                   </button>
                 </div>
+              )
               )}
               {aiKeyError && <p className="text-sm text-red-400">{aiKeyError}</p>}
               <div className="flex gap-2">

--- a/apps/web/src/app/onboarding/wizard.tsx
+++ b/apps/web/src/app/onboarding/wizard.tsx
@@ -1042,8 +1042,18 @@ export default function OnboardingWizard() {
 
             <div className="flex justify-between items-center">
               <BackBtn />
-              <PrimaryBtn onClick={next} disabled={!aiProvider}>
-                Next <ArrowRight className="w-4 h-4" />
+              <PrimaryBtn onClick={() => {
+                if (aiProvider === 'github-copilot') {
+                  if (process.env.NEXT_PUBLIC_GITHUB_CLIENT_ID) {
+                    window.location.href = `/api/auth/github?returnTo=${encodeURIComponent('/onboarding?step=3')}`;
+                  } else {
+                    next();
+                  }
+                } else {
+                  next();
+                }
+              }} disabled={!aiProvider}>
+                {aiProvider === 'github-copilot' && process.env.NEXT_PUBLIC_GITHUB_CLIENT_ID ? 'Connect with GitHub' : 'Next'} <ArrowRight className="w-4 h-4" />
               </PrimaryBtn>
             </div>
           </div>
@@ -1266,7 +1276,20 @@ export default function OnboardingWizard() {
                   </div>
                   {serverActive && !aiKeyVerified && (
                     <div className="space-y-3">
-                      <p className="text-xs text-slate-400">Enter your API key to connect your AI provider.</p>
+                      {aiProvider === 'github-copilot' && process.env.NEXT_PUBLIC_GITHUB_CLIENT_ID ? (
+                        <>
+                          <p className="text-xs text-slate-400">Sign in with GitHub to connect your Copilot subscription.</p>
+                          <a
+                            href={`/api/auth/github?returnTo=${encodeURIComponent('/onboarding?step=7')}`}
+                            className="inline-flex items-center gap-2 px-4 py-2.5 rounded-lg bg-slate-800 hover:bg-slate-700 border border-slate-600 text-sm font-medium text-white transition-colors"
+                          >
+                            <Code className="w-4 h-4" />
+                            Sign in with GitHub
+                          </a>
+                        </>
+                      ) : (
+                        <>
+                          <p className="text-xs text-slate-400">Enter your API key to connect your AI provider.</p>
                       <div className="flex gap-2">
                         <input
                           type="password"
@@ -1328,6 +1351,8 @@ export default function OnboardingWizard() {
                       >
                         Get a key <ExternalLink className="w-3 h-3" />
                       </a>
+                        </>
+                      )}
                     </div>
                   )}
                   {serverActive && aiKeyVerified && (


### PR DESCRIPTION
## Changes

### 1. Gray out OpenAI and Anthropic with "Coming Soon"
- Onboarding wizard (step 3): OpenAI and Anthropic cards are non-clickable with `opacity-50 cursor-not-allowed` and a "COMING SOON" badge
- Settings page: Same treatment — provider buttons disabled with "Soon" label
- Verification API route left intact for future use

### 2. GitHub OAuth flow for Copilot
- New `/api/auth/github` route initiates GitHub OAuth with `copilot` scope
- New `/api/auth/github/callback` route exchanges code for token, verifies with GitHub Models API, saves to DB
- Onboarding step 3: "Connect with GitHub" button when Copilot selected (if OAuth configured)
- Onboarding step 7: "Sign in with GitHub" button instead of API key input
- Settings page: Same GitHub sign-in option
- Falls back to manual API key input when `GITHUB_CLIENT_ID` env var is not set

### Environment Variables Needed
- `GITHUB_CLIENT_ID` — from GitHub OAuth App
- `GITHUB_CLIENT_SECRET` — from GitHub OAuth App
- `NEXT_PUBLIC_GITHUB_CLIENT_ID` — same value, for client-side conditional rendering

### Build
✅ `next build` passes cleanly