### PR TITLE
fix: resolve build errors blocking Vercel deployment

### DIFF
--- a/apps/web/src/app/api/stripe/webhook/route.ts
+++ b/apps/web/src/app/api/stripe/webhook/route.ts
@@ -10,18 +10,7 @@ import { env } from "@/lib/env";
 import { apiError, handleApiError } from "@/lib/errors";
 
 // Idempotency
-const processedEvents = new Set<string>();
-const MAX_PROCESSED_EVENTS = 10_000;
-
-function markProcessed(eventId: string): boolean {
-  if (processedEvents.has(eventId)) return false;
-  if (processedEvents.size >= MAX_PROCESSED_EVENTS) {
-    const first = processedEvents.values().next().value;
-    if (first) processedEvents.delete(first);
-  }
-  processedEvents.add(eventId);
-  return true;
-}
+import { markProcessed } from "@/lib/stripe/idempotency";
 
 export async function POST(req: NextRequest) {
   const body = await req.text();
@@ -200,7 +189,7 @@ async function handleSubscriptionResumed(subscription: Stripe.Subscription) {
 
 async function handleInvoicePaid(invoice: Stripe.Invoice) {
   const customerId = invoice.customer as string;
-  const subscriptionId = invoice.subscription as string;
+  const subscriptionId = (invoice as any).subscription as string;
   console.log(`[stripe-webhook] Invoice paid: cust=${customerId} inv=${invoice.id}`);
   if (!subscriptionId) return;
 
@@ -223,4 +212,5 @@ async function handlePaymentFailed(invoice: Stripe.Invoice) {
   }
 }
 
-export { markProcessed, processedEvents };
+// For testing - export via a separate module, not from the route
+// See __tests__/webhook-idempotency.test.ts

--- a/apps/web/src/lib/stripe/idempotency.ts
+++ b/apps/web/src/lib/stripe/idempotency.ts
@@ -1,0 +1,14 @@
+const processedEvents = new Set<string>();
+const MAX_PROCESSED_EVENTS = 10_000;
+
+export function markProcessed(eventId: string): boolean {
+  if (processedEvents.has(eventId)) return false;
+  if (processedEvents.size >= MAX_PROCESSED_EVENTS) {
+    const first = processedEvents.values().next().value;
+    if (first) processedEvents.delete(first);
+  }
+  processedEvents.add(eventId);
+  return true;
+}
+
+export { processedEvents };

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -10,11 +10,7 @@ export default defineConfig({
     },
   },
   test: {
-    environment: 'node',
-    environmentMatchGlobs: [
-      ['src/components/**/*.test.tsx', 'jsdom'],
-      ['src/app/**/*.test.tsx', 'jsdom'],
-    ],
+    environment: 'jsdom',
     coverage: {
       provider: 'v8',
       include: [


### PR DESCRIPTION
Three build errors were preventing Vercel from deploying PRs #182-#190:

1. Stripe webhook route exported non-HTTP functions (markProcessed/processedEvents) - moved to src/lib/stripe/idempotency.ts
2. Stripe Invoice type doesn't have .subscription property in this SDK version - cast to any
3. vitest.config.ts used environmentMatchGlobs which isn't available - switched to jsdom for all tests

This should unblock Vercel production deploys.