### PR TITLE
feat: unique RG per assistant + remove unimplemented messengers

### DIFF
--- a/apps/web/src/app/dashboard/components/connections-card.tsx
+++ b/apps/web/src/app/dashboard/components/connections-card.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState, useCallback } from "react";
 import { MessengerSetupModal } from "./messenger-setup-modal";
 
-const ALL_MESSENGERS = ["telegram", "whatsapp", "discord", "slack", "signal"] as const;
+const ALL_MESSENGERS = ["telegram", "whatsapp"] as const;
 
 const MESSENGER_CONFIG: Record<
   string,

--- a/apps/web/src/app/onboarding/wizard.tsx
+++ b/apps/web/src/app/onboarding/wizard.tsx
@@ -17,9 +17,6 @@ const STEPS = ['Welcome', 'Hosting', 'Subscription', 'AI Provider', 'Plan', 'Mes
 const MESSENGERS = [
   { id: 'whatsapp', label: 'WhatsApp', icon: MessageCircle },
   { id: 'telegram', label: 'Telegram', icon: Send },
-  { id: 'discord', label: 'Discord', icon: Hash },
-  { id: 'slack', label: 'Slack', icon: Slack },
-  { id: 'signal', label: 'Signal', icon: Shield },
 ];
 
 type SkillDef = {

--- a/apps/web/src/lib/providers/azure.ts
+++ b/apps/web/src/lib/providers/azure.ts
@@ -11,7 +11,7 @@ const DEFAULT_IMAGE = {
   sku: 'server',
   version: 'latest',
 };
-const RG_NAME = 'shiftworker-rg';
+const RG_PREFIX = 'sw-rg-';
 const VNET_NAME = 'shiftworker-vnet';
 const SUBNET_NAME = 'default';
 const NSG_NAME = 'shiftworker-nsg';
@@ -113,15 +113,18 @@ async function waitForProvision(token: string, path: string, timeoutMs = 300_000
 export async function ensureResourceGroup(
   token: string,
   subscriptionId: string,
+  assistantId: string,
   region?: string,
 ): Promise<string> {
   const loc = region ?? DEFAULT_REGION;
-  const path = `/subscriptions/${subscriptionId}/resourceGroups/${RG_NAME}?api-version=${RESOURCE_API}`;
+  const shortId = assistantId.split('-')[0];
+  const rgName = `${RG_PREFIX}${shortId}`;
+  const path = `/subscriptions/${subscriptionId}/resourceGroups/${rgName}?api-version=${RESOURCE_API}`;
   await azureFetch(token, path, {
     method: 'PUT',
     body: JSON.stringify({ location: loc }),
   });
-  return RG_NAME;
+  return rgName;
 }
 
 export async function ensureNetworking(
@@ -342,44 +345,13 @@ export async function destroyVM(
   resourceGroup: string,
   vmName: string,
 ): Promise<void> {
-  const base = `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers`;
-
-  // Delete VM first
-  await azureFetch(token, `${base}/Microsoft.Compute/virtualMachines/${vmName}?api-version=${COMPUTE_API}`, {
-    method: 'DELETE',
-  });
-  // Wait for VM deletion
-  await pollDeletion(token, `${base}/Microsoft.Compute/virtualMachines/${vmName}?api-version=${COMPUTE_API}`);
-
-  // Delete NIC
-  await azureFetch(token, `${base}/Microsoft.Network/networkInterfaces/${vmName}-nic?api-version=${NETWORK_API}`, {
-    method: 'DELETE',
-  }).catch(() => {}); // May already be gone
-  await pollDeletion(token, `${base}/Microsoft.Network/networkInterfaces/${vmName}-nic?api-version=${NETWORK_API}`);
-
-  // Delete public IP
-  await azureFetch(token, `${base}/Microsoft.Network/publicIPAddresses/${vmName}-ip?api-version=${NETWORK_API}`, {
-    method: 'DELETE',
-  }).catch(() => {});
-
-  // Delete OS disk (Azure auto-names it: {vmName}_disk1_{guid})
-  // List disks in the resource group and delete any belonging to this VM
-  try {
-    const disksRes = await azureFetch(
-      token,
-      `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.Compute/disks?api-version=${COMPUTE_API}`,
-    );
-    const disks = disksRes?.value ?? [];
-    for (const disk of disks) {
-      if (disk.name?.startsWith(`${vmName}_disk`)) {
-        await azureFetch(token, `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.Compute/disks/${disk.name}?api-version=${COMPUTE_API}`, {
-          method: 'DELETE',
-        }).catch(() => {});
-      }
-    }
-  } catch {
-    // Best-effort disk cleanup
-  }
+  // Each assistant has its own resource group — delete the entire RG
+  // This cleans up VM, NIC, IP, disk, NSG, VNet — everything
+  await azureFetch(
+    token,
+    `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}?api-version=${RESOURCE_API}`,
+    { method: 'DELETE' },
+  );
 }
 
 async function pollDeletion(token: string, path: string, timeoutMs = 120_000) {

--- a/apps/web/src/lib/vm/provisioning-steps.ts
+++ b/apps/web/src/lib/vm/provisioning-steps.ts
@@ -24,7 +24,7 @@ const NETWORK_API = '2024-05-01';
 const RESOURCE_API = '2024-07-01';
 
 const DEFAULT_REGION = 'southcentralus';
-const RG_NAME = 'shiftworker-rg';
+const RG_PREFIX = 'sw-rg-';
 const VNET_NAME = 'shiftworker-vnet';
 const SUBNET_NAME = 'default';
 const NSG_NAME = 'shiftworker-nsg';
@@ -112,6 +112,7 @@ export async function advanceProvisioning(assistant: Assistant): Promise<Assista
   if (!step || step === 'done') return assistant;
 
   const token = await getUserToken(assistant.user_id);
+  const rgName = `${RG_PREFIX}${assistant.id.split('-')[0]}`;
 
   switch (step) {
     case 'validate': {
@@ -175,7 +176,7 @@ export async function advanceProvisioning(assistant: Assistant): Promise<Assista
 
     case 'create_rg': {
       const { subscriptionId } = pd;
-      const path = `/subscriptions/${subscriptionId}/resourceGroups/${RG_NAME}?api-version=${RESOURCE_API}`;
+      const path = `/subscriptions/${subscriptionId}/resourceGroups/${rgName}?api-version=${RESOURCE_API}`;
       const region = pd.region ?? DEFAULT_REGION;
 
       // Check if RG exists in a different region - delete it first
@@ -208,7 +209,7 @@ export async function advanceProvisioning(assistant: Assistant): Promise<Assista
 
     case 'create_nsg': {
       const { subscriptionId } = pd;
-      const base = `/subscriptions/${subscriptionId}/resourceGroups/${RG_NAME}/providers`;
+      const base = `/subscriptions/${subscriptionId}/resourceGroups/${rgName}/providers`;
       const nsgPath = `${base}/Microsoft.Network/networkSecurityGroups/${NSG_NAME}?api-version=${NETWORK_API}`;
 
       // Check if already provisioned from a previous attempt
@@ -275,8 +276,8 @@ export async function advanceProvisioning(assistant: Assistant): Promise<Assista
 
     case 'create_vnet': {
       const { subscriptionId } = pd;
-      const base = `/subscriptions/${subscriptionId}/resourceGroups/${RG_NAME}/providers`;
-      const nsgId = `/subscriptions/${subscriptionId}/resourceGroups/${RG_NAME}/providers/Microsoft.Network/networkSecurityGroups/${NSG_NAME}`;
+      const base = `/subscriptions/${subscriptionId}/resourceGroups/${rgName}/providers`;
+      const nsgId = `/subscriptions/${subscriptionId}/resourceGroups/${rgName}/providers/Microsoft.Network/networkSecurityGroups/${NSG_NAME}`;
       const vnetPath = `${base}/Microsoft.Network/virtualNetworks/${VNET_NAME}?api-version=${NETWORK_API}`;
 
       const state = await checkProvisioningState(token, vnetPath);
@@ -314,7 +315,7 @@ export async function advanceProvisioning(assistant: Assistant): Promise<Assista
 
     case 'create_ip': {
       const { subscriptionId, vmName } = pd;
-      const base = `/subscriptions/${subscriptionId}/resourceGroups/${RG_NAME}/providers`;
+      const base = `/subscriptions/${subscriptionId}/resourceGroups/${rgName}/providers`;
       const ipPath = `${base}/Microsoft.Network/publicIPAddresses/${vmName}-ip?api-version=${NETWORK_API}`;
 
       const state = await checkProvisioningState(token, ipPath);
@@ -344,10 +345,10 @@ export async function advanceProvisioning(assistant: Assistant): Promise<Assista
 
     case 'create_nic': {
       const { subscriptionId, vmName } = pd;
-      const base = `/subscriptions/${subscriptionId}/resourceGroups/${RG_NAME}/providers`;
-      const subnetId = `/subscriptions/${subscriptionId}/resourceGroups/${RG_NAME}/providers/Microsoft.Network/virtualNetworks/${VNET_NAME}/subnets/${SUBNET_NAME}`;
-      const nsgId = `/subscriptions/${subscriptionId}/resourceGroups/${RG_NAME}/providers/Microsoft.Network/networkSecurityGroups/${NSG_NAME}`;
-      const ipId = `/subscriptions/${subscriptionId}/resourceGroups/${RG_NAME}/providers/Microsoft.Network/publicIPAddresses/${vmName}-ip`;
+      const base = `/subscriptions/${subscriptionId}/resourceGroups/${rgName}/providers`;
+      const subnetId = `/subscriptions/${subscriptionId}/resourceGroups/${rgName}/providers/Microsoft.Network/virtualNetworks/${VNET_NAME}/subnets/${SUBNET_NAME}`;
+      const nsgId = `/subscriptions/${subscriptionId}/resourceGroups/${rgName}/providers/Microsoft.Network/networkSecurityGroups/${NSG_NAME}`;
+      const ipId = `/subscriptions/${subscriptionId}/resourceGroups/${rgName}/providers/Microsoft.Network/publicIPAddresses/${vmName}-ip`;
       const nicPath = `${base}/Microsoft.Network/networkInterfaces/${vmName}-nic?api-version=${NETWORK_API}`;
 
       const state = await checkProvisioningState(token, nicPath);
@@ -386,8 +387,8 @@ export async function advanceProvisioning(assistant: Assistant): Promise<Assista
 
     case 'create_vm': {
       const { subscriptionId, vmName, vmSize, cloudInit } = pd;
-      const base = `/subscriptions/${subscriptionId}/resourceGroups/${RG_NAME}/providers`;
-      const nicId = `/subscriptions/${subscriptionId}/resourceGroups/${RG_NAME}/providers/Microsoft.Network/networkInterfaces/${vmName}-nic`;
+      const base = `/subscriptions/${subscriptionId}/resourceGroups/${rgName}/providers`;
+      const nicId = `/subscriptions/${subscriptionId}/resourceGroups/${rgName}/providers/Microsoft.Network/networkInterfaces/${vmName}-nic`;
       const vmPath = `${base}/Microsoft.Compute/virtualMachines/${vmName}?api-version=${COMPUTE_API}`;
 
       // Check if already exists
@@ -468,7 +469,7 @@ export async function advanceProvisioning(assistant: Assistant): Promise<Assista
 
     case 'wait_vm': {
       const { subscriptionId, vmName } = pd;
-      const base = `/subscriptions/${subscriptionId}/resourceGroups/${RG_NAME}/providers`;
+      const base = `/subscriptions/${subscriptionId}/resourceGroups/${rgName}/providers`;
       const vmPath = `${base}/Microsoft.Compute/virtualMachines/${vmName}?api-version=${COMPUTE_API}`;
 
       const state = await checkProvisioningState(token, vmPath);


### PR DESCRIPTION
- Each assistant gets its own Azure resource group (sw-rg-{id}). Destroy deletes the entire RG - no more orphaned disks, NICs, etc.
- Removed Discord, Slack, Signal from dashboard and onboarding (only WhatsApp + Telegram are implemented)