### PR TITLE
fix: use gemini-2.5-flash for API key verification

### DIFF
--- a/apps/web/src/app/api/ai/verify-key/route.ts
+++ b/apps/web/src/app/api/ai/verify-key/route.ts
@@ -16,8 +16,9 @@ export async function POST(request: NextRequest) {
 
   try {
     if (provider === 'gemini') {
+      // Use gemini-2.5-flash - available on free tier (2.0-flash may not be)
       const res = await fetch(
-        `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${apiKey}`,
+        `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=${apiKey}`,
         {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
@@ -28,6 +29,10 @@ export async function POST(request: NextRequest) {
         }
       );
       if (!res.ok) {
+        const status = res.status;
+        if (status === 429) {
+          return NextResponse.json({ valid: false, error: 'API key is valid but rate limited. Try again in a moment.' });
+        }
         return NextResponse.json({ valid: false, error: 'Invalid API key.' });
       }
       return NextResponse.json({ valid: true });


### PR DESCRIPTION
## Problem
The verify-key endpoint uses gemini-2.0-flash for testing Gemini API keys, but Google changed their free tier - gemini-2.0-flash returns 429 even for brand new keys.

This causes ALL free-tier Gemini keys to show 'Invalid API key' during onboarding and settings.

## Fix
- Changed verification model to gemini-2.5-flash (available on free tier)
- Added 429 status handling to show 'rate limited' instead of 'invalid key'

## Testing
Verified with a fresh API key - only gemini-2.5-flash works on free tier now.