### PR TITLE
feat: Harden Stripe webhooks + free-plan VM usage limits

### DIFF
--- a/apps/web/src/app/api/cron/enforce-limits/route.ts
+++ b/apps/web/src/app/api/cron/enforce-limits/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from "next/server";
+import { enforceFreePlanLimits } from "@/lib/vm/free-plan-limits";
+import { env } from "@/lib/env";
+import { ERR, apiError, handleApiError } from "@/lib/errors";
+
+export async function GET(req: NextRequest) {
+  const cronSecret = env("CRON_SECRET");
+  const authHeader = req.headers.get("authorization");
+  if (cronSecret && authHeader !== `Bearer ${cronSecret}`) {
+    return apiError(ERR.UNAUTHORIZED, 401);
+  }
+  try {
+    const result = await enforceFreePlanLimits();
+    console.log(`[enforce-limits] checked=${result.checked} suspended=${result.suspended}`);
+    return NextResponse.json(result);
+  } catch (err) {
+    console.error("[enforce-limits] failed:", err);
+    return NextResponse.json({ error: "Internal error" }, { status: 500 });
+  }
+}

--- a/apps/web/src/app/api/stripe/webhook/__tests__/webhook-idempotency.test.ts
+++ b/apps/web/src/app/api/stripe/webhook/__tests__/webhook-idempotency.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+
+describe("webhook idempotency", () => {
+  const MAX = 10_000;
+  function store() {
+    const s = new Set<string>();
+    function mark(id: string) { if (s.has(id)) return false; if (s.size >= MAX) { const f = s.values().next().value; if (f) s.delete(f); } s.add(id); return true; }
+    return { s, mark };
+  }
+
+  it("accepts new", () => { expect(store().mark("e1")).toBe(true); });
+  it("rejects dup", () => { const st = store(); st.mark("e2"); expect(st.mark("e2")).toBe(false); });
+  it("evicts oldest", () => {
+    const { s, mark } = store();
+    for (let i = 0; i < MAX; i++) mark("e_"+i);
+    mark("new");
+    expect(s.has("e_0")).toBe(false);
+    expect(s.has("new")).toBe(true);
+  });
+});

--- a/apps/web/src/app/api/stripe/webhook/route.ts
+++ b/apps/web/src/app/api/stripe/webhook/route.ts
@@ -3,31 +3,49 @@ import Stripe from "stripe";
 import { stripe } from "@/lib/stripe/client";
 import { planKeyFromPriceId } from "@/lib/stripe/config";
 import { createClient } from "@/lib/supabase/server";
-import { resumeAssistant } from "@/lib/vm/lifecycle";
+import { resumeAssistant, suspendAssistant } from "@/lib/vm/lifecycle";
 import { handleCancellation } from "@/lib/billing/cancellation";
 import { onSubscriptionConfirmed, onPaymentFailed as sendPaymentFailedEmail } from "@/lib/email/triggers";
 import { env } from "@/lib/env";
-import { apiError } from "@/lib/errors";
+import { apiError, handleApiError } from "@/lib/errors";
 
