### PR TITLE
fix: use standard setup API for Telegram on dashboard

### DIFF
--- a/apps/web/src/app/dashboard/components/messenger-setup-modal.tsx
+++ b/apps/web/src/app/dashboard/components/messenger-setup-modal.tsx
@@ -61,7 +61,7 @@ export function MessengerSetupModal({
   onConnected,
 }: MessengerSetupModalProps) {
   const info = MESSENGER_INFO[messenger];
-  const isTelegram = messenger === "telegram";
+  const isTelegram = false; // Use the standard setup flow for all platforms now
 
   // Non-Telegram state
   const [status, setStatus] = useState<


### PR DESCRIPTION
The dashboard's Telegram connect modal used a separate pairing flow (start-pairing/check-pairing/confirm-pairing) that required a TELEGRAM_BOT_USERNAME env var. This was never set, so Telegram setup always returned 500.

The BotFather automation credentials (API_ID, API_HASH, SESSION_STRING) ARE configured on Vercel. The `/api/messaging/setup` endpoint uses them to auto-create bots - the onboarding wizard uses this flow successfully.

Fix: route Telegram through the same `/api/messaging/setup` flow as all other platforms on the dashboard.