### PR TITLE
fix: stop gateway WA channel before requesting pairing code

### DIFF
--- a/apps/sidecar/dist/sidecar.cjs
+++ b/apps/sidecar/dist/sidecar.cjs
@@ -595,6 +595,15 @@ async function requestWhatsAppPairingCode(phoneNumber) {
     } catch {
     }
   }
+  try {
+    await runAsClaw("openclaw gateway stop --channel whatsapp 2>/dev/null", 1e4);
+  } catch {
+  }
+  try {
+    await gatewayRpc("web.login.start", { channel: "whatsapp", force: true }, 5e3);
+  } catch {
+  }
+  await new Promise((r) => setTimeout(r, 2e3));
   const { state, saveCreds } = await useMultiFileAuthState(authDir);
   const { version } = await fetchLatestBaileysVersion();
   const sock = makeWASocket({

--- a/apps/sidecar/src/routes/messaging.ts
+++ b/apps/sidecar/src/routes/messaging.ts
@@ -179,6 +179,18 @@ async function requestWhatsAppPairingCode(phoneNumber: string): Promise<{ pairin
     } catch {}
   }
 
+  // Stop the gateway's WhatsApp channel to avoid socket conflicts.
+  // Both Baileys sockets can't use the same auth state simultaneously.
+  try {
+    await runAsClaw('openclaw gateway stop --channel whatsapp 2>/dev/null', 10_000);
+  } catch {}
+  // Also kill any lingering WA login sessions via the gateway RPC
+  try {
+    await gatewayRpc('web.login.start', { channel: 'whatsapp', force: true }, 5_000);
+  } catch {}
+  // Brief pause to let the gateway release the connection
+  await new Promise(r => setTimeout(r, 2000));
+
   const { state, saveCreds } = await useMultiFileAuthState(authDir);
   const { version } = await fetchLatestBaileysVersion();
 


### PR DESCRIPTION
The sidecar's Baileys socket was conflicting with the gateway's running WhatsApp channel when the modal's QR setup was already active. Both tried to use the same auth state simultaneously, causing 'Connection closed before pairing code was issued' errors.

Fix: stop the gateway's WA channel before creating the Baileys socket for pairing codes. Brief 2s pause to let the gateway release the connection.