-/**
- * POST /api/stripe/webhook
- */
+// Idempotency
+const processedEvents = new Set<string>();
+const MAX_PROCESSED_EVENTS = 10_000;
+
+function markProcessed(eventId: string): boolean {
+  if (processedEvents.has(eventId)) return false;
+  if (processedEvents.size >= MAX_PROCESSED_EVENTS) {
+    const first = processedEvents.values().next().value;
+    if (first) processedEvents.delete(first);
+  }
+  processedEvents.add(eventId);
+  return true;
+}
+
 export async function POST(req: NextRequest) {
   const body = await req.text();
   const sig = req.headers.get("stripe-signature");
   const webhookSecret = env("STRIPE_WEBHOOK_SECRET");
 
   if (!sig || !webhookSecret) {
-    return apiError("Missing signature or webhook secret.", 400);
+    return NextResponse.json({ error: "Missing signature or webhook secret" }, { status: 400 });
   }
 
   let event: Stripe.Event;
   try {
     event = stripe.webhooks.constructEvent(body, sig, webhookSecret);
   } catch (err) {
-    console.error("Webhook signature verification failed:", err);
-    return apiError("Invalid signature.", 400);
+    console.error("[stripe-webhook] Signature verification failed:", err);
+    return NextResponse.json({ error: "Invalid signature" }, { status: 400 });
   }
+
+  if (!markProcessed(event.id)) {
+    console.log(`[stripe-webhook] Duplicate skipped: ${event.id} (${event.type})`);
+    return NextResponse.json({ received: true, duplicate: true });
+  }
+
+  console.log(`[stripe-webhook] Processing ${event.id} type=${event.type}`);
 
   try {
     switch (event.type) {
@@ -40,23 +58,28 @@ export async function POST(req: NextRequest) {
       case "customer.subscription.deleted":
         await handleSubscriptionDeleted(event.data.object as Stripe.Subscription);
         break;
+      case "customer.subscription.paused":
+        await handleSubscriptionPaused(event.data.object as Stripe.Subscription);
+        break;
+      case "customer.subscription.resumed":
+        await handleSubscriptionResumed(event.data.object as Stripe.Subscription);
+        break;
+      case "invoice.paid":
+        await handleInvoicePaid(event.data.object as Stripe.Invoice);
+        break;
       case "invoice.payment_failed":
         await handlePaymentFailed(event.data.object as Stripe.Invoice);
         break;
       default:
-        console.log(`Unhandled event type: ${event.type}`);
+        console.log(`[stripe-webhook] Unhandled: ${event.type}`);
     }
   } catch (err) {
-    console.error(`[stripe/webhook] Error processing ${event.type}:`, err);
-    return apiError("Webhook processing failed.", 500);
+    console.error(`[stripe-webhook] Error processing ${event.type} (${event.id}):`, err);
+    return NextResponse.json({ error: "Webhook handler failed" }, { status: 500 });
   }
 
   return NextResponse.json({ received: true });
 }
-
-// ---------------------------------------------------------------------------
-// Event handlers (unchanged internal logic)
-// ---------------------------------------------------------------------------
 
 async function handleCheckoutCompleted(session: Stripe.Checkout.Session) {
   const userId = session.metadata?.userId;
@@ -64,81 +87,38 @@ async function handleCheckoutCompleted(session: Stripe.Checkout.Session) {
   const customerId = session.customer as string;
   const plan = session.metadata?.plan ?? "pro";
 
-  if (!userId) {
-    console.error("Checkout session missing userId in metadata");
-    return;
-  }
+  if (!userId) { console.error("[stripe-webhook] Checkout missing userId"); return; }
 
-  console.log(`Checkout completed: user=${userId} subscription=${subscriptionId} customer=${customerId} plan=${plan}`);
+  console.log(`[stripe-webhook] Checkout: user=${userId} sub=${subscriptionId} cust=${customerId} plan=${plan}`);
 
   const supabase: any = await createClient();
 
-  const { data: existingSub } = await supabase
-    .from("subscriptions")
-    .select("id")
-    .eq("user_id", userId)
-    .maybeSingle();
+  const { data: existingSub } = await supabase.from("subscriptions").select("id").eq("user_id", userId).maybeSingle();
 
   if (existingSub) {
-    const { error: subError } = await supabase
-      .from("subscriptions")
-      .update({
-        stripe_customer_id: customerId,
-        stripe_subscription_id: subscriptionId,
-        plan,
-        status: "active",
-        updated_at: new Date().toISOString(),
-      })
-      .eq("user_id", userId);
-    if (subError) {
-      console.error("Failed to update subscription:", subError.message);
-      throw subError;
-    }
+    const { error: subError } = await supabase.from("subscriptions").update({
+      stripe_customer_id: customerId, stripe_subscription_id: subscriptionId,
+      plan, status: "active", updated_at: new Date().toISOString(),
+    }).eq("user_id", userId);
+    if (subError) { console.error("[stripe-webhook] Update sub failed:", subError.message); throw subError; }
   } else {
-    const { error: subError } = await supabase
-      .from("subscriptions")
-      .insert({
-        user_id: userId,
-        stripe_customer_id: customerId,
-        stripe_subscription_id: subscriptionId,
-        plan,
-        status: "active",
-        updated_at: new Date().toISOString(),
-      });
-    if (subError) {
-      console.error("Failed to insert subscription:", subError.message);
-      throw subError;
-    }
+    const { error: subError } = await supabase.from("subscriptions").insert({
+      user_id: userId, stripe_customer_id: customerId, stripe_subscription_id: subscriptionId,
+      plan, status: "active", updated_at: new Date().toISOString(),
+    });
+    if (subError) { console.error("[stripe-webhook] Insert sub failed:", subError.message); throw subError; }
   }
 
-  const { error: userError } = await supabase
-    .from("users")
-    .update({ plan, updated_at: new Date().toISOString() })
-    .eq("id", userId);
+  const { error: userError } = await supabase.from("users").update({ plan, updated_at: new Date().toISOString() }).eq("id", userId);
+  if (userError) console.error("[stripe-webhook] Update user plan failed:", userError.message);
 
-  if (userError) {
-    console.error("Failed to update user plan:", userError.message);
-  }
-
-  onSubscriptionConfirmed(userId).catch((err) =>
-    console.error("[email] Failed to send subscription-confirmed email:", err),
-  );
+  onSubscriptionConfirmed(userId).catch((err: any) => console.error("[stripe-webhook][email] confirm email failed:", err));
 
   if (plan !== "free") {
-    const { data: assistant } = await supabase
-      .from("assistants")
-      .select("id, status")
-      .eq("user_id", userId)
-      .eq("status", "suspended")
-      .single();
-
+    const { data: assistant } = await supabase.from("assistants").select("id, status").eq("user_id", userId).eq("status", "suspended").single();
     if (assistant) {
-      try {
-        await resumeAssistant(assistant.id);
-        console.log(`Resumed assistant ${assistant.id} after upgrade to ${plan}`);
-      } catch (err) {
-        console.error(`Failed to resume assistant ${assistant.id}:`, err);
-      }
+      try { await resumeAssistant(assistant.id); console.log(`[stripe-webhook] Resumed ${assistant.id} after upgrade`); }
+      catch (err) { console.error(`[stripe-webhook] Resume failed ${assistant.id}:`, err); }
     }
   }
 }
@@ -146,116 +126,101 @@ async function handleCheckoutCompleted(session: Stripe.Checkout.Session) {
 async function handleSubscriptionUpdated(subscription: Stripe.Subscription) {
   const priceId = subscription.items.data[0]?.price.id;
   const plan = priceId ? planKeyFromPriceId(priceId) : null;
-
-  console.log(`Subscription updated: id=${subscription.id} plan=${plan} status=${subscription.status}`);
+  console.log(`[stripe-webhook] Sub updated: id=${subscription.id} plan=${plan} status=${subscription.status}`);
 
   const supabase: any = await createClient();
-
-  const { data: existingSub } = await supabase
-    .from("subscriptions")
-    .select("user_id, plan")
-    .eq("stripe_subscription_id", subscription.id)
-    .single();
-
-  if (!existingSub) {
-    console.error(`No subscription found for stripe ID ${subscription.id}`);
-    return;
-  }
+  const { data: existingSub } = await supabase.from("subscriptions").select("user_id, plan").eq("stripe_subscription_id", subscription.id).single();
+  if (!existingSub) { console.error(`[stripe-webhook] No sub for ${subscription.id}`); return; }
 
   const previousPlan = existingSub.plan;
   const newPlan = plan ?? "free";
-
   const rawSub = subscription as any;
-  const periodEnd = rawSub.current_period_end
-    ? new Date(rawSub.current_period_end * 1000).toISOString()
-    : null;
+  const periodEnd = rawSub.current_period_end ? new Date(rawSub.current_period_end * 1000).toISOString() : null;
 
-  const { error } = await supabase
-    .from("subscriptions")
-    .update({
-      plan: newPlan,
-      status: subscription.status,
-      cancel_at_period_end: subscription.cancel_at_period_end ?? false,
-      ...(periodEnd ? { current_period_end: periodEnd } : {}),
-      updated_at: new Date().toISOString(),
-    })
-    .eq("stripe_subscription_id", subscription.id);
+  const { error } = await supabase.from("subscriptions").update({
+    plan: newPlan, status: subscription.status,
+    cancel_at_period_end: subscription.cancel_at_period_end ?? false,
+    ...(periodEnd ? { current_period_end: periodEnd } : {}),
+    updated_at: new Date().toISOString(),
+  }).eq("stripe_subscription_id", subscription.id);
+  if (error) { console.error("[stripe-webhook] Update failed:", error.message); throw error; }
 
-  if (error) {
-    console.error("Failed to update subscription:", error.message);
-    throw error;
-  }
-
-  await supabase
-    .from("users")
-    .update({ plan: newPlan, updated_at: new Date().toISOString() })
-    .eq("id", existingSub.user_id);
+  await supabase.from("users").update({ plan: newPlan, updated_at: new Date().toISOString() }).eq("id", existingSub.user_id);
 
   if (previousPlan === "free" && newPlan !== "free") {
-    const { data: assistant } = await supabase
-      .from("assistants")
-      .select("id, status")
-      .eq("user_id", existingSub.user_id)
-      .eq("status", "suspended")
-      .single();
-
+    const { data: assistant } = await supabase.from("assistants").select("id, status").eq("user_id", existingSub.user_id).eq("status", "suspended").single();
     if (assistant) {
-      try {
-        await resumeAssistant(assistant.id);
-        console.log(`Resumed assistant ${assistant.id} after upgrade to ${newPlan}`);
-      } catch (err) {
-        console.error(`Failed to resume assistant:`, err);
-      }
+      try { await resumeAssistant(assistant.id); console.log(`[stripe-webhook] Resumed ${assistant.id} after upgrade`); }
+      catch (err) { console.error("[stripe-webhook] Resume failed:", err); }
     }
   }
 }
 
 async function handleSubscriptionDeleted(subscription: Stripe.Subscription) {
-  console.log(`Subscription deleted: id=${subscription.id}`);
+  console.log(`[stripe-webhook] Sub deleted: id=${subscription.id}`);
+  const supabase: any = await createClient();
+  const { data: sub } = await supabase.from("subscriptions").select("user_id").eq("stripe_subscription_id", subscription.id).single();
+  if (!sub) { console.error(`[stripe-webhook] No sub for ${subscription.id}`); return; }
+  await handleCancellation(sub.user_id);
+}
+
+async function handleSubscriptionPaused(subscription: Stripe.Subscription) {
+  console.log(`[stripe-webhook] Sub paused: id=${subscription.id}`);
+  const supabase: any = await createClient();
+  const { data: sub } = await supabase.from("subscriptions").select("user_id").eq("stripe_subscription_id", subscription.id).single();
+  if (!sub) { console.error(`[stripe-webhook] No sub for ${subscription.id}`); return; }
+
+  await supabase.from("subscriptions").update({ status: "paused", updated_at: new Date().toISOString() }).eq("stripe_subscription_id", subscription.id);
+
+  const { data: assistant } = await supabase.from("assistants").select("id, status").eq("user_id", sub.user_id).eq("status", "active").single();
+  if (assistant) {
+    try { await suspendAssistant(assistant.id); console.log(`[stripe-webhook] Suspended ${assistant.id} — paused`); }
+    catch (err) { console.error(`[stripe-webhook] Suspend failed ${assistant.id}:`, err); }
+  }
+}
+
+async function handleSubscriptionResumed(subscription: Stripe.Subscription) {
+  console.log(`[stripe-webhook] Sub resumed: id=${subscription.id}`);
+  const supabase: any = await createClient();
+  const { data: sub } = await supabase.from("subscriptions").select("user_id").eq("stripe_subscription_id", subscription.id).single();
+  if (!sub) { console.error(`[stripe-webhook] No sub for ${subscription.id}`); return; }
+
+  const priceId = subscription.items.data[0]?.price.id;
+  const plan = priceId ? planKeyFromPriceId(priceId) : "pro";
+
+  await supabase.from("subscriptions").update({ status: "active", plan, updated_at: new Date().toISOString() }).eq("stripe_subscription_id", subscription.id);
+  await supabase.from("users").update({ plan, updated_at: new Date().toISOString() }).eq("id", sub.user_id);
+
+  const { data: assistant } = await supabase.from("assistants").select("id, status").eq("user_id", sub.user_id).eq("status", "suspended").single();
+  if (assistant) {
+    try { await resumeAssistant(assistant.id); console.log(`[stripe-webhook] Resumed ${assistant.id}`); }
+    catch (err) { console.error(`[stripe-webhook] Resume failed ${assistant.id}:`, err); }
+  }
+}
+
+async function handleInvoicePaid(invoice: Stripe.Invoice) {
+  const customerId = invoice.customer as string;
+  const subscriptionId = invoice.subscription as string;
+  console.log(`[stripe-webhook] Invoice paid: cust=${customerId} inv=${invoice.id}`);
+  if (!subscriptionId) return;
 
   const supabase: any = await createClient();
-
-  const { data: sub } = await supabase
-    .from("subscriptions")
-    .select("user_id")
-    .eq("stripe_subscription_id", subscription.id)
-    .single();
-
-  if (!sub) {
-    console.error(`No subscription found for stripe ID ${subscription.id}`);
-    return;
-  }
-
-  await handleCancellation(sub.user_id);
+  const { error } = await supabase.from("subscriptions").update({ status: "active", updated_at: new Date().toISOString() }).eq("stripe_subscription_id", subscriptionId);
+  if (error) console.error("[stripe-webhook] invoice.paid update failed:", error.message);
 }
 
 async function handlePaymentFailed(invoice: Stripe.Invoice) {
   const customerId = invoice.customer as string;
-  console.log(`Payment failed: customer=${customerId} invoice=${invoice.id}`);
+  console.log(`[stripe-webhook] Payment failed: cust=${customerId} inv=${invoice.id}`);
 
   const supabase: any = await createClient();
+  const { error } = await supabase.from("subscriptions").update({ status: "past_due", updated_at: new Date().toISOString() }).eq("stripe_customer_id", customerId);
+  if (error) console.error("[stripe-webhook] past_due update failed:", error.message);
 
-  const { error } = await supabase
-    .from("subscriptions")
-    .update({
-      status: "past_due",
-      updated_at: new Date().toISOString(),
-    })
-    .eq("stripe_customer_id", customerId);
-
-  if (error) {
-    console.error("Failed to update subscription status:", error.message);
-  }
-
-  const { data: sub } = await supabase
-    .from("subscriptions")
-    .select("user_id")
-    .eq("stripe_customer_id", customerId)
-    .single();
-
+  const { data: sub } = await supabase.from("subscriptions").select("user_id").eq("stripe_customer_id", customerId).single();
   if (sub?.user_id) {
-    sendPaymentFailedEmail(sub.user_id).catch((err) =>
-      console.error("[email] Failed to send payment-failed email:", err),
-    );
+    sendPaymentFailedEmail(sub.user_id).catch((err: any) => console.error("[stripe-webhook][email] payment-failed email failed:", err));
   }
 }
+
+export { markProcessed, processedEvents };

--- a/apps/web/src/lib/vm/__tests__/free-plan-limits.test.ts
+++ b/apps/web/src/lib/vm/__tests__/free-plan-limits.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase/server", () => ({ createClient: vi.fn() }));
+vi.mock("@/lib/vm/lifecycle", () => ({ suspendAssistant: vi.fn().mockResolvedValue({}) }));
+
+import { getDailyUptimeHours, hasRemainingHoursToday, FREE_PLAN_DAILY_HOURS } from "../free-plan-limits";
+import { createClient } from "@/lib/supabase/server";
+
+function mockChain(data: any) {
+  const c: any = {};
+  for (const m of ["from","select","insert","eq","gte","lte","in","single"]) c[m] = vi.fn().mockReturnValue(c);
+  c.lte = vi.fn().mockResolvedValue({ data, error: null });
+  return c;
+}
+
+describe("free-plan-limits", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("constant is 8", () => { expect(FREE_PLAN_DAILY_HOURS).toBe(8); });
+
+  it("returns 0 with no logs", async () => {
+    (createClient as any).mockResolvedValue(mockChain([]));
+    expect(await getDailyUptimeHours("a1")).toBe(0);
+  });
+
+  it("sums seconds to hours", async () => {
+    (createClient as any).mockResolvedValue(mockChain([{duration_seconds:3600},{duration_seconds:7200}]));
+    expect(await getDailyUptimeHours("a1")).toBe(3);
+  });
+
+  it("not exceeded under limit", async () => {
+    (createClient as any).mockResolvedValue(mockChain([{duration_seconds:3600}]));
+    const r = await hasRemainingHoursToday("a1");
+    expect(r.exceeded).toBe(false);
+    expect(r.remaining).toBe(7);
+  });
+
+  it("exceeded at limit", async () => {
+    (createClient as any).mockResolvedValue(mockChain([{duration_seconds:28800}]));
+    const r = await hasRemainingHoursToday("a1");
+    expect(r.exceeded).toBe(true);
+    expect(r.remaining).toBe(0);
+  });
+});

--- a/apps/web/src/lib/vm/free-plan-limits.ts
+++ b/apps/web/src/lib/vm/free-plan-limits.ts
@@ -1,0 +1,54 @@
+import { createClient } from "@/lib/supabase/server";
+import { suspendAssistant } from "./lifecycle";
+
+export const FREE_PLAN_DAILY_HOURS = 8;
+
+export async function getDailyUptimeHours(assistantId: string, now: Date = new Date()): Promise<number> {
+  const supabase: any = await createClient();
+  const startOfDay = new Date(now);
+  startOfDay.setHours(0, 0, 0, 0);
+
+  const { data, error } = await supabase
+    .from("usage_logs").select("duration_seconds")
+    .eq("assistant_id", assistantId).eq("type", "vm_uptime")
+    .gte("created_at", startOfDay.toISOString())
+    .lte("created_at", now.toISOString());
+
+  if (error) { console.error(`[free-plan-limits] query failed for ${assistantId}:`, error.message); return 0; }
+  return (data ?? []).reduce((s: number, r: any) => s + (r.duration_seconds ?? 0), 0) / 3600;
+}
+
+export async function hasRemainingHoursToday(assistantId: string, now?: Date): Promise<{ remaining: number; exceeded: boolean }> {
+  const used = await getDailyUptimeHours(assistantId, now);
+  const remaining = Math.max(0, FREE_PLAN_DAILY_HOURS - used);
+  return { remaining, exceeded: remaining <= 0 };
+}
+
+export async function logVmUptime(assistantId: string, durationSeconds: number): Promise<void> {
+  const supabase: any = await createClient();
+  const { error } = await supabase.from("usage_logs").insert({
+    assistant_id: assistantId, type: "vm_uptime",
+    duration_seconds: durationSeconds, created_at: new Date().toISOString(),
+  });
+  if (error) console.error(`[free-plan-limits] log failed for ${assistantId}:`, error.message);
+}
+
+export async function enforceFreePlanLimits(): Promise<{ checked: number; suspended: number }> {
+  const supabase: any = await createClient();
+  const { data: assistants, error } = await supabase
+    .from("assistants").select("id, user_id, users!inner(plan)")
+    .eq("status", "active").eq("users.plan", "free");
+
+  if (error) { console.error("[enforce-limits] query failed:", error.message); return { checked: 0, suspended: 0 }; }
+  if (!assistants?.length) return { checked: 0, suspended: 0 };
+
+  let suspended = 0;
+  for (const a of assistants) {
+    const { exceeded } = await hasRemainingHoursToday(a.id);
+    if (exceeded) {
+      try { await suspendAssistant(a.id); suspended++; console.log(`[enforce-limits] Suspended ${a.id}`); }
+      catch (err) { console.error(`[enforce-limits] Failed to suspend ${a.id}:`, err); }
+    }
+  }
+  return { checked: assistants.length, suspended };
+}

--- a/vercel.json
+++ b/vercel.json
@@ -7,6 +7,10 @@
     {
       "path": "/api/cron/vm-scheduler",
       "schedule": "0 0 * * *"
+    },
+    {
+      "path": "/api/cron/enforce-limits",
+      "schedule": "*/15 * * * *"
     }
   ]
 }


### PR DESCRIPTION
## Changes

### Stripe Webhook Hardening
- **Idempotency**: In-memory Set (capped at 10k) prevents duplicate event processing
- **New events handled**:
  - `customer.subscription.paused` → suspends VM
  - `customer.subscription.resumed` → resumes VM and reactivates subscription
  - `invoice.paid` → confirms subscription active (recovers from past_due)
- **Structured logging**: All log lines prefixed with `[stripe-webhook]` for filtering
- Cancellation flow properly suspends VM via existing `handleCancellation`

### Free-Plan VM Usage Limits
- New `free-plan-limits.ts` utility:
  - Tracks daily VM uptime via `usage_logs` table
  - `getDailyUptimeHours()` / `hasRemainingHoursToday()` for checking limits
  - `logVmUptime()` for recording usage
  - `enforceFreePlanLimits()` suspends over-limit assistants
- New `/api/cron/enforce-limits` route (protected by CRON_SECRET)
- Vercel Cron configured to run every 15 minutes

### Tests
- Idempotency logic unit tests
- Free-plan limits unit tests (uptime calculation, limit checking)