### PR TITLE
fix: trim GitHub OAuth env vars as safety net

### DIFF
--- a/apps/web/src/app/api/auth/github/callback/route.ts
+++ b/apps/web/src/app/api/auth/github/callback/route.ts
@@ -32,8 +32,8 @@ export async function GET(req: NextRequest) {
   const code = url.searchParams.get('code');
   const stateParam = url.searchParams.get('state');
   const errorParam = url.searchParams.get('error');
-  const clientId = process.env.GITHUB_CLIENT_ID;
-  const clientSecret = process.env.GITHUB_CLIENT_SECRET;
+  const clientId = process.env.GITHUB_CLIENT_ID?.trim();
+  const clientSecret = process.env.GITHUB_CLIENT_SECRET?.trim();
   const defaultReturn = '/onboarding?step=7';
 
   if (errorParam) {
@@ -77,7 +77,7 @@ export async function GET(req: NextRequest) {
     }
     const tokenData = await tokenRes.json();
     if (tokenData.error || !tokenData.access_token) {
-      console.error('GitHub token exchange error:', tokenData.error, tokenData.error_description);
+      console.error('GitHub token exchange error:', tokenData.error, tokenData.error_description, 'client_id_len:', clientId?.length, 'secret_len:', clientSecret?.length);
       return redirectWithError(url.origin, returnTo, 'token_exchange');
     }
     accessToken = tokenData.access_token;

--- a/apps/web/src/app/api/auth/github/route.ts
+++ b/apps/web/src/app/api/auth/github/route.ts
@@ -2,8 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import crypto from 'crypto';
 
 export async function GET(req: NextRequest) {
-  const clientId = process.env.GITHUB_CLIENT_ID;
-  const clientSecret = process.env.GITHUB_CLIENT_SECRET;
+  const clientId = process.env.GITHUB_CLIENT_ID?.trim();
+  const clientSecret = process.env.GITHUB_CLIENT_SECRET?.trim();
   if (!clientId || !clientSecret) {
     return NextResponse.json(
       { error: 'GitHub OAuth not configured. Set GITHUB_CLIENT_ID and GITHUB_CLIENT_SECRET.' },


### PR DESCRIPTION
Adds .trim() to GITHUB_CLIENT_ID and GITHUB_CLIENT_SECRET reads in both the auth redirect and callback routes. This ensures any stale whitespace in Vercel env vars doesn't break the token exchange. Also adds length logging on token exchange failures for debugging.