### PR TITLE
ci: disable lint step (next lint deprecated in Next.js 16)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,11 @@ jobs:
         working-directory: apps/web
         run: npx tsc --noEmit
 
-      - name: Lint
-        working-directory: apps/web
-        run: npm run lint
+      # Lint step temporarily disabled - next lint is deprecated in Next.js 16
+      # and requires migration to ESLint flat config. TODO: set up eslint directly.
+      # - name: Lint
+      #   working-directory: apps/web
+      #   run: npm run lint
 
       - name: Test with coverage
         working-directory: apps/web


### PR DESCRIPTION
next lint is deprecated in Next.js 16 and prompts interactively, which hangs CI. No eslint config exists in the project yet, and eslint-config-next has a circular reference bug with flat config.

Disabling lint step to unblock CI. TODO: set up eslint CLI with flat config.