### PR TITLE
fix: auto-advance wizard after GitHub OAuth success

### DIFF
--- a/apps/web/src/app/onboarding/wizard.tsx
+++ b/apps/web/src/app/onboarding/wizard.tsx
@@ -178,6 +178,21 @@ export default function OnboardingWizard() {
       return;
     }
 
+    // Handle GitHub Copilot OAuth success: mark as connected and advance
+    const githubConnected = searchParams.get('github');
+    if (githubConnected === 'connected') {
+      setAiProvider('github-copilot');
+      setAiKeyVerified(true);
+      // If we have a step param (e.g. step=7 from Setup & Connect), go there
+      if (stepParam) {
+        const s = parseInt(stepParam, 10);
+        if (s >= 0 && s < STEPS.length) { setStep(s); return; }
+      }
+      // Otherwise advance past AI Provider to Plan step
+      setStep(4);
+      return;
+    }
+
     if (stepParam) {
       const s = parseInt(stepParam, 10);
       if (s >= 0 && s < STEPS.length) setStep(s);


### PR DESCRIPTION
The GitHub OAuth callback redirects to `/onboarding?step=3&github=connected` but the wizard had no handler for the `github=connected` param - it only handled `connected=azure|digitalocean`. Users would complete GitHub auth successfully but get stuck on the AI Provider page.

Now:
- Detects `github=connected` query param
- Sets provider to `github-copilot` and marks key as verified
- Auto-advances to the Plan step (step 4)
- If `step=7` is in the URL (from Setup & Connect flow), goes there instead