### PR TITLE
fix: resume existing VM instead of creating new one, default window to current hour

### DIFF
--- a/apps/web/src/app/api/assistant/__tests__/launch-route.test.ts
+++ b/apps/web/src/app/api/assistant/__tests__/launch-route.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockGetSession = vi.fn();
+const mockLaunchAssistant = vi.fn();
+const mockSingle = vi.fn();
+const mockLimit = vi.fn().mockReturnValue({ single: mockSingle });
+const mockEqStatus = vi.fn().mockReturnValue({ limit: mockLimit });
+const mockEqUserId = vi.fn().mockReturnValue({ eq: mockEqStatus });
+const mockSelect = vi.fn().mockReturnValue({ eq: mockEqUserId });
+const mockFrom = vi.fn().mockReturnValue({ select: mockSelect });
+
+vi.mock('@/lib/auth/session', () => ({ getSession: (...a: any[]) => mockGetSession(...a) }));
+vi.mock('@/lib/vm/lifecycle', () => ({ launchAssistant: (...a: any[]) => mockLaunchAssistant(...a) }));
+vi.mock('@/lib/supabase/server', () => ({ createClient: () => ({ from: mockFrom }) }));
+vi.mock('@/lib/errors', () => ({
+  ERR: { UNAUTHORIZED: 'Unauthorized' },
+  apiError: (msg: string, status: number) =>
+    new Response(JSON.stringify({ error: msg }), { status, headers: { 'content-type': 'application/json' } }),
+  handleApiError: (err: unknown, _ctx: string) =>
+    new Response(JSON.stringify({ error: String(err) }), { status: 500 }),
+}));
+
+import { POST } from '../launch/route';
+
+describe('POST /api/assistant/launch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 409 when user has a suspended assistant', async () => {
+    mockGetSession.mockResolvedValue({ userId: 'u1' });
+    mockSingle.mockResolvedValue({ data: { id: 'a1' } });
+
+    const res = await POST();
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error).toMatch(/suspended/i);
+    expect(mockLaunchAssistant).not.toHaveBeenCalled();
+  });
+
+  it('launches when no suspended assistant exists', async () => {
+    mockGetSession.mockResolvedValue({ userId: 'u1' });
+    mockSingle.mockResolvedValue({ data: null });
+    const fakeAssistant = { id: 'a2', status: 'provisioning' };
+    mockLaunchAssistant.mockResolvedValue(fakeAssistant);
+
+    const res = await POST();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.assistant).toEqual(fakeAssistant);
+  });
+});

--- a/apps/web/src/app/api/assistant/__tests__/resume-route.test.ts
+++ b/apps/web/src/app/api/assistant/__tests__/resume-route.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockGetSession = vi.fn();
+const mockResumeAssistant = vi.fn();
+const mockSingle = vi.fn();
+const mockLimit = vi.fn().mockReturnValue({ single: mockSingle });
+const mockEqStatus = vi.fn().mockReturnValue({ limit: mockLimit });
+const mockEqUserId = vi.fn().mockReturnValue({ eq: mockEqStatus });
+const mockSelect = vi.fn().mockReturnValue({ eq: mockEqUserId });
+const mockFrom = vi.fn().mockReturnValue({ select: mockSelect });
+
+vi.mock('@/lib/auth/session', () => ({ getSession: (...a: any[]) => mockGetSession(...a) }));
+vi.mock('@/lib/vm/lifecycle', () => ({ resumeAssistant: (...a: any[]) => mockResumeAssistant(...a) }));
+vi.mock('@/lib/supabase/server', () => ({ createClient: () => ({ from: mockFrom }) }));
+vi.mock('@/lib/errors', () => ({
+  ERR: { UNAUTHORIZED: 'Unauthorized' },
+  apiError: (msg: string, status: number) =>
+    new Response(JSON.stringify({ error: msg }), { status, headers: { 'content-type': 'application/json' } }),
+  handleApiError: (err: unknown, _ctx: string) =>
+    new Response(JSON.stringify({ error: String(err) }), { status: 500 }),
+}));
+
+import { POST } from '../resume/route';
+
+describe('POST /api/assistant/resume', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 401 when not authenticated', async () => {
+    mockGetSession.mockResolvedValue(null);
+    const res = await POST();
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 404 when no suspended assistant exists', async () => {
+    mockGetSession.mockResolvedValue({ userId: 'u1' });
+    mockSingle.mockResolvedValue({ data: null });
+    const res = await POST();
+    expect(res.status).toBe(404);
+  });
+
+  it('calls resumeAssistant and returns the assistant', async () => {
+    mockGetSession.mockResolvedValue({ userId: 'u1' });
+    mockSingle.mockResolvedValue({ data: { id: 'a1' } });
+    const fakeAssistant = { id: 'a1', status: 'active' };
+    mockResumeAssistant.mockResolvedValue(fakeAssistant);
+
+    const res = await POST();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.assistant).toEqual(fakeAssistant);
+    expect(mockResumeAssistant).toHaveBeenCalledWith('a1');
+  });
+});

