### PR TITLE
fix: guard against undefined hours_active in usage card

### DIFF
--- a/apps/web/src/app/dashboard/components/usage-card.tsx
+++ b/apps/web/src/app/dashboard/components/usage-card.tsx
@@ -128,7 +128,7 @@ export function UsageCard() {
       <div className="mb-4">
         <p className="text-sm text-slate-400 mb-1">Hours active today</p>
         <p className="text-slate-100 text-2xl font-bold">
-          {hours_active.toFixed(1)}
+          {(hours_active ?? 0).toFixed(1)}
           <span className="text-base font-normal text-slate-500"> / {hours_limit}h</span>
         </p>
         <ProgressBar value={hours_active} max={hours_limit} />


### PR DESCRIPTION
The toFixed() call on hours_active crashed when API returned unexpected data, causing the entire dashboard to error. Added null coalescing.