### PR TITLE
security: remove bot token from migration file

### DIFF
--- a/supabase/migrations/20260331_add_telegram_bot_to_users.sql
+++ b/supabase/migrations/20260331_add_telegram_bot_to_users.sql
@@ -4,8 +4,5 @@
 ALTER TABLE users ADD COLUMN IF NOT EXISTS telegram_bot_username text;
 ALTER TABLE users ADD COLUMN IF NOT EXISTS telegram_bot_token text;
 
--- Save Julie's existing bot
-UPDATE users
-SET telegram_bot_username = 'sw_25c935d0_bot',
-    telegram_bot_token = '8750667722:AAF5Y0mN_rHjNhkF-wnu4p3k8GAypqD0b_k'
-WHERE id = '25c935d0-a7a3-422d-929e-b4dbb9dc4856';
+-- Note: Bot tokens should be set via the application, not in migration files.
+-- Never commit bot tokens or API keys to source control.


### PR DESCRIPTION
Removes hardcoded Telegram bot token from the SQL migration file. Tokens should be set at runtime, not committed to source control.