### PR TITLE
feat: polish loading states across dashboard

### DIFF
--- a/apps/web/src/app/dashboard/__tests__/loading-pages.test.tsx
+++ b/apps/web/src/app/dashboard/__tests__/loading-pages.test.tsx
@@ -1,0 +1,28 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import DashboardLoading from '../loading';
+import SettingsLoading from '../settings/loading';
+import BillingLoading from '../billing/loading';
+
+describe('DashboardLoading', () => {
+  it('renders skeleton grid matching 3-column layout', () => {
+    const { container } = render(<DashboardLoading />);
+    expect(container.querySelectorAll('.animate-pulse').length).toBeGreaterThan(10);
+    expect(container.querySelector('.grid')).toBeTruthy();
+  });
+});
+
+describe('SettingsLoading', () => {
+  it('renders skeleton with pulse animations', () => {
+    const { container } = render(<SettingsLoading />);
+    expect(container.querySelectorAll('.animate-pulse').length).toBeGreaterThan(5);
+  });
+});
+
+describe('BillingLoading', () => {
+  it('renders skeleton with pulse animations', () => {
+    const { container } = render(<BillingLoading />);
+    expect(container.querySelectorAll('.animate-pulse').length).toBeGreaterThan(5);
+  });
+});

--- a/apps/web/src/app/dashboard/billing/loading.tsx
+++ b/apps/web/src/app/dashboard/billing/loading.tsx
@@ -1,0 +1,21 @@
+export default function BillingLoading() {
+  return (
+    <div className="max-w-2xl space-y-8">
+      <div className="h-8 w-24 animate-pulse rounded bg-slate-800" />
+      <div className="rounded-xl border border-slate-800 bg-slate-900/50 p-6 space-y-4">
+        <div className="flex items-center justify-between">
+          <div className="h-5 w-28 animate-pulse rounded bg-slate-800" />
+          <div className="h-6 w-16 animate-pulse rounded-full bg-slate-800" />
+        </div>
+        <div className="h-8 w-24 animate-pulse rounded bg-slate-800" />
+        <div className="h-4 w-48 animate-pulse rounded bg-slate-800/60" />
+        <div className="h-10 w-40 animate-pulse rounded-lg bg-slate-800" />
+      </div>
+      <div className="rounded-xl border border-slate-800 bg-slate-900/50 p-6 space-y-3">
+        <div className="h-5 w-24 animate-pulse rounded bg-slate-800" />
+        <div className="h-4 w-full animate-pulse rounded bg-slate-800/60" />
+        <div className="h-4 w-3/4 animate-pulse rounded bg-slate-800/60" />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/dashboard/billing/page.tsx
+++ b/apps/web/src/app/dashboard/billing/page.tsx
@@ -27,9 +27,11 @@ export default function BillingPage() {
           setSubscription(data.user.subscription ?? null);
         }
       })
-      .catch(() => {})
+      .catch(() => { setFetchError('Failed to load billing info'); })
       .finally(() => setLoading(false));
   }, []);
