### PR TITLE
fix: handle Telegram setup timeout on Vercel Hobby plan

### DIFF
--- a/apps/web/src/app/api/messaging/setup/route.ts
+++ b/apps/web/src/app/api/messaging/setup/route.ts
@@ -7,6 +7,8 @@ import {
 } from '@/lib/messaging/setup';
 import { NextResponse } from 'next/server';
 
+export const maxDuration = 60; // BotFather automation can take 15-30s
+
 export async function POST(request: Request) {
   try {
     const session = await getSession();

--- a/apps/web/src/app/api/messaging/status/route.ts
+++ b/apps/web/src/app/api/messaging/status/route.ts
@@ -2,6 +2,8 @@ import { createClient } from '@/lib/supabase/server';
 import { getSession } from '@/lib/auth/session';
 import { NextResponse } from 'next/server';
 
+export const maxDuration = 15;
+
 const SIDECAR_PORT = 8788;
 
 export async function GET() {

--- a/apps/web/src/app/onboarding/wizard.tsx
+++ b/apps/web/src/app/onboarding/wizard.tsx
@@ -604,10 +604,46 @@ export default function OnboardingWizard() {
           setStatus('ready');
         }
       } catch {
-        setError('Failed to set up — please try again');
+        // Setup may have succeeded but timed out - check status before giving up
+        try {
+          await new Promise(r => setTimeout(r, 3000));
+          const statusRes = await fetch('/api/messaging/status');
+          if (statusRes.ok) {
+            const statusData = await statusRes.json();
+            const platformStatus = statusData?.platforms?.[messengerId] || statusData?.statuses?.find?.((s: any) => s.messenger === messengerId);
+            if (platformStatus?.connected || platformStatus?.configured) {
+              setStatus('connected');
+              if (platformStatus.botLink) {
+                setBotLink(platformStatus.botLink);
+                onReady?.(messengerId, platformStatus.botLink);
+              }
+              return;
+            }
+          }
+        } catch { /* ignore */ }
+        setError('Setup timed out — please try again');
         setStatus('failed');
       }
     }, [messengerId, onReady]);
+
+    // Poll status while setup is in progress — self-heals if setup call times out
+    useEffect(() => {
+      if (status !== 'setting-up') return;
+      const interval = setInterval(async () => {
+        try {
+          const res = await fetch('/api/messaging/status');
+          if (!res.ok) return;
+          const data = await res.json();
+          const ps = data?.platforms?.[messengerId];
+          if (ps?.connected || ps?.configured) {
+            setStatus('connected');
+            if (ps.botLink) setBotLink(ps.botLink);
+            onReady?.(messengerId, ps.botLink || '');
+          }
+        } catch { /* ignore */ }
+      }, 5000);
+      return () => clearInterval(interval);
+    }, [status, messengerId, onReady]);
 
     // Auto-trigger setup when server comes online (all messengers)
     useEffect(() => {

--- a/apps/web/src/lib/messaging/telegram-bot-factory.ts
+++ b/apps/web/src/lib/messaging/telegram-bot-factory.ts
@@ -48,15 +48,15 @@ export async function createTelegramBot(
   const botFather = await tg.getEntity('BotFather');
 
   await tg.sendMessage(botFather, { message: '/newbot' });
-  await sleep(1500);
+  await sleep(1000);
 
   // Send the display name
   await tg.sendMessage(botFather, { message: botName });
-  await sleep(1500);
+  await sleep(1000);
 
   // Send the username
   await tg.sendMessage(botFather, { message: botUsername });
-  await sleep(2000);
+  await sleep(1500);
 
   // Read the response — BotFather sends back the token
   const messages = await tg.getMessages(botFather, { limit: 3 });
@@ -82,9 +82,9 @@ export async function createTelegramBot(
       // The bot already exists from a previous run. Request its token via /token.
       try {
         await tg.sendMessage(botFather, { message: '/token' });
-        await sleep(1500);
+        await sleep(1000);
         await tg.sendMessage(botFather, { message: `@${botUsername}` });
-        await sleep(2000);
+        await sleep(1500);
 
         const tokenMsgs = await tg.getMessages(botFather, { limit: 3 });
         for (const msg of tokenMsgs) {
@@ -105,11 +105,11 @@ export async function createTelegramBot(
       // Try with a random suffix.
       const fallbackUsername = `sw_${shortId}_${Math.floor(Math.random() * 999)}_bot`;
       await tg.sendMessage(botFather, { message: '/newbot' });
-      await sleep(1500);
+      await sleep(1000);
       await tg.sendMessage(botFather, { message: botName });
-      await sleep(1500);
+      await sleep(1000);
       await tg.sendMessage(botFather, { message: fallbackUsername });
-      await sleep(2000);
+      await sleep(1500);
 
       const retryMsgs = await tg.getMessages(botFather, { limit: 3 });
       for (const msg of retryMsgs) {
@@ -162,9 +162,9 @@ export async function deleteTelegramBot(botUsername: string): Promise<void> {
   const botFather = await tg.getEntity('BotFather');
 
   await tg.sendMessage(botFather, { message: '/deletebot' });
-  await sleep(1500);
+  await sleep(1000);
   await tg.sendMessage(botFather, { message: `@${botUsername}` });
-  await sleep(1500);
+  await sleep(1000);
   // BotFather asks "Are you sure?" — confirm
   await tg.sendMessage(botFather, { message: 'Yes, I am totally sure.' });
   await sleep(1000);


### PR DESCRIPTION
## Problem
Telegram bot creation via BotFather automation takes 10-30s (sleep delays + API calls + sidecar config). Vercel Hobby plan has a 10s default function timeout, causing the wizard to show an error even though the bot was actually created.

## Changes
- **`maxDuration` exports**: Set 60s for setup route, 15s for status route (Vercel respects these)
- **Self-healing status poll**: New `useEffect` polls `/api/messaging/status` every 5s while setup is in progress — if the bot gets created despite a timeout, the UI auto-updates to 'connected'
- **Catch-block fallback**: If the setup call errors, waits 3s then checks status before showing failure
- **Reduced sleep durations**: Shaved ~2s off BotFather interaction by reducing conservative sleeps (1500→1000ms, 2000→1500ms)