### PR TITLE
feat: Telegram bot auto-configured during VM provisioning

### DIFF
--- a/apps/web/src/lib/providers/cloud-init.ts
+++ b/apps/web/src/lib/providers/cloud-init.ts
@@ -9,6 +9,9 @@ export interface CloudInitOptions {
   username?: string;
   openclawVersion?: string;
   nodeVersion?: number;
+  telegramBotToken?: string;
+  aiProvider?: string;
+  aiApiKey?: string;
 }
 
 export function generateCloudInit(opts: CloudInitOptions): string {
@@ -149,7 +152,32 @@ write_files:
         systemctl restart shiftworker-sidecar
         sleep 10
       fi
-      source /etc/shiftworker/sidecar.env
+${opts.telegramBotToken ? `
+      # Configure Telegram bot
+      echo "Configuring Telegram bot..."
+      TELEGRAM_TOKEN="${opts.telegramBotToken.replace(/"/g, '\\"')}"
+      # Pre-configure dmPolicy and allowFrom
+      python3 -c "
+import json, os, pwd
+user = '${user}'
+config_path = os.path.join('/home', user, '.openclaw', 'openclaw.json')
+config = {}
+if os.path.exists(config_path):
+    with open(config_path) as f:
+        config = json.load(f)
+channels = config.setdefault('channels', {})
+tg = channels.setdefault('telegram', {})
+tg['dmPolicy'] = 'open'
+tg['allowFrom'] = ['*']
+with open(config_path, 'w') as f:
+    json.dump(config, f, indent=2)
+pw = pwd.getpwnam(user)
+os.chown(config_path, pw.pw_uid, pw.pw_gid)
+"
+      su - ${user} -c "openclaw channels add --channel telegram --token $TELEGRAM_TOKEN" || true
+      systemctl restart openclaw-sidecar
+      sleep 5
+` : ''}      source /etc/shiftworker/sidecar.env
       curl -sf -X POST "$PORTAL_URL/api/instances/$INSTANCE_ID/phone-home" \\
         -H "Authorization: Bearer $SIDECAR_TOKEN" \\
         -H "Content-Type: application/json" \\

--- a/apps/web/src/lib/vm/lifecycle.ts
+++ b/apps/web/src/lib/vm/lifecycle.ts
@@ -120,7 +120,7 @@ export async function launchAssistant(userId: string): Promise<Assistant> {
   // Read user record to get VM size and subscription preferences
   const { data: user, error: userError } = await supabase
     .from('users')
-    .select('vm_size, azure_subscription_id')
+    .select('vm_size, azure_subscription_id, telegram_bot_token')
     .eq('id', userId)
     .single();
 
@@ -135,6 +135,7 @@ export async function launchAssistant(userId: string): Promise<Assistant> {
     sidecarToken,
     portalUrl: PORTAL_URL,
     instanceId: assistantId,
+    telegramBotToken: user?.telegram_bot_token ?? undefined,
   });
 
   // Insert assistant record as provisioning


### PR DESCRIPTION
Configures the Telegram bot during cloud-init so it's ready to respond as soon as the VM finishes provisioning. No more clicking 'Connect' on the dashboard and waiting for sidecar API calls.

The pre-created bot token (from signup) is passed into cloud-init, which:
1. Pre-configures dmPolicy + allowFrom in openclaw.json
2. Runs `openclaw channels add` with the bot token
3. Restarts the gateway

This means the bot responds immediately when the user opens it in Telegram.