### PR TITLE
feat: add terms of service and privacy policy pages

### DIFF
--- a/apps/web/src/app/auth/signin/page.tsx
+++ b/apps/web/src/app/auth/signin/page.tsx
@@ -68,6 +68,10 @@ function Inner() {
             Coming Soon
           </span>
         </div>
+        <div className="mt-8 flex justify-center gap-4 text-xs text-gray-500">
+          <a href="/terms" className="hover:text-white transition-colors">Terms</a>
+          <a href="/privacy" className="hover:text-white transition-colors">Privacy</a>
+        </div>
       </div>
     </main>
   );

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -333,6 +333,8 @@ export default function Home() {
             <span className="font-bold">ShiftWorker</span>
           </div>
           <div className="flex gap-6 text-sm text-slate-400">
+            <a href="/terms" className="hover:text-white transition-colors">Terms</a>
+            <a href="/privacy" className="hover:text-white transition-colors">Privacy</a>
           </div>
           <p className="text-sm text-slate-500">
             © {new Date().getFullYear()} ShiftWorker

--- a/apps/web/src/app/privacy/page.tsx
+++ b/apps/web/src/app/privacy/page.tsx
@@ -1,0 +1,118 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+export const metadata: Metadata = {
+  title: 'Privacy Policy | ShiftWorker',
+  description: 'How ShiftWorker collects, uses, and protects your personal information.',
+};
+
+export default function PrivacyPage() {
+  return (
+    <div className="min-h-screen bg-slate-950 text-white">
+      <div className="mx-auto max-w-3xl px-6 py-16">
+        <Link href="/" className="text-sm text-slate-400 hover:text-white transition-colors">
+          ← Back to home
+        </Link>
+
+        <div className="mt-8 prose prose-invert prose-slate max-w-none">
+          <p className="text-sm text-slate-500">Last updated: April 2026</p>
+          <h1>Privacy Policy</h1>
+
+          <p>
+            This Privacy Policy explains how ShiftWorker (&quot;we,&quot; &quot;us,&quot; or &quot;our&quot;) collects, uses, and
+            protects your information when you use our service at shiftworker.ai.
+          </p>
+
+          <h2>What We Collect</h2>
+          <p>When you create an account, we collect:</p>
+          <ul>
+            <li><strong>Account information:</strong> Your name and email address (from Google or GitHub OAuth sign-in)</li>
+            <li><strong>Preferences:</strong> Timezone, usage preferences, and settings you configure</li>
+            <li><strong>Cloud provider tokens:</strong> OAuth tokens from your cloud provider (e.g., Azure, DigitalOcean) to manage VMs on your behalf. These are encrypted and stored only as long as needed.</li>
+            <li><strong>Payment information:</strong> Processed by Stripe — we do not store your card details directly</li>
+          </ul>
+
+          <h2>What We Don&apos;t Collect</h2>
+          <p>
+            Your AI assistant runs on your own cloud infrastructure. <strong>We do not read, store, or have
+            access to the content of your AI conversations.</strong> That data lives on your VM and is entirely
+            under your control.
+          </p>
+
+          <h2>How We Use Your Information</h2>
+          <ul>
+            <li>To provide and maintain the ShiftWorker service</li>
+            <li>To provision and manage VMs in your cloud account</li>
+            <li>To process payments and manage your subscription</li>
+            <li>To send you service-related communications (e.g., billing, downtime)</li>
+            <li>To improve and develop our service</li>
+          </ul>
+
+          <h2>Cookies</h2>
+          <p>
+            We use session cookies to keep you signed in. We do not use tracking cookies, advertising cookies,
+            or third-party analytics cookies.
+          </p>
+
+          <h2>Third-Party Services</h2>
+          <p>We use the following third-party services to operate ShiftWorker:</p>
+          <ul>
+            <li><strong>Stripe</strong> — payment processing</li>
+            <li><strong>Supabase</strong> — database and authentication</li>
+            <li><strong>Vercel</strong> — web application hosting</li>
+            <li><strong>Azure / DigitalOcean</strong> — cloud providers where your AI assistants are deployed (on your account)</li>
+          </ul>
+          <p>
+            Each of these services has their own privacy policy. We recommend reviewing them if you have concerns.
+          </p>
+
+          <h2>Data Retention</h2>
+          <p>
+            We retain your account data for as long as your account is active. When you delete your account,
+            we delete your data from our systems. Cloud provider tokens are revoked and deleted when no longer
+            needed or upon account deletion.
+          </p>
+          <p>
+            Note: Deleting your ShiftWorker account does not automatically delete VMs or data in your cloud
+            provider account. You are responsible for managing your own cloud resources.
+          </p>
+
+          <h2>Your Rights (CCPA / GDPR)</h2>
+          <p>
+            Regardless of where you live, you have the right to:
+          </p>
+          <ul>
+            <li>Request a copy of your personal data</li>
+            <li>Request deletion of your personal data</li>
+            <li>Request correction of inaccurate data</li>
+            <li>Opt out of any marketing communications</li>
+          </ul>
+          <p>
+            To exercise any of these rights, email us at{' '}
+            <a href="mailto:hello@shiftworker.ai">hello@shiftworker.ai</a>.
+            We will respond within 30 days.
+          </p>
+
+          <h2>Data Security</h2>
+          <p>
+            We use industry-standard security measures to protect your data, including encryption of sensitive
+            information like cloud provider tokens. However, no method of transmission over the internet is
+            100% secure, and we cannot guarantee absolute security.
+          </p>
+
+          <h2>Changes to This Policy</h2>
+          <p>
+            We may update this Privacy Policy from time to time. We&apos;ll notify you of significant changes
+            via email or through the service.
+          </p>
+
+          <h2>Contact</h2>
+          <p>
+            Questions about this Privacy Policy? Email us at{' '}
+            <a href="mailto:hello@shiftworker.ai">hello@shiftworker.ai</a>.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/terms/page.tsx
+++ b/apps/web/src/app/terms/page.tsx
@@ -1,0 +1,114 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+export const metadata: Metadata = {
+  title: 'Terms of Service | ShiftWorker',
+  description: 'ShiftWorker terms of service and conditions of use.',
+};
+
+export default function TermsPage() {
+  return (
+    <div className="min-h-screen bg-slate-950 text-white">
+      <div className="mx-auto max-w-3xl px-6 py-16">
+        <Link href="/" className="text-sm text-slate-400 hover:text-white transition-colors">
+          ← Back to home
+        </Link>
+
+        <div className="mt-8 prose prose-invert prose-slate max-w-none">
+          <p className="text-sm text-slate-500">Last updated: April 2026</p>
+          <h1>Terms of Service</h1>
+
+          <p>
+            These Terms of Service (&quot;Terms&quot;) govern your use of ShiftWorker (&quot;we,&quot; &quot;us,&quot; or &quot;our&quot;),
+            operated at shiftworker.ai. By using our service, you agree to these Terms.
+          </p>
+
+          <h2>What ShiftWorker Does</h2>
+          <p>
+            ShiftWorker deploys personal AI assistants on your own cloud infrastructure. We connect to your
+            cloud provider account (e.g., Azure), provision and manage virtual machines on your behalf, and
+            configure AI assistant software on those VMs. The AI assistant runs entirely on your infrastructure —
+            not ours.
+          </p>
+
+          <h2>Your Cloud Provider Account</h2>
+          <p>
+            To use ShiftWorker, you grant us permission to create, manage, and delete virtual machines in your
+            cloud provider subscription (e.g., Azure). You are solely responsible for all costs incurred through
+            your cloud provider, including compute, storage, networking, and any other charges. ShiftWorker does
+            not pay for or subsidize your cloud infrastructure costs.
+          </p>
+          <p>
+            You should monitor your cloud provider billing and set up spending alerts as appropriate. We are not
+            liable for unexpected cloud costs.
+          </p>
+
+          <h2>Your Account</h2>
+          <p>
+            You must provide accurate information when creating an account. You are responsible for maintaining
+            the security of your account credentials. You must be at least 18 years old to use ShiftWorker.
+          </p>
+
+          <h2>How We Handle Your Data</h2>
+          <p>
+            We store your account information (email, name, preferences) in our database to provide the service.
+            Your cloud provider OAuth tokens are encrypted and stored only as long as needed to manage your VMs.
+          </p>
+          <p>
+            Your AI assistant runs on your own infrastructure. We do not read, store, or have access to the
+            content of your AI conversations. That data stays on your VM and is under your control.
+          </p>
+
+          <h2>Acceptable Use</h2>
+          <p>
+            You agree not to use ShiftWorker to violate any laws, infringe on intellectual property rights,
+            distribute malware, or engage in any activity that could harm ShiftWorker or other users. We
+            reserve the right to suspend or terminate accounts that violate these terms.
+          </p>
+
+          <h2>Termination</h2>
+          <p>
+            We may suspend or terminate your account at any time, with or without cause, with or without notice.
+            Upon termination, we will stop managing your cloud resources, but any VMs or resources already
+            provisioned in your cloud account will remain until you delete them. You are responsible for cleaning
+            up your own cloud resources after termination.
+          </p>
+
+          <h2>Disclaimer of Warranties</h2>
+          <p>
+            ShiftWorker is provided <strong>&quot;as is&quot;</strong> and <strong>&quot;as available&quot;</strong> without
+            warranties of any kind, whether express or implied, including but not limited to implied warranties of
+            merchantability, fitness for a particular purpose, and non-infringement. We do not guarantee that the
+            service will be uninterrupted, error-free, or secure.
+          </p>
+
+          <h2>Limitation of Liability</h2>
+          <p>
+            To the maximum extent permitted by law, ShiftWorker and its officers, employees, and affiliates shall
+            not be liable for any indirect, incidental, special, consequential, or punitive damages, including
+            loss of profits, data, or goodwill, arising out of or related to your use of the service. Our total
+            liability shall not exceed the amount you paid us in the 12 months preceding the claim.
+          </p>
+
+          <h2>Changes to These Terms</h2>
+          <p>
+            We may update these Terms from time to time. We&apos;ll notify you of significant changes via email or
+            through the service. Continued use after changes constitutes acceptance.
+          </p>
+
+          <h2>Governing Law</h2>
+          <p>
+            These Terms are governed by the laws of the State of Arizona, USA, without regard to conflict of law
+            principles. Any disputes shall be resolved in the courts of Arizona.
+          </p>
+
+          <h2>Contact</h2>
+          <p>
+            Questions about these Terms? Email us at{' '}
+            <a href="mailto:hello@shiftworker.ai">hello@shiftworker.ai</a>.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Adds /terms and /privacy pages that were returning 404 (linked from Azure AD app registration).

## Changes
- **Terms of Service** page at `/terms` — covers service description, cloud costs responsibility, VM management permissions, liability, governing law (Arizona), etc.
- **Privacy Policy** page at `/privacy` — covers data collection, OAuth tokens, conversation privacy (stays on user's VM), cookies, third parties, CCPA/GDPR rights, etc.
- **Footer links** added to landing page and sign-in page
- Dark theme styling consistent with the rest of the site (`prose prose-invert prose-slate`)