### PR TITLE
feat: harden GitHub Copilot OAuth flow

### DIFF
--- a/apps/web/src/app/api/auth/github/callback/route.test.ts
+++ b/apps/web/src/app/api/auth/github/callback/route.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import crypto from 'crypto';
+
+const mockGetSession = vi.fn();
+const mockSaveProviderToken = vi.fn();
+
+vi.mock('@/lib/auth/session', () => ({ getSession: (...a: any[]) => mockGetSession(...a) }));
+vi.mock('@/lib/providers/token-store', () => ({ saveProviderToken: (...a: any[]) => mockSaveProviderToken(...a) }));
+
+const SECRET = 'test-client-secret';
+const CLIENT_ID = 'test-client-id';
+
+function makeState(overrides: Record<string, unknown> = {}) {
+  const payload = JSON.stringify({
+    returnTo: '/onboarding?step=7',
+    purpose: 'ai-provider',
+    ts: Date.now(),
+    nonce: crypto.randomBytes(16).toString('hex'),
+    ...overrides,
+  });
+  const payloadB64 = Buffer.from(payload).toString('base64url');
+  const hmac = crypto.createHmac('sha256', SECRET).update(payloadB64).digest('base64url');
+  return `${payloadB64}.${hmac}`;
+}
+
+const fetchMock = vi.fn();
+
+import { GET } from './route';
+
+describe('GitHub OAuth callback', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', fetchMock);
+    fetchMock.mockReset();
+    mockGetSession.mockReset();
+    mockSaveProviderToken.mockReset();
+    vi.stubEnv('GITHUB_CLIENT_ID', CLIENT_ID);
+    vi.stubEnv('GITHUB_CLIENT_SECRET', SECRET);
+  });
+
+  function makeReq(params: Record<string, string>) {
+    const url = new URL('http://localhost/api/auth/github/callback');
+    for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v);
+    return new Request(url.toString()) as any;
+  }
+
+  it('rejects missing state', async () => {
+    const res = await GET(makeReq({ code: 'abc' }));
+    expect(res.headers.get('location')).toContain('error=invalid_state');
+  });
+
+  it('rejects forged state', async () => {
+    const res = await GET(makeReq({ code: 'abc', state: 'forged.badhmac' }));
+    expect(res.headers.get('location')).toContain('error=invalid_state');
+  });
+
+  it('rejects expired state', async () => {
+    const state = makeState({ ts: Date.now() - 15 * 60 * 1000 });
+    const res = await GET(makeReq({ code: 'abc', state }));
+    expect(res.headers.get('location')).toContain('error=invalid_state');
+  });
+
+  it('handles error=access_denied from GitHub', async () => {
+    const state = makeState();
+    const res = await GET(makeReq({ error: 'access_denied', state }));
+    expect(res.headers.get('location')).toContain('error=access_denied');
+  });
+
+  it('rejects missing code', async () => {
+    const state = makeState();
+    const res = await GET(makeReq({ state }));
+    expect(res.headers.get('location')).toContain('error=missing_code');
+  });
+
+  it('handles token exchange failure', async () => {
+    fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ error: 'bad_verification_code' }) });
+    const state = makeState();
+    const res = await GET(makeReq({ code: 'bad', state }));
+    expect(res.headers.get('location')).toContain('error=token_exchange');
+  });
+
+  it('redirects to login when no session', async () => {
+    fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ access_token: 'tok' }) });
+    fetchMock.mockResolvedValueOnce({ ok: true });
+    mockGetSession.mockResolvedValue(null);
+    const state = makeState();
+    const res = await GET(makeReq({ code: 'good', state }));
+    expect(res.headers.get('location')).toContain('/login');
+  });
+
+  it('saves encrypted token and redirects on success', async () => {
+    fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ access_token: 'ghu_abc' }) });
+    fetchMock.mockResolvedValueOnce({ ok: true });
+    mockGetSession.mockResolvedValue({ userId: 'u1' });
+    mockSaveProviderToken.mockResolvedValue(undefined);
+    const state = makeState({ returnTo: '/dash' });
+    const res = await GET(makeReq({ code: 'good', state }));
+    const loc = res.headers.get('location')!;
+    expect(loc).toContain('/dash');
+    expect(loc).toContain('github=connected');
+    expect(mockSaveProviderToken).toHaveBeenCalledWith('u1', 'github-copilot', 'ghu_abc', null, null);
+  });
+
+  it('adds copilot_warning when verification fails', async () => {
+    fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ access_token: 'ghu_abc' }) });
+    fetchMock.mockResolvedValueOnce({ ok: false, status: 403 });
+    mockGetSession.mockResolvedValue({ userId: 'u1' });
+    mockSaveProviderToken.mockResolvedValue(undefined);
+    const state = makeState({ returnTo: '/dash' });
+    const res = await GET(makeReq({ code: 'good', state }));
+    expect(res.headers.get('location')).toContain('copilot_warning=true');
+  });
+});

