### PR TITLE
fix: advance past AI Provider after GitHub OAuth success

### DIFF
--- a/apps/web/src/app/onboarding/wizard.tsx
+++ b/apps/web/src/app/onboarding/wizard.tsx
@@ -183,12 +183,12 @@ export default function OnboardingWizard() {
     if (githubConnected === 'connected') {
       setAiProvider('github-copilot');
       setAiKeyVerified(true);
-      // If we have a step param (e.g. step=7 from Setup & Connect), go there
+      // If returnTo was a step beyond the AI Provider (e.g. step=7 from Setup & Connect), go there
       if (stepParam) {
         const s = parseInt(stepParam, 10);
-        if (s >= 0 && s < STEPS.length) { setStep(s); return; }
+        if (s > 3 && s >= 0 && s < STEPS.length) { setStep(s); return; }
       }
-      // Otherwise advance past AI Provider to Plan step
+      // Otherwise always advance past AI Provider to Plan step
       setStep(4);
       return;
     }


### PR DESCRIPTION
Bug: callback returns `?step=3&github=connected` but the wizard's step param handler would set step=3, keeping the user on the AI Provider page instead of advancing.

Fix: only respect stepParam when it's > 3 (e.g. step=7 from Setup & Connect). Otherwise always advance to step 4 (Plan).