### PR TITLE
feat: sidecar self-update and config fix endpoints

### DIFF
--- a/apps/sidecar/dist/routes/openclaw.js
+++ b/apps/sidecar/dist/routes/openclaw.js
@@ -51,12 +51,66 @@ router.post('/openclaw/restart', async (_req, res) => {
 router.post('/openclaw/update', async (_req, res) => {
     try {
         await execAsync('npm install -g openclaw@latest');
-        await execAsync('systemctl restart openclaw');
+        // Try both possible service names
+        try {
+            await execAsync('systemctl restart openclaw-sidecar');
+        }
+        catch {
+            try {
+                await execAsync('systemctl restart openclaw');
+            }
+            catch { }
+        }
         const { stdout } = await execAsync('openclaw --version');
         res.json({ status: 'updated', version: stdout.trim() });
     }
     catch (err) {
         res.status(500).json({ error: 'Failed to update openclaw', details: err.message });
+    }
+});
+/** Update the sidecar code itself from GitHub and restart */
+router.post('/admin/update-sidecar', async (_req, res) => {
+    try {
+        const url = 'https://raw.githubusercontent.com/jemustain/openclaw-saas/main/apps/sidecar/dist/sidecar.cjs';
+        await execAsync(`curl -sf -L "${url}" -o /opt/shiftworker/sidecar/dist/sidecar.cjs`, { timeout: 30_000 });
+        // Restart the sidecar service (this will kill the current process)
+        try {
+            await execAsync('systemctl restart shiftworker-sidecar', { timeout: 10_000 });
+        }
+        catch { }
+        res.json({ status: 'updated' });
+    }
+    catch (err) {
+        res.status(500).json({ error: 'Failed to update sidecar', details: err.message });
+    }
+});
+/** Fix OpenClaw config issues (e.g. missing allowFrom for dmPolicy=open) */
+router.post('/admin/fix-config', async (_req, res) => {
+    try {
+        const CLAW_USER = process.env.OPENCLAW_USER || 'claw';
+        const configPath = `/home/${CLAW_USER}/.openclaw/openclaw.json`;
+        const fs = require('fs');
+        if (!fs.existsSync(configPath)) {
+            res.json({ status: 'no_config' });
+            return;
+        }
+        const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+        let fixed = false;
+        // Fix dmPolicy=open without allowFrom=["*"]
+        if (config.channels?.telegram?.dmPolicy === 'open') {
+            if (!config.channels.telegram.allowFrom || !config.channels.telegram.allowFrom.includes('*')) {
+                config.channels.telegram.allowFrom = ['*'];
+                fixed = true;
+            }
+        }
+        if (fixed) {
+            fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+            await execAsync(`chown ${CLAW_USER}:${CLAW_USER} ${configPath}`);
+        }
+        res.json({ status: fixed ? 'fixed' : 'ok', fixed });
+    }
+    catch (err) {
+        res.status(500).json({ error: 'Failed to fix config', details: err.message });
     }
 });
 exports.default = router;

--- a/apps/sidecar/src/routes/openclaw.ts
+++ b/apps/sidecar/src/routes/openclaw.ts
@@ -53,11 +53,61 @@ router.post('/openclaw/restart', async (_req: Request, res: Response) => {
 router.post('/openclaw/update', async (_req: Request, res: Response) => {
   try {
     await execAsync('npm install -g openclaw@latest');
-    await execAsync('systemctl restart openclaw');
+    // Try both possible service names
+    try { await execAsync('systemctl restart openclaw-sidecar'); } catch {
+      try { await execAsync('systemctl restart openclaw'); } catch {}
+    }
     const { stdout } = await execAsync('openclaw --version');
     res.json({ status: 'updated', version: stdout.trim() });
   } catch (err: any) {
     res.status(500).json({ error: 'Failed to update openclaw', details: err.message });
+  }
+});
+
+/** Update the sidecar code itself from GitHub and restart */
+router.post('/admin/update-sidecar', async (_req: Request, res: Response) => {
+  try {
+    const url = 'https://raw.githubusercontent.com/jemustain/openclaw-saas/main/apps/sidecar/dist/sidecar.cjs';
+    await execAsync(`curl -sf -L "${url}" -o /opt/shiftworker/sidecar/dist/sidecar.cjs`, { timeout: 30_000 });
+    // Restart the sidecar service (this will kill the current process)
+    try { await execAsync('systemctl restart shiftworker-sidecar', { timeout: 10_000 }); } catch {}
+    res.json({ status: 'updated' });
+  } catch (err: any) {
+    res.status(500).json({ error: 'Failed to update sidecar', details: err.message });
+  }
+});
+
+/** Fix OpenClaw config issues (e.g. missing allowFrom for dmPolicy=open) */
+router.post('/admin/fix-config', async (_req: Request, res: Response) => {
+  try {
+    const CLAW_USER = process.env.OPENCLAW_USER || 'claw';
+    const configPath = `/home/${CLAW_USER}/.openclaw/openclaw.json`;
+    const fs = require('fs');
+    
+    if (!fs.existsSync(configPath)) {
+      res.json({ status: 'no_config' });
+      return;
+    }
+    
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    let fixed = false;
+    
+    // Fix dmPolicy=open without allowFrom=["*"]
+    if (config.channels?.telegram?.dmPolicy === 'open') {
+      if (!config.channels.telegram.allowFrom || !config.channels.telegram.allowFrom.includes('*')) {
+        config.channels.telegram.allowFrom = ['*'];
+        fixed = true;
+      }
+    }
+    
+    if (fixed) {
+      fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+      await execAsync(`chown ${CLAW_USER}:${CLAW_USER} ${configPath}`);
+    }
+    
+    res.json({ status: fixed ? 'fixed' : 'ok', fixed });
+  } catch (err: any) {
+    res.status(500).json({ error: 'Failed to fix config', details: err.message });
   }
 });
 

--- a/apps/web/src/app/api/admin/update-sidecar/route.ts
+++ b/apps/web/src/app/api/admin/update-sidecar/route.ts
@@ -1,0 +1,55 @@
+import { NextResponse } from 'next/server';
+import { getSession } from '@/lib/auth/session';
+import { createClient } from '@/lib/supabase/server';
+
+export const maxDuration = 60;
+
+export async function POST() {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const supabase: any = createClient();
+  const { data: assistant } = await supabase
+    .from('assistants')
+    .select('ip_address, sidecar_token')
+    .eq('user_id', session.userId)
+    .eq('status', 'active')
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .single();
+
+  if (!assistant?.ip_address || !assistant?.sidecar_token) {
+    return NextResponse.json({ error: 'No active assistant' }, { status: 404 });
+  }
+
+  const ip = assistant.ip_address;
+  const token = assistant.sidecar_token;
+  const results: Record<string, any> = {};
+
+  // Step 1: Fix any config issues on the current sidecar
+  try {
+    const res = await fetch(`http://${ip}:8788/admin/fix-config`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(10000),
+    });
+    results.fixConfig = await res.json();
+  } catch (err: any) {
+    results.fixConfig = { error: err.message };
+  }
+
+  // Step 2: Update the sidecar code from GitHub
+  try {
+    const res = await fetch(`http://${ip}:8788/admin/update-sidecar`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(40000),
+    });
+    results.updateSidecar = await res.json();
+  } catch (err: any) {
+    // The sidecar restarts itself, so the connection may drop
+    results.updateSidecar = { status: 'restarting', note: err.message };
+  }
+
+  return NextResponse.json(results);
+}


### PR DESCRIPTION
Adds ability to remotely update the sidecar and fix config issues without SSH.

- `/admin/update-sidecar`: fetches latest sidecar.cjs from GitHub and restarts
- `/admin/fix-config`: fixes dmPolicy=open without allowFrom=['*']
- Web API `/api/admin/update-sidecar`: triggers both via the sidecar