+
+  const [fetchError, setFetchError] = useState<string | null>(null);
 
   async function openPortal() {
     setPortalLoading(true);
@@ -78,10 +80,38 @@ export default function BillingPage() {
 
   if (loading) {
     return (
-      <div className="max-w-2xl space-y-8">
+      <div className="max-w-2xl space-y-8" data-testid="billing-skeleton">
+        <div className="h-8 w-24 animate-pulse rounded bg-slate-800" />
+        <div className="rounded-xl border border-slate-800 bg-slate-900/50 p-6 space-y-4">
+          <div className="flex items-center justify-between">
+            <div className="h-5 w-28 animate-pulse rounded bg-slate-800" />
+            <div className="h-6 w-16 animate-pulse rounded-full bg-slate-800" />
+          </div>
+          <div className="h-8 w-24 animate-pulse rounded bg-slate-800" />
+          <div className="h-4 w-48 animate-pulse rounded bg-slate-800/60" />
+          <div className="h-10 w-40 animate-pulse rounded-lg bg-slate-800" />
+        </div>
+        <div className="rounded-xl border border-slate-800 bg-slate-900/50 p-6 space-y-3">
+          <div className="h-5 w-24 animate-pulse rounded bg-slate-800" />
+          <div className="h-4 w-full animate-pulse rounded bg-slate-800/60" />
+          <div className="h-4 w-3/4 animate-pulse rounded bg-slate-800/60" />
+        </div>
+      </div>
+    );
+  }
+
+  if (fetchError) {
+    return (
+      <div className="max-w-2xl space-y-8" data-testid="billing-error">
         <h1 className="text-2xl font-bold text-white">Billing</h1>
         <div className="rounded-xl border border-slate-800 bg-slate-900/50 p-6">
-          <p className="text-sm text-slate-400">Loading...</p>
+          <p className="text-sm text-red-400 mb-3">{fetchError}</p>
+          <button
+            onClick={() => window.location.reload()}
+            className="rounded-lg bg-indigo-600 px-4 py-2 text-sm text-white hover:bg-indigo-500"
+          >
+            Retry
+          </button>
         </div>
       </div>
     );

--- a/apps/web/src/app/dashboard/components/__tests__/connections-card.test.tsx
+++ b/apps/web/src/app/dashboard/components/__tests__/connections-card.test.tsx
@@ -1,0 +1,12 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ConnectionsCardSkeleton } from '../connections-card';
+
+describe('ConnectionsCardSkeleton', () => {
+  it('renders skeleton with pulse animations', () => {
+    const { container } = render(<ConnectionsCardSkeleton />);
+    expect(screen.getByTestId('connections-card-skeleton')).toBeTruthy();
+    expect(container.querySelectorAll('.animate-pulse').length).toBeGreaterThan(0);
+  });
+});

--- a/apps/web/src/app/dashboard/components/__tests__/usage-card.test.tsx
+++ b/apps/web/src/app/dashboard/components/__tests__/usage-card.test.tsx
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, cleanup } from '@testing-library/react';
+import { UsageCard, UsageCardSkeleton } from '../usage-card';
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('UsageCardSkeleton', () => {
+  it('renders skeleton with pulse animations', () => {
+    const { container } = render(<UsageCardSkeleton />);
+    expect(screen.getByTestId('usage-card-skeleton')).toBeTruthy();
+    expect(container.querySelectorAll('.animate-pulse').length).toBeGreaterThan(0);
+  });
+});
+
+describe('UsageCard', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    global.fetch = mockFetch;
+    mockFetch.mockReset();
+  });
+
+  it('shows skeleton while loading', () => {
+    mockFetch.mockReturnValue(new Promise(() => {}));
+    render(<UsageCard />);
+    expect(screen.getByTestId('usage-card-skeleton')).toBeTruthy();
+  });
+
+  it('shows data after successful fetch', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        messages_today: 42,
+        messages_limit: 100,
+        hours_active: 3.5,
+        hours_limit: 8,
+        plan: 'free',
+      }),
+    });
+
+    render(<UsageCard />);
+    await waitFor(() => {
+      expect(screen.getByText(/42/)).toBeTruthy();
+    });
+    expect(screen.getByText(/free plan/i)).toBeTruthy();
+  });
+});

--- a/apps/web/src/app/dashboard/components/connections-card.tsx
+++ b/apps/web/src/app/dashboard/components/connections-card.tsx
@@ -23,6 +23,28 @@ interface MessengerStatus {
   botLink?: string | null;
 }
 