--- a/apps/web/src/app/api/assistant/__tests__/window-start.test.ts
+++ b/apps/web/src/app/api/assistant/__tests__/window-start.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+
+describe('default window start calculation', () => {
+  it('returns 1 hour before current time, wrapping at midnight', () => {
+    const calc = (hour: number) => (hour - 1 + 24) % 24;
+
+    expect(calc(15)).toBe(14); // 3 PM → 2 PM
+    expect(calc(0)).toBe(23);  // midnight → 11 PM
+    expect(calc(1)).toBe(0);   // 1 AM → midnight
+    expect(calc(9)).toBe(8);   // 9 AM → 8 AM
+  });
+});

--- a/apps/web/src/app/api/assistant/launch/route.ts
+++ b/apps/web/src/app/api/assistant/launch/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { getSession } from '@/lib/auth/session';
+import { createClient } from '@/lib/supabase/server';
 import { launchAssistant } from '@/lib/vm/lifecycle';
 import { apiError, handleApiError, ERR } from '@/lib/errors';
 
@@ -10,6 +11,23 @@ export async function POST() {
   }
 
   try {
+    // Block launch if user has a suspended assistant
+    const supabase: any = createClient();
+    const { data: suspended } = await supabase
+      .from('assistants')
+      .select('id')
+      .eq('user_id', session.userId)
+      .eq('status', 'suspended')
+      .limit(1)
+      .single();
+
+    if (suspended) {
+      return apiError(
+        'You have a suspended assistant. Please resume it instead of launching a new one.',
+        409,
+      );
+    }
+
     const assistant = await launchAssistant(session.userId);
     return NextResponse.json({ assistant });
   } catch (err) {

--- a/apps/web/src/app/api/assistant/resume/route.ts
+++ b/apps/web/src/app/api/assistant/resume/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from 'next/server';
+import { getSession } from '@/lib/auth/session';
+import { createClient } from '@/lib/supabase/server';
+import { resumeAssistant } from '@/lib/vm/lifecycle';
+import { apiError, handleApiError, ERR } from '@/lib/errors';
+
+export async function POST() {
+  try {
+    const session = await getSession();
+    if (!session) {
+      return apiError(ERR.UNAUTHORIZED, 401);
+    }
+
+    const supabase: any = createClient();
+    const { data: existing } = await supabase
+      .from('assistants')
+      .select('id')
+      .eq('user_id', session.userId)
+      .eq('status', 'suspended')
+      .limit(1)
+      .single();
+
+    if (!existing) {
+      return apiError('No suspended assistant to resume.', 404);
+    }
+
+    const assistant = await resumeAssistant(existing.id);
+    return NextResponse.json({ assistant });
+  } catch (err) {
+    return handleApiError(err, 'assistant/resume');
+  }
+}

--- a/apps/web/src/app/dashboard/components/assistant-card.tsx
+++ b/apps/web/src/app/dashboard/components/assistant-card.tsx
@@ -92,6 +92,7 @@ export function AssistantHero({ assistant }: { assistant: Assistant | null }) {
   const [error, setError] = useState<string | null>(null);
 
   const [destroying, setDestroying] = useState(false);
+  const [resuming, setResuming] = useState(false);
   const [destroyElapsed, setDestroyElapsed] = useState(0);
   const [destroySteps, setDestroySteps] = useState<string[]>([]);
 
@@ -271,20 +272,39 @@ export function AssistantHero({ assistant }: { assistant: Assistant | null }) {
   }
 
   async function handleResume() {
-    setLoading("/api/assistant/launch");
+    setLoading("/api/assistant/resume");
     setError(null);
+    setResuming(true);
     try {
-      const res = await fetch("/api/assistant/launch", { method: "POST" });
+      const res = await fetch("/api/assistant/resume", { method: "POST" });
       if (!res.ok) {
         const data = await res.json().catch(() => ({}));
         setError(data.error ?? "Resume failed");
+        setResuming(false);
         return;
       }
-      const refreshed = await fetch("/api/assistant/status");
-      const data = await refreshed.json();
-      setCurrent(data.assistant ?? null);
+      // Poll for active status — az vm start is async
+      const maxWait = 60_000;
+      const interval = 3_000;
+      const start = Date.now();
+      while (Date.now() - start < maxWait) {
+        await new Promise((r) => setTimeout(r, interval));
+        const poll = await fetch("/api/assistant/status");
+        const pollData = await poll.json();
+        if (pollData.assistant?.status === "active") {
+          setCurrent(pollData.assistant);
+          setResuming(false);
+          return;
+        }
+      }
+      // Timed out — show whatever we have
+      const final = await fetch("/api/assistant/status");
+      const finalData = await final.json();
+      setCurrent(finalData.assistant ?? null);
+      setResuming(false);
     } catch {
       setError("Network error - please try again");
+      setResuming(false);
     } finally {
       setLoading(null);
     }
@@ -390,11 +410,16 @@ export function AssistantHero({ assistant }: { assistant: Assistant | null }) {
 
               {status === "suspended" && (
                 <button
-                  disabled={!!loading}
+                  disabled={!!loading || resuming}
                   onClick={handleResume}
                   className="rounded-full bg-indigo-600 px-5 py-2 text-sm font-medium text-white hover:bg-indigo-500 disabled:opacity-50 transition-colors"
                 >
-                  {loading === "/api/assistant/launch" ? "Resuming…" : "Resume"}
+                  {resuming ? (
+                    <span className="flex items-center gap-2">
+                      <svg className="animate-spin h-4 w-4" viewBox="0 0 24 24"><circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" fill="none" /><path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" /></svg>
+                      Resuming…
+                    </span>
+                  ) : "Resume"}
                 </button>
               )}
 

--- a/apps/web/src/app/onboarding/wizard.tsx
+++ b/apps/web/src/app/onboarding/wizard.tsx
@@ -85,7 +85,10 @@ export default function OnboardingWizard() {
     return '';
   };
   const [plan, setPlan] = useState<'free' | 'pro'>('free');
-  const [windowStart, setWindowStart] = useState(9);
+  const [windowStart, setWindowStart] = useState(() => {
+    const now = new Date();
+    return (now.getHours() - 1 + 24) % 24;
+  });
   const [messengers, setMessengers] = useState<string[]>([]);
   const [skills, setSkills] = useState<string[]>([]);
   const [setupStatus, setSetupStatus] = useState<string[]>([]);


### PR DESCRIPTION
## Changes

### Fix 1: Resume should start existing VM, not create a new one

- **New route** `/api/assistant/resume` — looks up the user's suspended assistant and calls `resumeAssistant()` from lifecycle.ts
- **Updated `assistant-card.tsx`** — `handleResume` now calls `/api/assistant/resume` instead of `/api/assistant/launch`, polls for active status up to 60s with a spinner
- **Updated `/api/assistant/launch`** — returns 409 if user has a suspended assistant, preventing duplicate VMs

### Fix 2: Default window start to 1 hour before current time

- **Updated `wizard.tsx`** — `windowStart` now defaults to `(currentHour - 1 + 24) % 24` so new users are immediately in their active window

### Tests
- Resume route: auth, 404, and success cases
- Launch route: 409 when suspended assistant exists, normal launch
- Window start calculation with wraparound