### PR TITLE
fix: resolve dashboard display bugs (usage limits, settings link, em dash)

### DIFF
--- a/apps/web/src/app/api/usage/__tests__/usage-routes.test.ts
+++ b/apps/web/src/app/api/usage/__tests__/usage-routes.test.ts
@@ -70,7 +70,7 @@ describe("GET /api/usage/today", () => {
     const json = await res.json();
     expect(json).toEqual({
       messages_today: 0,
-      messages_limit: 50,
+      messages_limit: 100,
       hours_active: 0,
       hours_limit: 8,
       plan: "free",
@@ -87,7 +87,7 @@ describe("GET /api/usage/today", () => {
     const res = await todayGET();
     const json = await res.json();
     expect(json.messages_today).toBe(30);
-    expect(json.messages_limit).toBe(50);
+    expect(json.messages_limit).toBe(100);
     expect(json.hours_active).toBe(3.5);
     expect(json.hours_limit).toBe(8);
     expect(json.plan).toBe("free");

--- a/apps/web/src/app/api/usage/today/route.ts
+++ b/apps/web/src/app/api/usage/today/route.ts
@@ -31,7 +31,7 @@ export async function GET() {
   if (!assistant) {
     return NextResponse.json({
       messages_today: 0,
-      messages_limit: plan === "free" ? 50 : null,
+      messages_limit: plan === "free" ? 100 : null,
       hours_active: 0,
       hours_limit: plan === "free" ? 8 : 24,
       plan,
@@ -47,7 +47,7 @@ export async function GET() {
 
   return NextResponse.json({
     messages_today: usage?.messages_sent ?? 0,
-    messages_limit: plan === "free" ? 50 : null,
+    messages_limit: plan === "free" ? 100 : null,
     hours_active: usage?.hours_active ?? 0,
     hours_limit: plan === "free" ? 8 : 24,
     plan,

--- a/apps/web/src/app/dashboard/components/ai-model-card.tsx
+++ b/apps/web/src/app/dashboard/components/ai-model-card.tsx
@@ -52,7 +52,7 @@ export function AiModelCard({
         </span>
       ) : (
         <Link
-          href="/settings/ai"
+          href="/dashboard/settings"
           className="inline-block rounded-lg bg-indigo-600 px-4 py-2 text-sm text-white hover:bg-indigo-500"
         >
           {configured ? "Change" : "Set up AI provider"}

--- a/apps/web/src/app/onboarding/wizard.tsx
+++ b/apps/web/src/app/onboarding/wizard.tsx
@@ -1132,7 +1132,7 @@ export default function OnboardingWizard() {
                         <span className="font-semibold">Anthropic</span>
                         <span className="text-[10px] font-bold uppercase tracking-wider px-2 py-0.5 rounded-full bg-slate-700 text-slate-400">Coming Soon</span>
                       </div>
-                      <p className="text-sm text-slate-400 mt-1">Claude \u2014 excellent at writing and analysis</p>
+                      <p className="text-sm text-slate-400 mt-1">Claude — excellent at writing and analysis</p>
                       <p className="text-xs text-slate-500 mt-1">Models: Claude Sonnet 4, Claude Haiku</p>
                     </div>
                   </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "openclaw-saas-v1",
+  "name": "openclaw-saas",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {}


### PR DESCRIPTION
## Fixes

**Bug 1: Anthropic em dash** — Replaced escaped \\u2014 with actual — in wizard.tsx

**Bug 2: Message limit mismatch** — Changed free plan limit from 50 to 100 in API route (matching plan-card)

**Bug 3: Settings link** — Changed /settings/ai to /dashboard/settings in ai-model-card.tsx

All 169 tests pass.