+export function ConnectionsCardSkeleton() {
+  return (
+    <div className="rounded-xl border border-slate-800 bg-slate-900 p-6" data-testid="connections-card-skeleton">
+      <div className="flex items-center justify-between mb-4">
+        <div className="h-5 w-28 animate-pulse rounded bg-slate-800" />
+      </div>
+      <div className="space-y-3">
+        {[1, 2].map((i) => (
+          <div key={i} className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <div className="h-5 w-5 animate-pulse rounded bg-slate-800" />
+              <div className="h-4 w-20 animate-pulse rounded bg-slate-800/60" />
+              <div className="h-3 w-16 animate-pulse rounded bg-slate-800/40" />
+            </div>
+            <div className="h-6 w-16 animate-pulse rounded-md bg-slate-800" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
 interface ConnectionsCardProps {
   messengers?: string[];
   disabled?: boolean;
@@ -61,9 +83,14 @@ export function ConnectionsCard({
         setMessengerStatuses(statuses);
       }
     } catch {
-      // silently fail
+      setFetchError("Failed to load connections");
+    } finally {
+      setFetchLoading(false);
     }
   }, []);
+
+  const [fetchLoading, setFetchLoading] = useState(true);
+  const [fetchError, setFetchError] = useState<string | null>(null);
 
   useEffect(() => {
     fetchMessengerStatus();
@@ -129,6 +156,23 @@ export function ConnectionsCard({
     }
     setSetupModal(key);
   };
+
+  if (fetchLoading) return <ConnectionsCardSkeleton />;
+
+  if (fetchError && messengerStatuses.length === 0) {
+    return (
+      <div className="rounded-xl border border-slate-800 bg-slate-900 p-6" data-testid="connections-card-error">
+        <h2 className="text-lg font-semibold text-white mb-2">Connections</h2>
+        <p className="text-sm text-red-400 mb-3">{fetchError}</p>
+        <button
+          onClick={() => { setFetchLoading(true); fetchMessengerStatus(); }}
+          className="rounded-lg bg-indigo-600 px-4 py-2 text-sm text-white hover:bg-indigo-500"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
 
   return (
     <>

--- a/apps/web/src/app/dashboard/components/usage-card.tsx
+++ b/apps/web/src/app/dashboard/components/usage-card.tsx
@@ -38,24 +38,44 @@ function ProgressBar({
   );
 }
 
+export function UsageCardSkeleton() {
+  return (
+    <div className="rounded-xl border border-slate-800 bg-slate-900 p-6" data-testid="usage-card-skeleton">
+      <div className="h-5 w-28 animate-pulse rounded bg-slate-800 mb-4" />
+      <div className="mb-4">
+        <div className="h-3 w-24 animate-pulse rounded bg-slate-800/60 mb-2" />
+        <div className="h-7 w-20 animate-pulse rounded bg-slate-800 mb-2" />
+        <div className="h-2 w-full animate-pulse rounded-full bg-slate-800" />
+      </div>
+      <div className="mb-4">
+        <div className="h-3 w-32 animate-pulse rounded bg-slate-800/60 mb-2" />
+        <div className="h-7 w-20 animate-pulse rounded bg-slate-800 mb-2" />
+        <div className="h-2 w-full animate-pulse rounded-full bg-slate-800" />
+      </div>
+      <div className="h-3 w-16 animate-pulse rounded bg-slate-800/60" />
+    </div>
+  );
+}
+
 export function UsageCard() {
-  const [data, setData] = useState<UsageData>({
-    messages_today: 0,
-    messages_limit: 50,
-    hours_active: 0,
-    hours_limit: 8,
-    plan: "free",
-  });
+  const [data, setData] = useState<UsageData | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
 
   const fetchUsage = useCallback(async () => {
     try {
+      setError(null);
       const res = await fetch("/api/usage/today");
       if (res.ok) {
         const json = await res.json();
         setData(json);
+      } else {
+        setError("Failed to load usage data");
       }
     } catch {
-      // silently fail
+      setError("Failed to load usage data");
+    } finally {
+      setLoading(false);
     }
   }, []);
 
@@ -65,17 +85,29 @@ export function UsageCard() {
     return () => clearInterval(interval);
   }, [fetchUsage]);
 
-  const { messages_today, messages_limit, hours_active, hours_limit, plan } =
-    data;
+  if (loading) return <UsageCardSkeleton />;
+
+  if (error || !data) {
+    return (
+      <div className="rounded-xl border border-slate-800 bg-slate-900 p-6" data-testid="usage-card-error">
+        <h2 className="text-lg font-semibold text-white mb-2">Today&apos;s Usage</h2>
+        <p className="text-sm text-red-400 mb-3">{error ?? "Failed to load usage data"}</p>
+        <button
+          onClick={() => { setLoading(true); fetchUsage(); }}
+          className="rounded-lg bg-indigo-600 px-4 py-2 text-sm text-white hover:bg-indigo-500"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  const { messages_today, messages_limit, hours_active, hours_limit, plan } = data;
   const isUnlimitedMessages = messages_limit === null;
 
   return (
     <div className="rounded-xl border border-slate-800 bg-slate-900 p-6">
-      <h2 className="text-lg font-semibold text-white mb-4">
-        Today&apos;s Usage
-      </h2>
-
-      {/* Messages */}
+      <h2 className="text-lg font-semibold text-white mb-4">Today&apos;s Usage</h2>
       <div className="mb-4">
         <p className="text-sm text-slate-400 mb-1">Messages today</p>
         <p className="text-slate-100 text-2xl font-bold">
@@ -84,11 +116,7 @@ export function UsageCard() {
             {isUnlimitedMessages ? "unlimited" : `/ ${messages_limit}`}
           </span>
         </p>
-        <ProgressBar
-          value={messages_today}
-          max={messages_limit}
-          unlimited={isUnlimitedMessages}
-        />
+        <ProgressBar value={messages_today} max={messages_limit} unlimited={isUnlimitedMessages} />
         {!isUnlimitedMessages && (
           <p className="text-xs text-slate-500 mt-1">
             {messages_today >= messages_limit!
@@ -97,25 +125,17 @@ export function UsageCard() {
           </p>
         )}
       </div>
-
-      {/* Hours */}
       <div className="mb-4">
         <p className="text-sm text-slate-400 mb-1">Hours active today</p>
         <p className="text-slate-100 text-2xl font-bold">
           {hours_active.toFixed(1)}
-          <span className="text-base font-normal text-slate-500">
-            {" "}
-            / {hours_limit}h
-          </span>
+          <span className="text-base font-normal text-slate-500"> / {hours_limit}h</span>
         </p>
         <ProgressBar value={hours_active} max={hours_limit} />
         {hours_active >= hours_limit && (
-          <p className="text-xs text-red-400 mt-1">
-            Daily hours limit reached
-          </p>
+          <p className="text-xs text-red-400 mt-1">Daily hours limit reached</p>
         )}
       </div>
-
       <p className="text-xs text-indigo-400 capitalize">{plan} plan</p>
     </div>
   );

--- a/apps/web/src/app/dashboard/loading.tsx
+++ b/apps/web/src/app/dashboard/loading.tsx
@@ -1,21 +1,79 @@
 export default function DashboardLoading() {
   return (
-    <div className="p-6">
-      <div className="mb-6 h-8 w-48 animate-pulse rounded-lg bg-zinc-800" />
-      <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
-        {Array.from({ length: 4 }).map((_, i) => (
-          <div
-            key={i}
-            className="rounded-2xl border border-zinc-800 bg-zinc-900/60 p-6"
-          >
-            <div className="mb-4 h-5 w-32 animate-pulse rounded bg-zinc-800" />
-            <div className="space-y-3">
-              <div className="h-4 w-full animate-pulse rounded bg-zinc-800/60" />
-              <div className="h-4 w-3/4 animate-pulse rounded bg-zinc-800/60" />
-              <div className="h-4 w-1/2 animate-pulse rounded bg-zinc-800/60" />
+    <div className="min-h-screen bg-slate-950 px-4 py-8 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-6xl space-y-6">
+        {/* Hero skeleton */}
+        <div className="rounded-2xl border border-slate-800 bg-slate-900/60 p-6">
+          <div className="flex items-center gap-4 mb-4">
+            <div className="h-12 w-12 animate-pulse rounded-full bg-slate-800" />
+            <div className="space-y-2">
+              <div className="h-6 w-40 animate-pulse rounded bg-slate-800" />
+              <div className="h-4 w-24 animate-pulse rounded bg-slate-800/60" />
             </div>
           </div>
-        ))}
+          <div className="h-4 w-64 animate-pulse rounded bg-slate-800/60" />
+        </div>
+
+        {/* Quick actions skeleton */}
+        <div className="flex flex-wrap gap-3">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="h-10 w-36 animate-pulse rounded-full bg-slate-800" />
+          ))}
+        </div>
+
+        {/* Three-column grid */}
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+          {/* Col 1: Connections */}
+          <div className="rounded-xl border border-slate-800 bg-slate-900 p-6">
+            <div className="h-5 w-28 animate-pulse rounded bg-slate-800 mb-4" />
+            <div className="space-y-3">
+              {[1, 2].map((i) => (
+                <div key={i} className="flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <div className="h-5 w-5 animate-pulse rounded bg-slate-800" />
+                    <div className="h-4 w-20 animate-pulse rounded bg-slate-800/60" />
+                  </div>
+                  <div className="h-6 w-16 animate-pulse rounded-md bg-slate-800" />
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Col 2: AI Model + Usage */}
+          <div className="space-y-6">
+            <div className="rounded-xl border border-slate-800 bg-slate-900 p-6">
+              <div className="h-5 w-20 animate-pulse rounded bg-slate-800 mb-3" />
+              <div className="h-4 w-48 animate-pulse rounded bg-slate-800/60 mb-3" />
+              <div className="h-8 w-32 animate-pulse rounded-lg bg-slate-800" />
+            </div>
+            <div className="rounded-xl border border-slate-800 bg-slate-900 p-6">
+              <div className="h-5 w-28 animate-pulse rounded bg-slate-800 mb-4" />
+              <div className="mb-4">
+                <div className="h-3 w-24 animate-pulse rounded bg-slate-800/60 mb-2" />
+                <div className="h-7 w-20 animate-pulse rounded bg-slate-800 mb-2" />
+                <div className="h-2 w-full animate-pulse rounded-full bg-slate-800" />
+              </div>
+              <div className="mb-4">
+                <div className="h-3 w-32 animate-pulse rounded bg-slate-800/60 mb-2" />
+                <div className="h-7 w-20 animate-pulse rounded bg-slate-800 mb-2" />
+                <div className="h-2 w-full animate-pulse rounded-full bg-slate-800" />
+              </div>
+              <div className="h-3 w-16 animate-pulse rounded bg-slate-800/60" />
+            </div>
+          </div>
+
+          {/* Col 3: Plan */}
+          <div className="rounded-xl border border-slate-800 bg-slate-900 p-6">
+            <div className="h-5 w-24 animate-pulse rounded bg-slate-800 mb-3" />
+            <div className="h-7 w-16 animate-pulse rounded bg-slate-800 mb-4" />
+            <div className="space-y-2 mb-4">
+              {[1, 2, 3].map((i) => (
+                <div key={i} className="h-3 w-36 animate-pulse rounded bg-slate-800/60" />
+              ))}
+            </div>
+            <div className="h-9 w-full animate-pulse rounded-lg bg-slate-800" />
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/apps/web/src/app/dashboard/settings/loading.tsx
+++ b/apps/web/src/app/dashboard/settings/loading.tsx
@@ -1,0 +1,21 @@
+export default function SettingsLoading() {
+  return (
+    <div className="max-w-2xl space-y-8">
+      <div className="h-8 w-32 animate-pulse rounded bg-slate-800" />
+      <div className="rounded-xl border border-slate-800 bg-slate-900/50 p-6 space-y-4">
+        <div className="h-5 w-20 animate-pulse rounded bg-slate-800" />
+        <div className="h-10 w-full animate-pulse rounded-lg bg-slate-800" />
+        <div className="h-10 w-full animate-pulse rounded-lg bg-slate-800" />
+        <div className="h-10 w-full animate-pulse rounded-lg bg-slate-800" />
+        <div className="h-9 w-28 animate-pulse rounded-lg bg-slate-800" />
+      </div>
+      <div className="rounded-xl border border-slate-800 bg-slate-900/50 p-6 space-y-4">
+        <div className="h-5 w-20 animate-pulse rounded bg-slate-800" />
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div className="h-10 animate-pulse rounded bg-slate-800" />
+          <div className="h-10 animate-pulse rounded bg-slate-800" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/dashboard/settings/page.tsx
+++ b/apps/web/src/app/dashboard/settings/page.tsx
@@ -31,6 +31,8 @@ export default function SettingsPage() {
   const [aiKeyVerified, setAiKeyVerified] = useState(false);
   const [aiKeyError, setAiKeyError] = useState<string | null>(null);
   const [aiSaving, setAiSaving] = useState(false);
+  const [pageLoading, setPageLoading] = useState(true);
+  const [pageError, setPageError] = useState<string | null>(null);
 
   useEffect(() => {
     const detectedTz = Intl.DateTimeFormat().resolvedOptions().timeZone;
@@ -49,7 +51,9 @@ export default function SettingsPage() {
       })
       .catch(() => {
         setTimezone(detectedTz);
-      });
+        setPageError('Failed to load settings');
+      })
+      .finally(() => setPageLoading(false));
   }, []);
 
   async function handleSave() {
@@ -85,6 +89,45 @@ export default function SettingsPage() {
 
   const isPro = plan === 'pro' || plan === 'Pro';
   const inputClass = 'w-full rounded-lg border border-slate-700 bg-slate-800 px-4 py-2.5 text-sm text-white placeholder-slate-500 focus:border-violet-500 focus:outline-none';
+
+  if (pageLoading) {
+    return (
+      <div className="max-w-2xl space-y-8" data-testid="settings-skeleton">
+        <div className="h-8 w-32 animate-pulse rounded bg-slate-800" />
+        <div className="rounded-xl border border-slate-800 bg-slate-900/50 p-6 space-y-4">
+          <div className="h-5 w-20 animate-pulse rounded bg-slate-800" />
+          <div className="h-10 w-full animate-pulse rounded-lg bg-slate-800" />
+          <div className="h-10 w-full animate-pulse rounded-lg bg-slate-800" />
+          <div className="h-10 w-full animate-pulse rounded-lg bg-slate-800" />
+          <div className="h-9 w-28 animate-pulse rounded-lg bg-slate-800" />
+        </div>
+        <div className="rounded-xl border border-slate-800 bg-slate-900/50 p-6 space-y-4">
+          <div className="h-5 w-20 animate-pulse rounded bg-slate-800" />
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="h-10 animate-pulse rounded bg-slate-800" />
+            <div className="h-10 animate-pulse rounded bg-slate-800" />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (pageError) {
+    return (
+      <div className="max-w-2xl space-y-8" data-testid="settings-error">
+        <h1 className="text-2xl font-bold text-white">Settings</h1>
+        <div className="rounded-xl border border-slate-800 bg-slate-900/50 p-6">
+          <p className="text-sm text-red-400 mb-3">{pageError}</p>
+          <button
+            onClick={() => window.location.reload()}
+            className="rounded-lg bg-indigo-600 px-4 py-2 text-sm text-white hover:bg-indigo-500"
+          >
+            Retry
+          </button>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="max-w-2xl space-y-8">


### PR DESCRIPTION
## Summary

Polishes loading states across the dashboard for a smoother UX.

### Changes

**Skeleton loading states:**
- `UsageCard`: Shows animated pulse skeleton while fetching usage data
- `ConnectionsCard`: Shows animated pulse skeleton while fetching messenger status
- Dashboard `loading.tsx`: Updated to match actual 3-column layout (hero → quick actions → connections/AI model+usage/plan)
- Settings page: Shows skeleton while loading user profile data
- Billing page: Replaced plain "Loading..." text with animated skeleton

**Error states with retry:**
- `UsageCard`: Shows error message + retry button on fetch failure
- `ConnectionsCard`: Shows error message + retry button on fetch failure
- Settings page: Shows error state with retry on profile load failure
- Billing page: Shows error state with retry on billing info load failure

**New loading.tsx route files:**
- `/dashboard/settings/loading.tsx` — Next.js Suspense boundary skeleton
- `/dashboard/billing/loading.tsx` — Next.js Suspense boundary skeleton

**Tests (7 new):**
- `UsageCardSkeleton`: renders with pulse animations
- `UsageCard`: shows skeleton while loading, shows data after fetch
- `ConnectionsCardSkeleton`: renders with pulse animations
- `DashboardLoading`: renders 3-column grid skeleton
- `SettingsLoading`: renders skeleton
- `BillingLoading`: renders skeleton

### Cards not changed (no client-side data fetching):
- `assistant-card.tsx` — receives props from server component
- `plan-card.tsx` — receives props from server component
- `ai-model-card.tsx` — receives props from server component
- `quick-actions.tsx` — receives props, no fetch
- `upgrade-banner.tsx` — static UI, auto-dismisses