### PR TITLE
fix: prevent sidecar freezing on hanging openclaw commands

### DIFF
--- a/apps/sidecar/dist/routes/messaging.js
+++ b/apps/sidecar/dist/routes/messaging.js
@@ -20,9 +20,24 @@ const VALID_PLATFORMS = ['whatsapp', 'telegram', 'signal', 'discord', 'slack'];
 const CLAW_USER = process.env.OPENCLAW_USER || 'claw';
 const CLAW_HOME = process.env.OPENCLAW_HOME || `/home/${CLAW_USER}`;
 const GATEWAY_WS_URL = process.env.GATEWAY_WS_URL || 'ws://127.0.0.1:18789';
-/** Run a command as the claw user */
+/** Run a command as the claw user with aggressive timeout */
 async function runAsClaw(cmd, timeoutMs = 30_000) {
-    return execAsync(`su - ${CLAW_USER} -c '${cmd.replace(/'/g, "'\\''")}'`, { timeout: timeoutMs });
+    return new Promise((resolve, reject) => {
+        const child = (0, child_process_1.exec)(`su - ${CLAW_USER} -c '${cmd.replace(/'/g, "'\\''")}'`, { timeout: timeoutMs, killSignal: 'SIGKILL' }, (error, stdout, stderr) => {
+            if (error)
+                reject(error);
+            else
+                resolve({ stdout, stderr });
+        });
+        // Extra safety: force kill after timeout + 5s
+        const forceTimer = setTimeout(() => {
+            try {
+                child.kill('SIGKILL');
+            }
+            catch { }
+        }, timeoutMs + 5000);
+        child.on('exit', () => clearTimeout(forceTimer));
+    });
 }
 /** Read the gateway auth token from the OpenClaw config */
 function getGatewayToken() {

--- a/apps/sidecar/dist/sidecar.cjs
+++ b/apps/sidecar/dist/sidecar.cjs
@@ -525,7 +525,19 @@ var CLAW_USER = process.env.OPENCLAW_USER || "claw";
 var CLAW_HOME = process.env.OPENCLAW_HOME || `/home/${CLAW_USER}`;
 var GATEWAY_WS_URL = process.env.GATEWAY_WS_URL || "ws://127.0.0.1:18789";
 async function runAsClaw(cmd, timeoutMs = 3e4) {
-  return execAsync4(`su - ${CLAW_USER} -c '${cmd.replace(/'/g, "'\\''")}'`, { timeout: timeoutMs });
+  return new Promise((resolve2, reject) => {
+    const child = (0, import_child_process4.exec)(`su - ${CLAW_USER} -c '${cmd.replace(/'/g, "'\\''")}'`, { timeout: timeoutMs, killSignal: "SIGKILL" }, (error, stdout, stderr) => {
+      if (error) reject(error);
+      else resolve2({ stdout, stderr });
+    });
+    const forceTimer = setTimeout(() => {
+      try {
+        child.kill("SIGKILL");
+      } catch {
+      }
+    }, timeoutMs + 5e3);
+    child.on("exit", () => clearTimeout(forceTimer));
+  });
 }
 function getGatewayToken() {
   try {

--- a/apps/sidecar/src/routes/messaging.ts
+++ b/apps/sidecar/src/routes/messaging.ts
@@ -24,9 +24,19 @@ const CLAW_USER = process.env.OPENCLAW_USER || 'claw';
 const CLAW_HOME = process.env.OPENCLAW_HOME || `/home/${CLAW_USER}`;
 const GATEWAY_WS_URL = process.env.GATEWAY_WS_URL || 'ws://127.0.0.1:18789';
 
-/** Run a command as the claw user */
+/** Run a command as the claw user with aggressive timeout */
 async function runAsClaw(cmd: string, timeoutMs = 30_000): Promise<{ stdout: string; stderr: string }> {
-  return execAsync(`su - ${CLAW_USER} -c '${cmd.replace(/'/g, "'\\''")}'`, { timeout: timeoutMs });
+  return new Promise((resolve, reject) => {
+    const child = exec(`su - ${CLAW_USER} -c '${cmd.replace(/'/g, "'\\''")}'`, { timeout: timeoutMs, killSignal: 'SIGKILL' }, (error, stdout, stderr) => {
+      if (error) reject(error);
+      else resolve({ stdout, stderr });
+    });
+    // Extra safety: force kill after timeout + 5s
+    const forceTimer = setTimeout(() => {
+      try { child.kill('SIGKILL'); } catch {}
+    }, timeoutMs + 5000);
+    child.on('exit', () => clearTimeout(forceTimer));
+  });
 }
 
 /** Read the gateway auth token from the OpenClaw config */


### PR DESCRIPTION
runAsClaw now uses SIGKILL and a safety kill timer to ensure hanging child processes can't freeze the sidecar forever.