### PR TITLE
fix: route GitHub OAuth errors to AI Provider step

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ node_modules/
 .vercel
 .env.production
 tsconfig.tsbuildinfo
+.env.prod
+.env.vercel

--- a/apps/web/src/app/onboarding/wizard.tsx
+++ b/apps/web/src/app/onboarding/wizard.tsx
@@ -156,9 +156,25 @@ export default function OnboardingWizard() {
         missing_code: 'Sign-in was incomplete. Please try again.',
         invalid_state: 'Sign-in verification failed. Please try again.',
         no_tenant: 'Could not determine your Azure tenant. Please try again.',
+        access_denied: 'Access was denied. Please try again.',
+        github_error: 'GitHub sign-in failed. Please try again.',
+        oauth_not_configured: 'GitHub OAuth is not configured.',
+        save_failed: 'Failed to save your credentials. Please try again.',
       };
       setOnboardingError(errorMessages[errorParam] ?? 'Something went wrong. Please try again.');
-      setStep(1); // Go back to hosting step
+
+      // Route back to the correct step based on where the error came from
+      const githubErrors = ['token_exchange', 'missing_code', 'invalid_state', 'access_denied', 'github_error', 'oauth_not_configured', 'save_failed'];
+      if (githubErrors.includes(errorParam) && stepParam) {
+        // If we have a step param from returnTo, use it
+        const s = parseInt(stepParam, 10);
+        if (s >= 0 && s < STEPS.length) { setStep(s); return; }
+      }
+      if (githubErrors.includes(errorParam)) {
+        setStep(3); // AI Provider step
+      } else {
+        setStep(1); // Hosting step for Azure errors
+      }
       return;
     }
 


### PR DESCRIPTION
Fixes issue where GitHub OAuth errors (token_exchange, invalid_state, etc.) dumped users back to the hosting step (step 1) instead of the AI Provider step (step 3).

Also trimmed trailing newline from GITHUB_CLIENT_SECRET env var on Vercel (root cause of the token_exchange failure).