### PR TITLE
fix: rename handsoff references to shiftworker

### DIFF
--- a/apps/sidecar/package.json
+++ b/apps/sidecar/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@handsoff/sidecar",
+  "name": "@shiftworker/sidecar",
   "version": "0.1.0",
   "private": true,
   "description": "Lightweight sidecar agent for OpenClaw user VMs",


### PR DESCRIPTION
Renames the last remaining `@handsoff/sidecar` package name to `@shiftworker/sidecar`.