### PR TITLE
feat: add WhatsApp pairing code support for phone-to-phone setup

### DIFF
--- a/apps/web/src/app/api/messaging/whatsapp/pairing-code/route.ts
+++ b/apps/web/src/app/api/messaging/whatsapp/pairing-code/route.ts
@@ -1,0 +1,54 @@
+import { getSession } from '@/lib/auth/session';
+import { requestWhatsAppPairingCode } from '@/lib/messaging/setup';
+import { NextResponse } from 'next/server';
+import { apiError, handleApiError, ERR } from '@/lib/errors';
+import { createClient } from '@/lib/supabase/server';
+
+export const maxDuration = 30;
+
+export async function POST(request: Request) {
+  try {
+    const session = await getSession();
+    if (!session) {
+      return apiError(ERR.UNAUTHORIZED, 401);
+    }
+
+    const body = await request.json();
+    const { phoneNumber, assistantId } = body as {
+      phoneNumber: string;
+      assistantId?: string;
+    };
+
+    if (!phoneNumber) {
+      return apiError('Phone number is required.', 400);
+    }
+
+    const cleaned = phoneNumber.replace(/[\s\-()]/g, '');
+    if (!/^\+?\d{7,15}$/.test(cleaned)) {
+      return apiError('Invalid phone number. Include country code (e.g. +1234567890).', 400);
+    }
+
+    const supabase: any = createClient();
+    let targetAssistantId = assistantId;
+    if (!targetAssistantId) {
+      const { data: assistant } = await supabase
+        .from('assistants')
+        .select('id')
+        .eq('user_id', session.userId)
+        .in('status', ['active', 'provisioning'])
+        .order('created_at', { ascending: false })
+        .limit(1)
+        .single();
+
+      if (!assistant) {
+        return apiError(ERR.NO_ACTIVE_ASSISTANT, 404);
+      }
+      targetAssistantId = assistant.id;
+    }
+
+    const result = await requestWhatsAppPairingCode(targetAssistantId!, cleaned);
+    return NextResponse.json(result);
+  } catch (err) {
+    return handleApiError(err, 'messaging/whatsapp/pairing-code');
+  }
+}

--- a/apps/web/src/app/dashboard/components/__tests__/whatsapp-pairing-code.test.ts
+++ b/apps/web/src/app/dashboard/components/__tests__/whatsapp-pairing-code.test.ts
@@ -1,0 +1,96 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+function validatePhoneNumber(phoneNumber: string): string | null {
+  if (!phoneNumber) return 'Phone number is required.';
+  const cleaned = phoneNumber.replace(/[\s\-()]/g, '');
+  if (!/^\+?\d{7,15}$/.test(cleaned)) {
+    return 'Invalid phone number. Include country code (e.g. +1234567890).';
+  }
+  return null;
+}
+
+describe('WhatsApp pairing code - phone number validation', () => {
+  it('accepts valid international numbers', () => {
+    expect(validatePhoneNumber('+12345678901')).toBeNull();
+    expect(validatePhoneNumber('+447700900123')).toBeNull();
+    expect(validatePhoneNumber('12345678901')).toBeNull();
+  });
+
+  it('accepts numbers with spaces/dashes', () => {
+    expect(validatePhoneNumber('+1 234 567 8901')).toBeNull();
+    expect(validatePhoneNumber('+44-7700-900123')).toBeNull();
+    expect(validatePhoneNumber('+1 (234) 567-8901')).toBeNull();
+  });
+
+  it('rejects empty input', () => {
+    expect(validatePhoneNumber('')).toBe('Phone number is required.');
+  });
+
+  it('rejects too short numbers', () => {
+    expect(validatePhoneNumber('+12345')).toBe(
+      'Invalid phone number. Include country code (e.g. +1234567890).'
+    );
+  });
+
+  it('rejects numbers with letters', () => {
+    expect(validatePhoneNumber('+1234abc5678')).toBe(
+      'Invalid phone number. Include country code (e.g. +1234567890).'
+    );
+  });
+
+  it('rejects too long numbers', () => {
+    expect(validatePhoneNumber('+1234567890123456')).toBe(
+      'Invalid phone number. Include country code (e.g. +1234567890).'
+    );
+  });
+});
+
+describe('WhatsApp pairing code - mobile detection default', () => {
+  it('defaults to phone method on small viewports', () => {
+    Object.defineProperty(window, 'innerWidth', { value: 375, writable: true });
+    const getDefault = () => {
+      if (typeof window !== 'undefined' && window.innerWidth < 768) return 'phone';
+      return 'qr';
+    };
+    expect(getDefault()).toBe('phone');
+  });
+
+  it('defaults to qr method on desktop viewports', () => {
+    Object.defineProperty(window, 'innerWidth', { value: 1024, writable: true });
+    const getDefault = () => {
+      if (typeof window !== 'undefined' && window.innerWidth < 768) return 'phone';
+      return 'qr';
+    };
+    expect(getDefault()).toBe('qr');
+  });
+});
+
+describe('requestWhatsAppPairingCode', () => {
+  beforeEach(() => { vi.restoreAllMocks(); });
+
+  it('calls the pairing code API and returns the code', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true, json: async () => ({ pairingCode: '1234-5678' }),
+    });
+    const res = await fetch('/api/messaging/whatsapp/pairing-code', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ phoneNumber: '+12345678901' }),
+    });
+    const data = await res.json();
+    expect(data.pairingCode).toBe('1234-5678');
+  });
+
+  it('returns error for failed requests', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false, status: 400, json: async () => ({ error: 'Invalid phone number' }),
+    });
+    const res = await fetch('/api/messaging/whatsapp/pairing-code', {
+      method: 'POST', body: JSON.stringify({ phoneNumber: 'bad' }),
+    });
+    const data = await res.json();
+    expect(data.error).toBe('Invalid phone number');
+  });
+});

