### PR TITLE
fix: dashboard UX polish

### DIFF
--- a/apps/web/src/app/dashboard/components/assistant-card.tsx
+++ b/apps/web/src/app/dashboard/components/assistant-card.tsx
@@ -51,6 +51,7 @@ export function AssistantHero({ assistant }: { assistant: Assistant | null }) {
   const [loading, setLoading] = useState<string | null>(null);
   const [current, setCurrent] = useState(assistant);
   const [confirmDestroy, setConfirmDestroy] = useState(false);
+  const [showMenu, setShowMenu] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const [destroying, setDestroying] = useState(false);
@@ -335,12 +336,25 @@ export function AssistantHero({ assistant }: { assistant: Assistant | null }) {
               )}
 
               {current && status !== "destroying" && !confirmDestroy && (
-                <button
-                  onClick={() => setConfirmDestroy(true)}
-                  className="rounded-full bg-red-900/50 px-5 py-2 text-sm font-medium text-red-300 hover:bg-red-900 transition-colors"
-                >
-                  Destroy
-                </button>
+                <div className="relative">
+                  <button
+                    onClick={() => setShowMenu(!showMenu)}
+                    className="rounded-full bg-slate-800 p-2 text-slate-400 hover:text-white hover:bg-slate-700 transition-colors"
+                    title="More options"
+                  >
+                    <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20"><circle cx="4" cy="10" r="1.5"/><circle cx="10" cy="10" r="1.5"/><circle cx="16" cy="10" r="1.5"/></svg>
+                  </button>
+                  {showMenu && (
+                    <div className="absolute right-0 top-full mt-1 w-44 rounded-lg bg-slate-800 border border-slate-700 shadow-lg z-10">
+                      <button
+                        onClick={() => { setShowMenu(false); setConfirmDestroy(true); }}
+                        className="w-full text-left px-4 py-2.5 text-sm text-red-400 hover:bg-slate-700 rounded-lg transition-colors"
+                      >
+                        Destroy server
+                      </button>
+                    </div>
+                  )}
+                </div>
               )}
 
               {confirmDestroy && (

--- a/apps/web/src/app/dashboard/components/connections-card.tsx
+++ b/apps/web/src/app/dashboard/components/connections-card.tsx
@@ -203,12 +203,23 @@ export function ConnectionsCard({
               statusColor = "text-green-500";
               statusLabel = "Connected";
             } else if (configured) {
-              statusColor = "text-amber-400";
-              statusLabel = "Configured";
+              statusColor = "text-green-400";
+              statusLabel = "Connected";
             } else if (m === "telegram" && telegramBotUsername) {
               statusColor = "text-cyan-400";
               statusLabel = "Bot ready";
             }
+
+            // For free plan, only show the connected/configured messenger
+            // Hide other messengers entirely, show "Change messenger" link instead
+            if (isFree && !connected && !configured && !(m === "telegram" && telegramBotUsername)) {
+              return null;
+            }
+
+            // Determine the bot link for Telegram
+            const telegramLink = m === "telegram" && telegramBotUsername
+              ? `https://t.me/${telegramBotUsername}`
+              : botLink;
 
             return (
               <div key={m}>
@@ -223,40 +234,28 @@ export function ConnectionsCard({
                     </span>
                   </div>
 
-                  {/* Connected: show Open + Disconnect */}
-                  {connected && (
-                    <div className="flex items-center gap-2">
-                      {botLink && (
-                        <a
-                          href={botLink}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="rounded-md bg-slate-800 px-3 py-1 text-xs text-slate-300 hover:bg-slate-700"
-                        >
-                          Open
-                        </a>
-                      )}
-                      <button
-                        type="button"
-                        disabled={disconnecting === m || disabled}
-                        onClick={() => handleDisconnect(m)}
-                        className="rounded-md bg-red-900/50 px-3 py-1 text-xs text-red-400 hover:bg-red-900/80 disabled:opacity-50"
-                      >
-                        {disconnecting === m ? "Disconnecting…" : "Disconnect"}
-                      </button>
-                    </div>
+                  {/* Connected or configured: show Open in Telegram link */}
+                  {(connected || configured) && telegramLink && (
+                    <a
+                      href={telegramLink}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="rounded-md bg-indigo-600 px-3 py-1 text-xs text-white hover:bg-indigo-500"
+                    >
+                      Open in {config.name}
+                    </a>
                   )}
 
-                  {/* Configured but not connected: Reconnect */}
-                  {!connected && configured && !locked && (
-                    <button
-                      type="button"
-                      disabled={disabled}
-                      onClick={() => handleConnectClick(m)}
-                      className="rounded-md bg-amber-600 px-3 py-1 text-xs text-white hover:bg-amber-500 disabled:opacity-50 disabled:cursor-not-allowed"
+                  {/* Connected or configured but no link: show Open button */}
+                  {(connected || configured) && !telegramLink && botLink && (
+                    <a
+                      href={botLink}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="rounded-md bg-indigo-600 px-3 py-1 text-xs text-white hover:bg-indigo-500"
                     >
-                      Reconnect
-                    </button>
+                      Open in {config.name}
+                    </a>
                   )}
 
                   {/* Not connected, not configured, not locked: Connect */}
@@ -333,6 +332,21 @@ export function ConnectionsCard({
               </div>
             );
           })}
+
+          {/* Free plan: show change messenger option */}
+          {isFree && hasConnection && (
+            <div className="pt-2 border-t border-slate-800">
+              <button
+                type="button"
+                onClick={() => setSwitchConfirm(
+                  connectedMessenger?.messenger === "telegram" ? "whatsapp" : "telegram"
+                )}
+                className="text-xs text-slate-500 hover:text-violet-400 transition-colors"
+              >
+                Change messenger...
+              </button>
+            </div>
+          )}
         </div>
       </div>
 


### PR DESCRIPTION
Per Julie's feedback:

- **Destroy button** hidden behind a ··· menu instead of prominent red button
- **Telegram status** shows green 'Connected' with 'Open in Telegram' link (was amber 'Configured' with red 'Reconnect')
- **Free plan** hides unconfigured messengers, shows subtle 'Change messenger...' link at bottom
- Removes scary red disconnect/reconnect buttons from the main view