### PR TITLE
Fix GitHub Copilot OAuth flow: use valid scope

### DIFF
--- a/apps/web/src/app/api/auth/github/route.ts
+++ b/apps/web/src/app/api/auth/github/route.ts
@@ -25,7 +25,7 @@ export async function GET(req: NextRequest) {
   const githubUrl = new URL('https://github.com/login/oauth/authorize');
   githubUrl.searchParams.set('client_id', clientId);
   githubUrl.searchParams.set('redirect_uri', redirectUri);
-  githubUrl.searchParams.set('scope', 'copilot');
+  githubUrl.searchParams.set('scope', 'read:user');
   githubUrl.searchParams.set('state', state);
 
   return NextResponse.redirect(githubUrl.toString());


### PR DESCRIPTION
## Problem
Clicking "Connect with GitHub" on the AI Provider onboarding step redirects to a GitHub 404 page.

## Root Cause
The OAuth authorize URL in `/api/auth/github/route.ts` was using `scope=copilot`, which is **not a valid GitHub OAuth scope**. GitHub returns a 404 when it encounters an unrecognized scope.

## Fix
Changed the scope from `copilot` to `read:user`. The callback route already independently verifies Copilot API access by making a test request to the GitHub Models inference endpoint, so no special scope is needed — just a valid OAuth token.

## Testing
- Click "Connect with GitHub" on AI Provider step → should redirect to GitHub authorization page instead of 404