### PR TITLE
fix: single sidecar build command + CI staleness check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,3 +54,15 @@ jobs:
       - name: Build
         working-directory: apps/web
         run: npm run build
+
+      - name: Verify sidecar bundle is up to date
+        working-directory: apps/sidecar
+        run: |
+          npm ci
+          HASH_BEFORE=$(sha256sum dist/sidecar.cjs | cut -d' ' -f1)
+          npm run build
+          HASH_AFTER=$(sha256sum dist/sidecar.cjs | cut -d' ' -f1)
+          if [ "$HASH_BEFORE" != "$HASH_AFTER" ]; then
+            echo "::error::sidecar.cjs is stale! Run 'cd apps/sidecar && npm run build' and commit the result."
+            exit 1
+          fi

--- a/apps/sidecar/package.json
+++ b/apps/sidecar/package.json
@@ -5,7 +5,7 @@
   "description": "Lightweight sidecar agent for OpenClaw user VMs",
   "main": "dist/index.js",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && npx esbuild src/index.ts --bundle --platform=node --outfile=dist/sidecar.cjs --format=cjs --external:@whiskeysockets/baileys --external:pino --external:ws --external:express",
     "start": "node dist/index.js",
     "dev": "tsx src/index.ts"
   },


### PR DESCRIPTION
Fixes #221

- `npm run build` in apps/sidecar now runs tsc AND esbuild bundle in one step
- CI verifies sidecar.cjs is up to date after build (fails if stale)