### PR TITLE
fix: Telegram bot persistence + setup verification

### DIFF
--- a/apps/sidecar/dist/routes/messaging.js
+++ b/apps/sidecar/dist/routes/messaging.js
@@ -133,6 +133,26 @@ async function setupTelegram(config) {
         }
         catch { }
     }
+    // Verify the channel was actually added
+    try {
+        const { stdout } = await runAsClaw('openclaw channels list --json 2>/dev/null', 10_000);
+        const data = JSON.parse(stdout.trim());
+        const channels = Array.isArray(data) ? data : data.channels || [];
+        const hasTelegram = channels.some((ch) => (ch.channel || ch.name || '').toLowerCase() === 'telegram');
+        if (!hasTelegram) {
+            // Retry: add again and restart
+            console.warn('Telegram channel not found after setup, retrying...');
+            await runAsClaw(`openclaw channels add --channel telegram --token ${config.botToken}`);
+            try {
+                await execAsync('systemctl restart openclaw-sidecar', { timeout: 15_000 });
+            }
+            catch { }
+            await new Promise(r => setTimeout(r, 5000));
+        }
+    }
+    catch {
+        // Non-fatal - channel may still work even if list fails
+    }
     // Auto-approve the first Telegram pairing request within the next 10 minutes.
     // This lets the bot owner pair seamlessly while keeping strangers blocked.
     autoApproveFirstPairing('telegram', 10 * 60_000);

--- a/apps/sidecar/dist/sidecar.cjs
+++ b/apps/sidecar/dist/sidecar.cjs
@@ -618,6 +618,22 @@ async function setupTelegram(config) {
     } catch {
     }
   }
+  try {
+    const { stdout } = await runAsClaw("openclaw channels list --json 2>/dev/null", 1e4);
+    const data = JSON.parse(stdout.trim());
+    const channels = Array.isArray(data) ? data : data.channels || [];
+    const hasTelegram = channels.some((ch) => (ch.channel || ch.name || "").toLowerCase() === "telegram");
+    if (!hasTelegram) {
+      console.warn("Telegram channel not found after setup, retrying...");
+      await runAsClaw(`openclaw channels add --channel telegram --token ${config.botToken}`);
+      try {
+        await execAsync4("systemctl restart openclaw-sidecar", { timeout: 15e3 });
+      } catch {
+      }
+      await new Promise((r) => setTimeout(r, 5e3));
+    }
+  } catch {
+  }
   autoApproveFirstPairing("telegram", 10 * 6e4);
   return { status: "configured" };
 }

--- a/apps/sidecar/src/routes/messaging.ts
+++ b/apps/sidecar/src/routes/messaging.ts
@@ -136,6 +136,23 @@ async function setupTelegram(config: { botToken: string }): Promise<{ status: st
     try { await runAsClaw('openclaw gateway restart'); } catch {}
   }
 
+  // Verify the channel was actually added
+  try {
+    const { stdout } = await runAsClaw('openclaw channels list --json 2>/dev/null', 10_000);
+    const data = JSON.parse(stdout.trim());
+    const channels = Array.isArray(data) ? data : data.channels || [];
+    const hasTelegram = channels.some((ch: any) => (ch.channel || ch.name || '').toLowerCase() === 'telegram');
+    if (!hasTelegram) {
+      // Retry: add again and restart
+      console.warn('Telegram channel not found after setup, retrying...');
+      await runAsClaw(`openclaw channels add --channel telegram --token ${config.botToken}`);
+      try { await execAsync('systemctl restart openclaw-sidecar', { timeout: 15_000 }); } catch {}
+      await new Promise(r => setTimeout(r, 5000));
+    }
+  } catch {
+    // Non-fatal - channel may still work even if list fails
+  }
+
   // Auto-approve the first Telegram pairing request within the next 10 minutes.
   // This lets the bot owner pair seamlessly while keeping strangers blocked.
   autoApproveFirstPairing('telegram', 10 * 60_000);

--- a/apps/web/src/app/dashboard/components/assistant-card.tsx
+++ b/apps/web/src/app/dashboard/components/assistant-card.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
+import { useRouter } from "next/navigation";
 
 interface Assistant {
   id: string;
@@ -46,6 +47,7 @@ function formatTime(secs: number): string {
 }
 
 export function AssistantHero({ assistant }: { assistant: Assistant | null }) {
+  const router = useRouter();
   const [loading, setLoading] = useState<string | null>(null);
   const [current, setCurrent] = useState(assistant);
   const [confirmDestroy, setConfirmDestroy] = useState(false);
@@ -144,6 +146,8 @@ export function AssistantHero({ assistant }: { assistant: Assistant | null }) {
             setCurrent(a);
             setProvisioning(false);
             setProvisionSteps((prev) => [...prev, "Your assistant is online!"]);
+            // Refresh server components so the whole dashboard reflects the new status
+            router.refresh();
             return;
           }
           if (a?.status === "destroyed" || a?.status === "destroying") {

--- a/apps/web/src/app/dashboard/components/messenger-setup-modal.tsx
+++ b/apps/web/src/app/dashboard/components/messenger-setup-modal.tsx
@@ -184,7 +184,9 @@ export function MessengerSetupModal({
         body: JSON.stringify({ platform: messenger }),
       });
       if (!res.ok) {
-        setError(`Setup failed (HTTP ${res.status})`);
+        setError(res.status === 500
+          ? "Your server is still starting up. Try again in a minute."
+          : `Setup failed (HTTP ${res.status})`);
         setStatus("failed");
         return;
       }
@@ -212,8 +214,10 @@ export function MessengerSetupModal({
         setStatus("ready");
       }
     } catch {
-      setError("Failed to set up - please try again");
+      setError("Setup is taking longer than expected. Retrying...");
       setStatus("failed");
+      // Auto-retry once after 10s
+      setTimeout(() => triggerSetup(), 10000);
     }
   }, [messenger, onConnected]);
 

--- a/apps/web/src/lib/messaging/setup.ts
+++ b/apps/web/src/lib/messaging/setup.ts
@@ -396,15 +396,8 @@ export async function disconnectMessenger(
   const errors: string[] = [];
 
   if (platform === 'telegram') {
-    // Delete bot via BotFather (best-effort)
-    if (assistant.telegram_bot_username) {
-      try {
-        await deleteTelegramBot(assistant.telegram_bot_username);
-      } catch (err: unknown) {
-        const msg = err instanceof Error ? err.message : String(err);
-        errors.push(`BotFather delete failed: ${msg}`);
-      }
-    }
+    // Keep the bot alive for reuse - don't delete via BotFather
+    // The bot is stored on the user record and can be re-attached to a new VM
 
     // Teardown sidecar channel (best-effort)
     if (assistant.ip_address && assistant.sidecar_token) {


### PR DESCRIPTION
Fixes #219, #220

- **Don't delete bots on disconnect** - keeps bots alive for reuse across VM rebuilds
- **Verify after setup** - checks `openclaw channels list` confirms telegram is present, retries once if not
- Rebuilt sidecar.cjs bundle