--- a/apps/web/src/app/api/auth/github/callback/route.ts
+++ b/apps/web/src/app/api/auth/github/callback/route.ts
@@ -1,109 +1,119 @@
 import { NextRequest, NextResponse } from 'next/server';
+import crypto from 'crypto';
 import { getSession } from '@/lib/auth/session';
-import { createClient } from '@/lib/supabase/server';
+import { saveProviderToken } from '@/lib/providers/token-store';
 
-/**
- * GitHub OAuth callback for Copilot API access.
- *
- * Exchanges the authorization code for an access token,
- * verifies it works with GitHub Models API, and saves it
- * as the user's AI provider credentials.
- *
- * Environment variables required:
- * - GITHUB_CLIENT_ID
- * - GITHUB_CLIENT_SECRET
- */
+const MAX_STATE_AGE_MS = 10 * 60 * 1000;
+
+function verifyState(stateParam: string, secret: string): { returnTo: string } | null {
+  const dotIdx = stateParam.indexOf('.');
+  if (dotIdx === -1) return null;
+  const payloadB64 = stateParam.slice(0, dotIdx);
+  const hmac = stateParam.slice(dotIdx + 1);
+  const expected = crypto.createHmac('sha256', secret).update(payloadB64).digest('base64url');
+  if (hmac.length !== expected.length) return null;
+  if (!crypto.timingSafeEqual(Buffer.from(hmac), Buffer.from(expected))) return null;
+  try {
+    const state = JSON.parse(Buffer.from(payloadB64, 'base64url').toString());
+    if (typeof state.ts === 'number' && Date.now() - state.ts > MAX_STATE_AGE_MS) return null;
+    return { returnTo: state.returnTo || '/onboarding?step=7' };
+  } catch {
+    return null;
+  }
+}
+
+function redirectWithError(origin: string, returnTo: string, error: string) {
+  const sep = returnTo.includes('?') ? '&' : '?';
+  return NextResponse.redirect(new URL(`${returnTo}${sep}error=${error}`, origin));
+}
+
 export async function GET(req: NextRequest) {
   const url = new URL(req.url);
   const code = url.searchParams.get('code');
   const stateParam = url.searchParams.get('state');
-
-  // Decode state
-  let returnTo = '/onboarding?step=7';
-  if (stateParam) {
-    try {
-      const state = JSON.parse(Buffer.from(stateParam, 'base64url').toString());
-      if (state.returnTo) returnTo = state.returnTo;
-    } catch {
-      // ignore malformed state
-    }
-  }
-
-  if (!code) {
-    return NextResponse.redirect(new URL(`${returnTo}${returnTo.includes('?') ? '&' : '?'}error=missing_code`, url.origin));
-  }
-
+  const errorParam = url.searchParams.get('error');
   const clientId = process.env.GITHUB_CLIENT_ID;
   const clientSecret = process.env.GITHUB_CLIENT_SECRET;
-  if (!clientId || !clientSecret) {
-    return NextResponse.redirect(new URL(`${returnTo}${returnTo.includes('?') ? '&' : '?'}error=oauth_not_configured`, url.origin));
+  const defaultReturn = '/onboarding?step=7';
+
+  if (errorParam) {
+    let returnTo = defaultReturn;
+    if (stateParam && clientSecret) {
+      const verified = verifyState(stateParam, clientSecret);
+      if (verified) returnTo = verified.returnTo;
+    }
+    return redirectWithError(url.origin, returnTo, errorParam === 'access_denied' ? 'access_denied' : 'github_error');
   }
 
-  // Exchange code for access token
+  if (!clientId || !clientSecret) {
+    return redirectWithError(url.origin, defaultReturn, 'oauth_not_configured');
+  }
+
+  if (!stateParam) {
+    return redirectWithError(url.origin, defaultReturn, 'invalid_state');
+  }
+
+  const stateResult = verifyState(stateParam, clientSecret);
+  if (!stateResult) {
+    return redirectWithError(url.origin, defaultReturn, 'invalid_state');
+  }
+
+  const { returnTo } = stateResult;
+
+  if (!code) {
+    return redirectWithError(url.origin, returnTo, 'missing_code');
+  }
+
   let accessToken: string;
   try {
     const tokenRes = await fetch('https://github.com/login/oauth/access_token', {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Accept: 'application/json',
-      },
-      body: JSON.stringify({
-        client_id: clientId,
-        client_secret: clientSecret,
-        code,
-      }),
+      headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+      body: JSON.stringify({ client_id: clientId, client_secret: clientSecret, code }),
     });
+    if (!tokenRes.ok) {
+      console.error('GitHub token exchange HTTP error:', tokenRes.status);
+      return redirectWithError(url.origin, returnTo, 'token_exchange');
+    }
     const tokenData = await tokenRes.json();
     if (tokenData.error || !tokenData.access_token) {
-      return NextResponse.redirect(
-        new URL(`${returnTo}${returnTo.includes('?') ? '&' : '?'}error=token_exchange`, url.origin)
-      );
+      console.error('GitHub token exchange error:', tokenData.error, tokenData.error_description);
+      return redirectWithError(url.origin, returnTo, 'token_exchange');
     }
     accessToken = tokenData.access_token;
-  } catch {
-    return NextResponse.redirect(
-      new URL(`${returnTo}${returnTo.includes('?') ? '&' : '?'}error=token_exchange`, url.origin)
-    );
+  } catch (err) {
+    console.error('GitHub token exchange fetch error:', err);
+    return redirectWithError(url.origin, returnTo, 'token_exchange');
   }
 
-  // Verify the token works with GitHub Models API (Copilot)
+  let copilotVerified = false;
   try {
     const testRes = await fetch('https://models.inference.ai.azure.com/chat/completions', {
       method: 'POST',
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        model: 'gpt-4o-mini',
-        messages: [{ role: 'user', content: 'Say hi' }],
-        max_tokens: 5,
-      }),
+      headers: { Authorization: `Bearer ${accessToken}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model: 'gpt-4o-mini', messages: [{ role: 'user', content: 'Say hi' }], max_tokens: 5 }),
     });
-    if (!testRes.ok) {
-      // Token doesn't have Copilot access - still save it but warn
-      console.warn('GitHub token Copilot verification failed:', testRes.status);
-    }
+    copilotVerified = testRes.ok;
+    if (!copilotVerified) console.warn('GitHub token Copilot verification failed:', testRes.status);
   } catch {
     console.warn('GitHub token Copilot verification request failed');
   }
 
-  // Save the token to the user's record
   const session = await getSession();
   if (!session) {
     return NextResponse.redirect(new URL('/login', url.origin));
   }
 
   try {
-    const supabase = createClient();
-    await (supabase as any).from('users').update({
-      ai_provider: 'github-copilot',
-      ai_api_key: accessToken,
-    }).eq('id', session.userId);
+    await saveProviderToken(session.userId, 'github-copilot', accessToken, null, null);
   } catch (err) {
     console.error('Failed to save GitHub token:', err);
+    return redirectWithError(url.origin, returnTo, 'save_failed');
   }
 
-  return NextResponse.redirect(new URL(returnTo, url.origin));
+  const sep = returnTo.includes('?') ? '&' : '?';
+  const successUrl = copilotVerified
+    ? `${returnTo}${sep}github=connected`
+    : `${returnTo}${sep}github=connected&copilot_warning=true`;
+  return NextResponse.redirect(new URL(successUrl, url.origin));
 }

--- a/apps/web/src/app/api/auth/github/route.ts
+++ b/apps/web/src/app/api/auth/github/route.ts
@@ -1,16 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { apiError, ERR, handleApiError } from '@/lib/errors';
+import crypto from 'crypto';
 
-/**
- * GitHub OAuth initiation for Copilot API access.
- *
- * Environment variables required:
- * - GITHUB_CLIENT_ID: from GitHub OAuth App
- * - GITHUB_CLIENT_SECRET: from GitHub OAuth App
- */
 export async function GET(req: NextRequest) {
   const clientId = process.env.GITHUB_CLIENT_ID;
-  if (!clientId) {
+  const clientSecret = process.env.GITHUB_CLIENT_SECRET;
+  if (!clientId || !clientSecret) {
     return NextResponse.json(
       { error: 'GitHub OAuth not configured. Set GITHUB_CLIENT_ID and GITHUB_CLIENT_SECRET.' },
       { status: 500 }
@@ -20,9 +14,11 @@ export async function GET(req: NextRequest) {
   const url = new URL(req.url);
   const returnTo = url.searchParams.get('returnTo') || '/onboarding?step=7';
 
-  const state = Buffer.from(
-    JSON.stringify({ returnTo, purpose: 'ai-provider', ts: Date.now() })
-  ).toString('base64url');
+  const nonce = crypto.randomBytes(16).toString('hex');
+  const payload = JSON.stringify({ returnTo, purpose: 'ai-provider', ts: Date.now(), nonce });
+  const payloadB64 = Buffer.from(payload).toString('base64url');
+  const hmac = crypto.createHmac('sha256', clientSecret).update(payloadB64).digest('base64url');
+  const state = `${payloadB64}.${hmac}`;
 
   const redirectUri = `${url.origin}/api/auth/github/callback`;
 


### PR DESCRIPTION
## Changes

### Security hardening for the GitHub Copilot OAuth flow:

1. **CSRF protection via HMAC-signed state** — State parameter now includes an HMAC signature using the client secret, verified on callback with `crypto.timingSafeEqual`. State expires after 10 minutes.

2. **Encrypted token storage** — Tokens are now saved via `saveProviderToken` (AES-256-GCM encrypted in `provider_tokens` table) instead of plaintext in the `users.ai_api_key` column.

3. **Error handling** — Handles GitHub error responses (`access_denied`, etc.), missing code, token exchange failures, and save failures with proper redirect error params.

4. **Copilot verification feedback** — Adds `copilot_warning=true` query param when the token works but Copilot access can't be verified, so the UI can show a warning.

5. **Unit tests** — 9 tests covering: invalid/forged/expired state, access denied, missing code, token exchange failure, no session, successful flow, and copilot warning.

### Files changed
- `apps/web/src/app/api/auth/github/route.ts` — HMAC-signed state generation
- `apps/web/src/app/api/auth/github/callback/route.ts` — Full rewrite with all fixes
- `apps/web/src/app/api/auth/github/callback/route.test.ts` — New test file (9 tests)