### PR TITLE
feat: pre-create Telegram bots during signup

### DIFF
--- a/apps/web/src/app/api/auth/google/callback/route.ts
+++ b/apps/web/src/app/api/auth/google/callback/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { exchangeCodeForTokens, getGoogleUserInfo } from '@/lib/auth/google';
 import { createSession } from '@/lib/auth/session';
 import { createClient } from '@/lib/supabase/server';
+import { preCreateTelegramBot } from '@/lib/messaging/pre-create-bot';
 
 export async function GET(request: NextRequest) {
   const { searchParams, origin } = new URL(request.url);
@@ -63,6 +64,11 @@ export async function GET(request: NextRequest) {
         return NextResponse.redirect(`${origin}/auth/signin?error=auth_callback_failed`);
       }
       userId = newUser.id;
+
+      // Fire-and-forget: pre-create a Telegram bot for this new user
+      preCreateTelegramBot(userId, googleUser.name).catch((err) =>
+        console.error('Pre-create Telegram bot failed:', err),
+      );
     }
 
     await createSession({

--- a/apps/web/src/app/dashboard/components/connections-card.tsx
+++ b/apps/web/src/app/dashboard/components/connections-card.tsx
@@ -49,12 +49,14 @@ interface ConnectionsCardProps {
   messengers?: string[];
   disabled?: boolean;
   plan?: string;
+  telegramBotUsername?: string;
 }
 
 export function ConnectionsCard({
   messengers = [],
   disabled = false,
   plan = "free",
+  telegramBotUsername,
 }: ConnectionsCardProps) {
   const [messengerStatuses, setMessengerStatuses] = useState<
     MessengerStatus[]
@@ -203,6 +205,9 @@ export function ConnectionsCard({
             } else if (configured) {
               statusColor = "text-amber-400";
               statusLabel = "Configured";
+            } else if (m === "telegram" && telegramBotUsername) {
+              statusColor = "text-cyan-400";
+              statusLabel = "Bot ready";
             }
 
             return (

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -38,7 +38,7 @@ async function DashboardContent({
 
   const { data: user } = await supabase
     .from("users")
-    .select("plan, provider_preference, messengers, ai_provider, ai_api_key")
+    .select("plan, provider_preference, messengers, ai_provider, ai_api_key, telegram_bot_username")
     .eq("id", session.userId)
     .single();
 
@@ -93,7 +93,7 @@ async function DashboardContent({
         <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
           {/* Col 1: Connections */}
           <div>
-            <ConnectionsCard messengers={messengers} disabled={disableActions} plan={plan} />
+            <ConnectionsCard messengers={messengers} disabled={disableActions} plan={plan} telegramBotUsername={user?.telegram_bot_username ?? undefined} />
           </div>
 
           {/* Col 2: AI Model + Usage stacked */}

--- a/apps/web/src/lib/messaging/pre-create-bot.ts
+++ b/apps/web/src/lib/messaging/pre-create-bot.ts
@@ -1,0 +1,49 @@
+import { createTelegramBot } from './telegram-bot-factory';
+import { createClient } from '../supabase/server';
+
+/**
+ * Pre-create a Telegram bot for a newly registered user.
+ * Uses the service-role client so it works outside of request context.
+ * Saves bot username + token to the users table.
+ */
+export async function preCreateTelegramBot(
+  userId: string,
+  displayName?: string,
+): Promise<void> {
+  // Check env vars are available
+  const hasConfig = !!(
+    process.env.TELEGRAM_API_ID &&
+    process.env.TELEGRAM_API_HASH &&
+    process.env.TELEGRAM_SESSION_STRING
+  );
+  if (!hasConfig) {
+    console.log('Skipping Telegram bot pre-creation: env not configured');
+    return;
+  }
+
+  const supabase: any = createClient();
+
+  // Check if user already has a bot
+  const { data: user } = await supabase
+    .from('users')
+    .select('telegram_bot_username, telegram_bot_token')
+    .eq('id', userId)
+    .single();
+
+  if (user?.telegram_bot_token) {
+    console.log(`User ${userId} already has a Telegram bot, skipping`);
+    return;
+  }
+
+  const bot = await createTelegramBot(userId, displayName);
+
+  await supabase
+    .from('users')
+    .update({
+      telegram_bot_username: bot.botUsername,
+      telegram_bot_token: bot.botToken,
+    })
+    .eq('id', userId);
+
+  console.log(`Pre-created Telegram bot @${bot.botUsername} for user ${userId}`);
+}

--- a/apps/web/src/lib/messaging/setup.ts
+++ b/apps/web/src/lib/messaging/setup.ts
@@ -94,6 +94,43 @@ export async function setupTelegramForAssistant(
   }
 
   try {
+    // Check if user already has a pre-created bot in users table
+    const { data: userRow } = await (supabase as any)
+      .from('users')
+      .select('telegram_bot_username, telegram_bot_token')
+      .eq('id', userId)
+      .single();
+
+    if (userRow?.telegram_bot_token) {
+      // Use the pre-created bot — configure sidecar and copy to assistant
+      try {
+        await callSidecar(
+          assistant.ip_address,
+          assistant.sidecar_token,
+          'telegram',
+          { botToken: userRow.telegram_bot_token },
+        );
+      } catch {
+        // Best-effort sidecar config
+      }
+
+      await (supabase as any)
+        .from('assistants')
+        .update({
+          telegram_bot_username: userRow.telegram_bot_username,
+          telegram_bot_token: userRow.telegram_bot_token,
+          updated_at: new Date().toISOString(),
+        })
+        .eq('id', assistantId);
+
+      return {
+        platform: 'telegram',
+        status: 'configured',
+        botUsername: userRow.telegram_bot_username,
+        botLink: `https://t.me/${userRow.telegram_bot_username}`,
+      };
+    }
+
     // Check if BotFather automation is configured
     const { env } = await import('../env');
     const hasBotFactory = !!(env('TELEGRAM_API_ID') && env('TELEGRAM_API_HASH') && env('TELEGRAM_SESSION_STRING'));
@@ -119,6 +156,15 @@ export async function setupTelegramForAssistant(
           updated_at: new Date().toISOString(),
         })
         .eq('id', assistantId);
+
+      // Also save to users table for future reuse
+      await (supabase as any)
+        .from('users')
+        .update({
+          telegram_bot_username: bot.botUsername,
+          telegram_bot_token: bot.botToken,
+        })
+        .eq('id', userId);
 
       return {
         platform: 'telegram',

--- a/apps/web/src/lib/messaging/telegram-bot-factory.ts
+++ b/apps/web/src/lib/messaging/telegram-bot-factory.ts
@@ -39,9 +39,9 @@ export async function createTelegramBot(
 ): Promise<BotCreationResult> {
   const tg = await getClient();
 
-  // Generate unique username: sw_{short_id}_bot (Telegram requires _bot suffix)
-  const shortId = userId.replace(/-/g, '').slice(0, 8).toLowerCase();
-  const botUsername = `sw_${shortId}_bot`;
+  // Generate unique username with random suffix to avoid collisions
+  const rand = Math.random().toString(36).slice(2, 8).toLowerCase();
+  const botUsername = `sw_${rand}_bot`;
   const botName = displayName ?? 'ShiftWorker Assistant';
 
   // Send /newbot to BotFather
@@ -103,7 +103,8 @@ export async function createTelegramBot(
 
       // /token didn't work (maybe bot is owned by a different account).
       // Try with a random suffix.
-      const fallbackUsername = `sw_${shortId}_${Math.floor(Math.random() * 999)}_bot`;
+      const fallbackRand = Math.random().toString(36).slice(2, 8).toLowerCase();
+      const fallbackUsername = `sw_${fallbackRand}_bot`;
       await tg.sendMessage(botFather, { message: '/newbot' });
       await sleep(1000);
       await tg.sendMessage(botFather, { message: botName });

--- a/supabase/migrations/20260331_add_telegram_bot_to_users.sql
+++ b/supabase/migrations/20260331_add_telegram_bot_to_users.sql
@@ -1,0 +1,11 @@
+-- Migration: Add telegram_bot_username and telegram_bot_token to users table
+-- Run this in Supabase SQL Editor: https://supabase.com/dashboard/project/bbraehnpnupxjeddssyq/sql/new
+
+ALTER TABLE users ADD COLUMN IF NOT EXISTS telegram_bot_username text;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS telegram_bot_token text;
+
+-- Save Julie's existing bot
+UPDATE users
+SET telegram_bot_username = 'sw_25c935d0_bot',
+    telegram_bot_token = '8750667722:AAF5Y0mN_rHjNhkF-wnu4p3k8GAypqD0b_k'
+WHERE id = '25c935d0-a7a3-422d-929e-b4dbb9dc4856';


### PR DESCRIPTION
## Summary
Pre-creates Telegram bots during user signup (Google OAuth) instead of waiting for VM provisioning. This eliminates the delay when users click 'Connect Telegram' on the dashboard.

## Changes
- **New columns**: `telegram_bot_username` and `telegram_bot_token` on `users` table
- **Signup hook**: Fire-and-forget bot creation in Google OAuth callback for new users
- **Random bot names**: `sw_{random6chars}_bot` instead of `sw_{userId}_bot` to avoid collisions
- **Setup optimization**: `setupTelegramForAssistant` checks users table first, uses pre-created bot if available
- **Dashboard UX**: Shows 'Bot ready' status when bot is pre-created but not yet connected
- **Persistence**: Bots created during setup are also saved to users table for reuse

## ⚠️ Manual Step Required
Run the SQL migration in Supabase SQL Editor before merging:
```sql
ALTER TABLE users ADD COLUMN IF NOT EXISTS telegram_bot_username text;
ALTER TABLE users ADD COLUMN IF NOT EXISTS telegram_bot_token text;

-- Save Julie's existing bot
UPDATE users SET telegram_bot_username = 'sw_25c935d0_bot', telegram_bot_token = '8750667722:AAF5Y0mN_rHjNhkF-wnu4p3k8GAypqD0b_k' WHERE id = '25c935d0-a7a3-422d-929e-b4dbb9dc4856';
```

## Testing
- All 169 tests pass ✅
- Web build succeeds ✅
- Sidecar build succeeds ✅