### PR TITLE
fix: resolve TypeScript errors in test mocks

### DIFF
--- a/apps/web/src/lib/email/send.test.ts
+++ b/apps/web/src/lib/email/send.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 const mockSend = vi.fn();
 
 vi.mock('resend', () => ({
-  Resend: function() {
+  Resend: function(this: any) {
     this.emails = { send: mockSend };
   },
 }));

--- a/apps/web/src/lib/stripe/client.test.ts
+++ b/apps/web/src/lib/stripe/client.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('stripe', () => ({
-  default: function() {
+  default: function(this: any) {
     this.customers = { list: vi.fn() };
   },
 }));


### PR DESCRIPTION
CI was failing on tsc --noEmit because mock factory constructors used implicit this. Added explicit type annotations.