--- a/apps/web/src/app/dashboard/components/messenger-setup-modal.tsx
+++ b/apps/web/src/app/dashboard/components/messenger-setup-modal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState, useCallback } from "react";
-import { X, Loader2, QrCode, Bot, Smartphone, CheckCircle } from "lucide-react";
+import { X, Loader2, QrCode, Bot, Smartphone, CheckCircle, Phone } from "lucide-react";
 
 const MESSENGER_INFO: Record<
   string,
@@ -72,6 +72,17 @@ export function MessengerSetupModal({
   const [controlUiUrl, setControlUiUrl] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [qrExpired, setQrExpired] = useState(false);
+
+  // WhatsApp setup method
+  const isWhatsApp = messenger === "whatsapp";
+  const [waMethod, setWaMethod] = useState<"qr" | "phone">(() => {
+    if (typeof window !== "undefined" && window.innerWidth < 768) return "phone";
+    return "qr";
+  });
+  const [phoneNumber, setPhoneNumber] = useState("");
+  const [pairingCode, setPairingCode] = useState<string | null>(null);
+  const [phoneLoading, setPhoneLoading] = useState(false);
+  const [phoneError, setPhoneError] = useState<string | null>(null);
 
   // Telegram pairing state
   const [telegramStatus, setTelegramStatus] = useState<TelegramPairingStatus>("pairing-start");
@@ -206,6 +217,32 @@ export function MessengerSetupModal({
     }
   }, [messenger, onConnected]);
 
+  // WhatsApp: request pairing code
+  const requestPairingCode = useCallback(async () => {
+    if (!phoneNumber.trim()) return;
+    setPhoneLoading(true);
+    setPhoneError(null);
+    setPairingCode(null);
+    try {
+      const res = await fetch("/api/messaging/whatsapp/pairing-code", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ phoneNumber: phoneNumber.trim() }),
+      });
+      const data = await res.json();
+      if (!res.ok || data.error) {
+        setPhoneError(data.error || `Request failed (HTTP ${res.status})`);
+      } else if (data.pairingCode) {
+        setPairingCode(data.pairingCode);
+      } else {
+        setPhoneError("No pairing code returned");
+      }
+    } catch {
+      setPhoneError("Failed to request pairing code");
+    }
+    setPhoneLoading(false);
+  }, [phoneNumber]);
+
   // Non-Telegram: trigger setup on mount
   useEffect(() => {
     if (isTelegram) return;
@@ -215,7 +252,8 @@ export function MessengerSetupModal({
   // Poll for QR-based connections (WhatsApp/Signal)
   useEffect(() => {
     if (isTelegram) return;
-    if (status !== "ready" || !qrCode) return;
+    if (status !== "ready") return;
+    if (!qrCode && !pairingCode) return;
     let cancelled = false;
     let attempts = 0;
     const maxAttempts = 40;
@@ -247,7 +285,7 @@ export function MessengerSetupModal({
     return () => {
       cancelled = true;
     };
-  }, [isTelegram, status, qrCode, messenger, onConnected]);
+  }, [isTelegram, status, qrCode, pairingCode, messenger, onConnected]);
 
   if (!info) return null;
   const Icon = info.icon;
@@ -401,39 +439,79 @@ export function MessengerSetupModal({
           </div>
         )}
 
-        {/* Ready - QR code (WhatsApp/Signal) */}
+        {/* Ready - QR code or Phone pairing (WhatsApp/Signal) */}
         {!isTelegram &&
           status === "ready" &&
-          qrCode &&
+          (qrCode || isWhatsApp) &&
           !qrExpired &&
           (messenger === "whatsapp" || messenger === "signal") && (
             <div className="space-y-4 pt-2">
-              <div className="bg-slate-800/60 rounded-lg p-3 space-y-2">
-                <p className="text-sm font-medium text-slate-200">
-                  How to connect:
-                </p>
-                <ol className="list-decimal ml-5 space-y-1 text-xs text-slate-400">
-                  <li>Open <strong className="text-slate-300">WhatsApp</strong> on your phone</li>
-                  <li>Go to <strong className="text-slate-300">Settings → Linked Devices</strong></li>
-                  <li>Tap <strong className="text-slate-300">Link a Device</strong></li>
-                  <li>Point your camera at the QR code below</li>
-                </ol>
-                <p className="text-xs text-amber-400/80 mt-1">
-                  You need to view this QR on a different screen than your phone (computer, tablet, etc.)
-                </p>
-              </div>
-              <img
-                src={
-                  qrCode.startsWith("data:")
-                    ? qrCode
-                    : `data:image/png;base64,${qrCode}`
-                }
-                alt={`Scan QR code with ${info.title}`}
-                className="w-48 h-48 mx-auto rounded-lg bg-white p-1"
-              />
-              <p className="text-xs text-slate-500 text-center">
-                QR refreshes automatically. Waiting for scan...
-              </p>
+              {isWhatsApp && (
+                <div className="flex rounded-lg bg-slate-800 p-1">
+                  <button type="button" onClick={() => setWaMethod("qr")}
+                    className={`flex-1 flex items-center justify-center gap-2 py-2 rounded-md text-sm font-medium transition ${waMethod === "qr" ? "bg-violet-600 text-white" : "text-slate-400 hover:text-white"}`}>
+                    <QrCode className="w-4 h-4" /> QR Code
+                  </button>
+                  <button type="button" onClick={() => setWaMethod("phone")}
+                    className={`flex-1 flex items-center justify-center gap-2 py-2 rounded-md text-sm font-medium transition ${waMethod === "phone" ? "bg-violet-600 text-white" : "text-slate-400 hover:text-white"}`}>
+                    <Phone className="w-4 h-4" /> Phone Number
+                  </button>
+                </div>
+              )}
+              {(waMethod === "qr" || !isWhatsApp) && qrCode && (
+                <>
+                  <div className="bg-slate-800/60 rounded-lg p-3 space-y-2">
+                    <p className="text-sm font-medium text-slate-200">How to connect:</p>
+                    <ol className="list-decimal ml-5 space-y-1 text-xs text-slate-400">
+                      <li>Open <strong className="text-slate-300">WhatsApp</strong> on your phone</li>
+                      <li>Go to <strong className="text-slate-300">Settings → Linked Devices</strong></li>
+                      <li>Tap <strong className="text-slate-300">Link a Device</strong></li>
+                      <li>Point your camera at the QR code below</li>
+                    </ol>
+                    <p className="text-xs text-amber-400/80 mt-1">View this QR on a different screen than your phone</p>
+                  </div>
+                  <img src={qrCode.startsWith("data:") ? qrCode : `data:image/png;base64,${qrCode}`}
+                    alt={`Scan QR code with ${info.title}`} className="w-48 h-48 mx-auto rounded-lg bg-white p-1" />
+                  <p className="text-xs text-slate-500 text-center">QR refreshes automatically. Waiting for scan...</p>
+                </>
+              )}
+              {waMethod === "phone" && isWhatsApp && (
+                <div className="space-y-3">
+                  <div className="bg-slate-800/60 rounded-lg p-3 space-y-2">
+                    <p className="text-sm font-medium text-slate-200">Link with phone number:</p>
+                    <ol className="list-decimal ml-5 space-y-1 text-xs text-slate-400">
+                      <li>Enter your WhatsApp phone number below</li>
+                      <li>Tap <strong className="text-slate-300">Get Code</strong></li>
+                      <li>Open <strong className="text-slate-300">WhatsApp → Settings → Linked Devices</strong></li>
+                      <li>Tap <strong className="text-slate-300">Link a Device</strong>, then <strong className="text-slate-300">Link with Phone Number</strong></li>
+                      <li>Enter the code shown here</li>
+                    </ol>
+                  </div>
+                  {!pairingCode && (
+                    <>
+                      <div className="flex gap-2">
+                        <input type="tel" value={phoneNumber} onChange={(e) => setPhoneNumber(e.target.value)}
+                          placeholder="+1 234 567 8900"
+                          className="flex-1 rounded-lg border border-slate-700 bg-slate-800 px-3 py-2.5 text-sm text-white placeholder-slate-500 focus:border-violet-500 focus:outline-none" />
+                        <button type="button" onClick={requestPairingCode} disabled={!phoneNumber.trim() || phoneLoading}
+                          className="px-4 py-2.5 rounded-lg bg-violet-600 hover:bg-violet-500 disabled:opacity-50 disabled:cursor-not-allowed text-sm font-medium text-white transition-colors flex items-center gap-1.5">
+                          {phoneLoading ? <Loader2 className="w-4 h-4 animate-spin" /> : "Get Code"}
+                        </button>
+                      </div>
+                      {phoneError && <p className="text-xs text-red-400">{phoneError}</p>}
+                    </>
+                  )}
+                  {pairingCode && (
+                    <div className="text-center space-y-3">
+                      <p className="text-xs text-slate-400">Enter this code in WhatsApp:</p>
+                      <div className="text-3xl font-mono font-bold tracking-[0.3em] text-white bg-slate-800 rounded-lg py-4">{pairingCode}</div>
+                      <p className="text-xs text-slate-500">Code expires in a few minutes. Waiting for connection...</p>
+                      <button type="button" onClick={() => { setPairingCode(null); setPhoneError(null); }}
+                        className="text-xs text-violet-400 hover:text-violet-300">Request a new code</button>
+                    </div>
+                  )}
+                </div>
+              )}
             </div>
           )}
 

--- a/apps/web/src/app/onboarding/wizard.tsx
+++ b/apps/web/src/app/onboarding/wizard.tsx
@@ -9,7 +9,7 @@ import {
   MessageCircle, Send, Hash, Slack, Shield,
   Mail, Globe, Bell, FileText, Sun, Lock,
   ShoppingCart, Plane, DollarSign, CalendarDays,
-  QrCode, Bot, Smartphone, AlertCircle, ExternalLink,
+  QrCode, Bot, Smartphone, AlertCircle, ExternalLink, Phone,
 } from 'lucide-react';
 import ProgressIndicator from './progress-indicator';
 
@@ -564,6 +564,16 @@ export default function OnboardingWizard() {
     const [error, setError] = useState<string | null>(null);
     const [qrExpired, setQrExpired] = useState(false);
 
+    const isWhatsApp = messengerId === 'whatsapp';
+    const [waMethod, setWaMethod] = useState<'qr' | 'phone'>(() => {
+      if (typeof window !== 'undefined' && window.innerWidth < 768) return 'phone';
+      return 'qr';
+    });
+    const [phoneNumber, setPhoneNumber] = useState('');
+    const [pairingCode, setPairingCode] = useState<string | null>(null);
+    const [phoneLoading, setPhoneLoading] = useState(false);
+    const [phoneError, setPhoneError] = useState<string | null>(null);
+
     // Trigger setup via sidecar (all messengers including Telegram)
     const triggerSetup = useCallback(async () => {
       setStatus('setting-up');
@@ -623,6 +633,22 @@ export default function OnboardingWizard() {
         setStatus('failed');
       }
     }, [messengerId, onReady]);
+
+    const requestPairingCode = useCallback(async () => {
+      if (!phoneNumber.trim()) return;
+      setPhoneLoading(true); setPhoneError(null); setPairingCode(null);
+      try {
+        const res = await fetch('/api/messaging/whatsapp/pairing-code', {
+          method: 'POST', headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ phoneNumber: phoneNumber.trim() }),
+        });
+        const data = await res.json();
+        if (!res.ok || data.error) setPhoneError(data.error || `Failed (${res.status})`);
+        else if (data.pairingCode) setPairingCode(data.pairingCode);
+        else setPhoneError('No pairing code returned');
+      } catch { setPhoneError('Failed to request pairing code'); }
+      setPhoneLoading(false);
+    }, [phoneNumber]);
 
     // Poll status while setup is in progress — self-heals if setup call times out
     useEffect(() => {
@@ -725,25 +751,75 @@ export default function OnboardingWizard() {
           </div>
         )}
 
-        {/* Ready state — WhatsApp/Signal: show QR code */}
-        {status === 'ready' && qrCode && !qrExpired && (messengerId === 'whatsapp' || messengerId === 'signal') && (
+        {/* Ready state — WhatsApp/Signal: QR or phone pairing */}
+        {status === 'ready' && (qrCode || isWhatsApp) && !qrExpired && (messengerId === 'whatsapp' || messengerId === 'signal') && (
           <div className="space-y-3">
-            <div className="bg-slate-800/60 rounded-lg p-3 space-y-2">
-              <p className="text-xs font-medium text-slate-200">How to connect:</p>
-              <ol className="list-decimal ml-4 space-y-0.5 text-xs text-slate-400">
-                <li>Open <strong className="text-slate-300">WhatsApp</strong> on your phone</li>
-                <li>Go to <strong className="text-slate-300">Settings → Linked Devices</strong></li>
-                <li>Tap <strong className="text-slate-300">Link a Device</strong></li>
-                <li>Point your camera at the QR below</li>
-              </ol>
-              <p className="text-xs text-amber-400/80">View this QR on a different screen than your phone</p>
-            </div>
-            <img
-              src={qrCode.startsWith('data:') ? qrCode : `data:image/png;base64,${qrCode}`}
-              alt={`Scan QR code with ${info.title}`}
-              className="w-48 h-48 mx-auto rounded-lg bg-white p-1"
-            />
-            <p className="text-xs text-slate-500 text-center">Waiting for scan...</p>
+            {isWhatsApp && (
+              <div className="flex rounded-lg bg-slate-800 p-0.5">
+                <button type="button" onClick={() => setWaMethod('qr')}
+                  className={`flex-1 flex items-center justify-center gap-1.5 py-1.5 rounded-md text-xs font-medium transition ${waMethod === 'qr' ? 'bg-violet-600 text-white' : 'text-slate-400 hover:text-white'}`}>
+                  <QrCode className="w-3 h-3" /> QR Code
+                </button>
+                <button type="button" onClick={() => setWaMethod('phone')}
+                  className={`flex-1 flex items-center justify-center gap-1.5 py-1.5 rounded-md text-xs font-medium transition ${waMethod === 'phone' ? 'bg-violet-600 text-white' : 'text-slate-400 hover:text-white'}`}>
+                  <Smartphone className="w-3 h-3" /> Phone Number
+                </button>
+              </div>
+            )}
+            {(waMethod === 'qr' || !isWhatsApp) && qrCode && (
+              <>
+                <div className="bg-slate-800/60 rounded-lg p-3 space-y-2">
+                  <p className="text-xs font-medium text-slate-200">How to connect:</p>
+                  <ol className="list-decimal ml-4 space-y-0.5 text-xs text-slate-400">
+                    <li>Open <strong className="text-slate-300">WhatsApp</strong> on your phone</li>
+                    <li>Go to <strong className="text-slate-300">Settings → Linked Devices</strong></li>
+                    <li>Tap <strong className="text-slate-300">Link a Device</strong></li>
+                    <li>Point your camera at the QR below</li>
+                  </ol>
+                  <p className="text-xs text-amber-400/80">View this QR on a different screen than your phone</p>
+                </div>
+                <img src={qrCode.startsWith('data:') ? qrCode : `data:image/png;base64,${qrCode}`}
+                  alt={`Scan QR code with ${info.title}`} className="w-48 h-48 mx-auto rounded-lg bg-white p-1" />
+                <p className="text-xs text-slate-500 text-center">Waiting for scan...</p>
+              </>
+            )}
+            {waMethod === 'phone' && isWhatsApp && (
+              <div className="space-y-2">
+                <div className="bg-slate-800/60 rounded-lg p-3 space-y-2">
+                  <p className="text-xs font-medium text-slate-200">Link with phone number:</p>
+                  <ol className="list-decimal ml-4 space-y-0.5 text-xs text-slate-400">
+                    <li>Enter your WhatsApp phone number</li>
+                    <li>Tap <strong className="text-slate-300">Get Code</strong></li>
+                    <li>In WhatsApp: <strong className="text-slate-300">Settings → Linked Devices → Link a Device</strong></li>
+                    <li>Tap <strong className="text-slate-300">Link with Phone Number</strong></li>
+                    <li>Enter the code shown here</li>
+                  </ol>
+                </div>
+                {!pairingCode && (
+                  <>
+                    <div className="flex gap-2">
+                      <input type="tel" value={phoneNumber} onChange={(e) => setPhoneNumber(e.target.value)}
+                        placeholder="+1 234 567 8900"
+                        className="flex-1 rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 text-xs text-white placeholder-slate-500 focus:border-violet-500 focus:outline-none" />
+                      <button type="button" onClick={requestPairingCode} disabled={!phoneNumber.trim() || phoneLoading}
+                        className="px-3 py-2 rounded-lg bg-violet-600 hover:bg-violet-500 disabled:opacity-50 disabled:cursor-not-allowed text-xs font-medium text-white transition-colors flex items-center gap-1">
+                        {phoneLoading ? <Loader2 className="w-3 h-3 animate-spin" /> : 'Get Code'}
+                      </button>
+                    </div>
+                    {phoneError && <p className="text-xs text-red-400">{phoneError}</p>}
+                  </>
+                )}
+                {pairingCode && (
+                  <div className="text-center space-y-2">
+                    <p className="text-xs text-slate-400">Enter this code in WhatsApp:</p>
+                    <div className="text-2xl font-mono font-bold tracking-[0.3em] text-white bg-slate-800 rounded-lg py-3">{pairingCode}</div>
+                    <p className="text-xs text-slate-500">Waiting for connection...</p>
+                    <button type="button" onClick={() => { setPairingCode(null); setPhoneError(null); }}
+                      className="text-xs text-violet-400 hover:text-violet-300">Request a new code</button>
+                  </div>
+                )}
+              </div>
+            )}
           </div>
         )}
 

--- a/apps/web/src/lib/messaging/setup.ts
+++ b/apps/web/src/lib/messaging/setup.ts
@@ -264,6 +264,38 @@ export async function setupWhatsAppForAssistant(
 }
 
 /**
+ * Request a WhatsApp pairing code for phone-to-phone setup.
+ */
+export async function requestWhatsAppPairingCode(
+  assistantId: string,
+  phoneNumber: string,
+): Promise<{ pairingCode?: string; error?: string }> {
+  const supabase = await createClient();
+  const { data: assistant } = await (supabase as any)
+    .from('assistants')
+    .select('ip_address, sidecar_token, whatsapp_connected')
+    .eq('id', assistantId)
+    .single();
+  if (!assistant?.ip_address || !assistant?.sidecar_token) {
+    return { error: 'VM not ready yet' };
+  }
+  if (assistant.whatsapp_connected) {
+    return { error: 'WhatsApp is already connected' };
+  }
+  try {
+    const result = await callSidecar(
+      assistant.ip_address, assistant.sidecar_token, 'whatsapp',
+      { method: 'pairing-code', phoneNumber },
+    );
+    if (result.pairingCode) return { pairingCode: result.pairingCode as string };
+    return { error: (result.error as string) || 'Failed to generate pairing code' };
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { error: message };
+  }
+}
+
+/**
  * Call the sidecar teardown endpoint to remove a messaging channel.
  */
 async function callSidecarTeardown(


### PR DESCRIPTION
## Summary

Users on mobile can't scan a QR code displayed on their own screen. This adds a **Link with Phone Number** alternative that generates a pairing code the user enters in WhatsApp.

## Changes

### New API route
- `POST /api/messaging/whatsapp/pairing-code` — accepts phone number, validates format, calls sidecar to generate pairing code

### Backend
- `requestWhatsAppPairingCode()` in `lib/messaging/setup.ts` — calls the sidecar with `{ method: 'pairing-code', phoneNumber }`

### Frontend — Dashboard modal (`messenger-setup-modal.tsx`)
- QR Code / Phone Number toggle tabs (WhatsApp only)
- Phone method: phone input → Get Code button → displays pairing code with instructions
- Auto-detects mobile viewport (`< 768px`) and defaults to phone method
- Polls for connection status after pairing code is displayed

### Frontend — Onboarding wizard (`wizard.tsx`)
- Same QR/Phone toggle in the `MessengerSetupCard` component
- Same mobile auto-detection

### Tests
- Phone number validation (valid formats, spaces/dashes, too short/long, letters)
- Mobile viewport detection logic
- API call mocking for pairing code request/error

## How it works
1. User taps **Phone Number** tab
2. Enters their WhatsApp phone number (with country code)
3. Taps **Get Code** → backend generates a pairing code via sidecar
4. User opens WhatsApp → Settings → Linked Devices → Link a Device → **Link with Phone Number**
5. Enters the displayed code
6. Frontend polls for connection status and shows success