### PR TITLE
fix: show WhatsApp phone number tab during setup

### DIFF
--- a/apps/web/src/app/dashboard/components/messenger-setup-modal.tsx
+++ b/apps/web/src/app/dashboard/components/messenger-setup-modal.tsx
@@ -429,8 +429,8 @@ export function MessengerSetupModal({
 
         {/* Non-Telegram flows below */}
 
-        {/* Setting up */}
-        {!isTelegram && status === "setting-up" && (
+        {/* Setting up - show spinner only for non-WhatsApp or QR mode */}
+        {!isTelegram && status === "setting-up" && !(isWhatsApp && waMethod === "phone") && (
           <div className="flex items-center justify-center gap-3 py-8">
             <Loader2 className="w-5 h-5 animate-spin text-violet-400" />
             <span className="text-slate-300">
@@ -439,9 +439,9 @@ export function MessengerSetupModal({
           </div>
         )}
 
-        {/* Ready - QR code or Phone pairing (WhatsApp/Signal) */}
+        {/* Ready OR setting-up with phone method - QR code or Phone pairing (WhatsApp/Signal) */}
         {!isTelegram &&
-          status === "ready" &&
+          (status === "ready" || (status === "setting-up" && isWhatsApp && waMethod === "phone")) &&
           (qrCode || isWhatsApp) &&
           !qrExpired &&
           (messenger === "whatsapp" || messenger === "signal") && (


### PR DESCRIPTION
The Phone Number tab was hidden behind `status === 'ready'` which only fires after the QR setup call completes (~30s). Users clicking 'Phone Number' saw a spinner instead of the input field.

Now when waMethod is 'phone', the tab content renders immediately - even while the QR setup is still loading in the background. The phone pairing code uses a separate API endpoint (`/api/messaging/whatsapp/pairing-code`) that doesn't depend on the QR flow.

This was the last missing piece for the end-to-end WhatsApp phone pairing flow to work through the UI.