### PR TITLE
test: add YAML parse validation to cloud-init tests

### DIFF
--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -25,11 +25,13 @@
         "@testing-library/dom": "^10.4.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
+        "@types/js-yaml": "^4.0.9",
         "@types/node": "^22.0.0",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "@vitejs/plugin-react": "^6.0.1",
         "@vitest/coverage-v8": "^4.1.2",
+        "js-yaml": "^4.1.1",
         "jsdom": "^29.0.1",
         "postcss": "^8.5.0",
         "tailwindcss": "^4.0.0",
@@ -1856,6 +1858,13 @@
         "@types/unist": "*"
       }
     },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/mdast": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
@@ -2118,6 +2127,13 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
     },
     "node_modules/aria-query": {
       "version": "5.3.0",
@@ -3044,6 +3060,19 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
     },
     "node_modules/jsdom": {
       "version": "29.0.1",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -28,15 +28,17 @@
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
+    "@types/js-yaml": "^4.0.9",
     "@types/node": "^22.0.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^6.0.1",
+    "@vitest/coverage-v8": "^4.1.2",
+    "js-yaml": "^4.1.1",
     "jsdom": "^29.0.1",
     "postcss": "^8.5.0",
     "tailwindcss": "^4.0.0",
     "typescript": "^5.7.0",
-    "vitest": "^4.1.2",
-    "@vitest/coverage-v8": "^4.1.2"
+    "vitest": "^4.1.2"
   }
 }

--- a/apps/web/src/lib/providers/__tests__/cloud-init.test.ts
+++ b/apps/web/src/lib/providers/__tests__/cloud-init.test.ts
@@ -1,5 +1,29 @@
 import { describe, it, expect } from 'vitest';
+import yaml from 'js-yaml';
 import { generateCloudInit } from '../cloud-init';
+
+/**
+ * Helper: parse cloud-init output as YAML and return the parsed document.
+ * Throws if the YAML is invalid - this is the core guard against the
+ * inline-Python-breaks-YAML class of bugs.
+ */
+function parseCloudInit(output: string): Record<string, any> {
+  const doc = yaml.load(output);
+  if (typeof doc !== 'object' || doc === null) {
+    throw new Error('cloud-init output did not parse as a YAML object');
+  }
+  return doc as Record<string, any>;
+}
+
+/**
+ * Helper: extract the content of a write_files entry by path.
+ */
+function getWriteFileContent(doc: Record<string, any>, filePath: string): string | undefined {
+  const files = doc.write_files as Array<{ path: string; content: string }> | undefined;
+  if (!files) return undefined;
+  const entry = files.find(f => f.path === filePath);
+  return entry?.content;
+}
 
 describe('cloud-init', () => {
   const baseOpts = {
@@ -8,130 +32,212 @@ describe('cloud-init', () => {
     instanceId: 'test-instance-id',
   };
 
-  it('includes groupPolicy and requireMention in telegram config', () => {
-    const output = generateCloudInit({
-      ...baseOpts,
-      telegramBotToken: '123456:ABC-DEF',
-    });
+  // --- YAML validity tests (the critical guard) ---
 
-    expect(output).toContain('groupPolicy');
-    expect(output).toContain('requireMention');
-  });
-
-  it('does not include telegram config when no bot token provided', () => {
+  it('parses as valid YAML with no optional features', () => {
     const output = generateCloudInit(baseOpts);
-
-    expect(output).not.toContain('groupPolicy');
-    expect(output).not.toContain('TELEGRAM_TOKEN');
+    const doc = parseCloudInit(output);
+    expect(doc.packages).toContain('curl');
+    expect(doc.runcmd).toBeDefined();
   });
 
-  it('includes AI model config when aiProvider is set', () => {
-    const result = generateCloudInit({
-      ...baseOpts,
-      aiProvider: 'gemini',
-      aiApiKey: 'test-gemini-key',
-    });
-
-    expect(result).toContain('Configuring AI model');
-    expect(result).toContain("'gemini'");
-    expect(result).toContain('GEMINI_API_KEY');
-    expect(result).toContain('test-gemini-key');
-    expect(result).toContain('gemini/gemini-2.5-flash');
-  });
-
-  it('does NOT include AI model config when aiProvider is not set', () => {
-    const result = generateCloudInit(baseOpts);
-
-    expect(result).not.toContain('Configuring AI model');
-    expect(result).not.toContain('GEMINI_API_KEY');
-    expect(result).not.toContain('OPENAI_API_KEY');
-  });
-
-  it('configures github-copilot provider correctly', () => {
-    const result = generateCloudInit({
+  it('parses as valid YAML with AI provider only', () => {
+    const output = generateCloudInit({
       ...baseOpts,
       aiProvider: 'github-copilot',
       aiApiKey: 'gho_testtoken123',
     });
-
-    expect(result).toContain('Configuring AI model');
-    expect(result).toContain('GITHUB_TOKEN');
-    expect(result).toContain('gho_testtoken123');
-    expect(result).toContain('github-copilot/claude-sonnet-4');
+    const doc = parseCloudInit(output);
+    expect(doc.write_files).toBeDefined();
+    expect(doc.runcmd).toBeDefined();
   });
 
-  it('configures openai provider correctly', () => {
-    const result = generateCloudInit({
+  it('parses as valid YAML with Telegram only', () => {
+    const output = generateCloudInit({
+      ...baseOpts,
+      telegramBotToken: '123456:ABC-DEF',
+    });
+    const doc = parseCloudInit(output);
+    expect(doc.write_files).toBeDefined();
+    expect(doc.runcmd).toBeDefined();
+  });
+
+  it('parses as valid YAML with both AI provider and Telegram', () => {
+    const output = generateCloudInit({
+      ...baseOpts,
+      aiProvider: 'github-copilot',
+      aiApiKey: 'gho_testtoken123',
+      telegramBotToken: '123456:ABC-DEF',
+    });
+    const doc = parseCloudInit(output);
+    expect(doc.write_files).toBeDefined();
+    expect(doc.runcmd).toBeDefined();
+  });
+
+  it('parses as valid YAML with special characters in API key', () => {
+    const output = generateCloudInit({
       ...baseOpts,
       aiProvider: 'openai',
-      aiApiKey: 'sk-test123',
+      aiApiKey: "key-with'quotes\"and\\backslashes&ampersands<brackets>",
     });
-
-    expect(result).toContain('OPENAI_API_KEY');
-    expect(result).toContain('sk-test123');
+    // Must not throw
+    const doc = parseCloudInit(output);
+    expect(doc.runcmd).toBeDefined();
   });
 
-  it('configures anthropic provider correctly', () => {
-    const result = generateCloudInit({
-      ...baseOpts,
-      aiProvider: 'anthropic',
-      aiApiKey: 'sk-ant-test123',
-    });
-
-    expect(result).toContain('ANTHROPIC_API_KEY');
-    expect(result).toContain('sk-ant-test123');
+  it('parses as valid YAML for every supported AI provider', () => {
+    for (const provider of ['gemini', 'openai', 'anthropic', 'github-copilot']) {
+      const output = generateCloudInit({
+        ...baseOpts,
+        aiProvider: provider,
+        aiApiKey: `test-key-for-${provider}`,
+        telegramBotToken: '123:TOK',
+      });
+      // Must not throw for any provider
+      const doc = parseCloudInit(output);
+      expect(doc.runcmd).toBeDefined();
+    }
   });
 
-  it('handles API keys with special characters', () => {
-    const result = generateCloudInit({
-      ...baseOpts,
-      aiProvider: 'openai',
-      aiApiKey: "key-with'quotes\"and\\backslashes",
-    });
+  // --- Structural tests ---
 
-    expect(result).toContain('Configuring AI model');
-    // Should not break the script
-    expect(result).toContain('OPENAI_API_KEY');
+  it('write_files contains all required service files', () => {
+    const doc = parseCloudInit(generateCloudInit(baseOpts));
+    const paths = (doc.write_files as Array<{ path: string }>).map(f => f.path);
+    expect(paths).toContain('/etc/shiftworker/sidecar.env');
+    expect(paths).toContain('/etc/systemd/system/openclaw-sidecar.service');
+    expect(paths).toContain('/etc/systemd/system/shiftworker-sidecar.service');
+    expect(paths).toContain('/opt/shiftworker/patch-config.py');
+    expect(paths).toContain('/opt/shiftworker/setup.sh');
   });
 
-  it('still includes telegram config alongside AI config', () => {
-    const result = generateCloudInit({
+  it('adds configure-ai.py write_file when aiProvider is set', () => {
+    const doc = parseCloudInit(generateCloudInit({
       ...baseOpts,
       aiProvider: 'gemini',
       aiApiKey: 'test-key',
-      telegramBotToken: 'telegram-bot-token',
-    });
-
-    expect(result).toContain('Configuring AI model');
-    expect(result).toContain('Configuring Telegram bot');
+    }));
+    const paths = (doc.write_files as Array<{ path: string }>).map(f => f.path);
+    expect(paths).toContain('/opt/shiftworker/configure-ai.py');
   });
 
-  it('generates valid YAML (no unindented Python code)', () => {
-    const result = generateCloudInit({
+  it('does NOT add configure-ai.py when aiProvider is not set', () => {
+    const doc = parseCloudInit(generateCloudInit(baseOpts));
+    const paths = (doc.write_files as Array<{ path: string }>).map(f => f.path);
+    expect(paths).not.toContain('/opt/shiftworker/configure-ai.py');
+  });
+
+  it('adds configure-telegram.py write_file when telegramBotToken is set', () => {
+    const doc = parseCloudInit(generateCloudInit({
+      ...baseOpts,
+      telegramBotToken: '123:ABC',
+    }));
+    const paths = (doc.write_files as Array<{ path: string }>).map(f => f.path);
+    expect(paths).toContain('/opt/shiftworker/configure-telegram.py');
+  });
+
+  it('does NOT add configure-telegram.py when telegramBotToken is not set', () => {
+    const doc = parseCloudInit(generateCloudInit(baseOpts));
+    const paths = (doc.write_files as Array<{ path: string }>).map(f => f.path);
+    expect(paths).not.toContain('/opt/shiftworker/configure-telegram.py');
+  });
+
+  // --- Content tests ---
+
+  it('setup.sh contains phone-home curl', () => {
+    const doc = parseCloudInit(generateCloudInit(baseOpts));
+    const setupSh = getWriteFileContent(doc, '/opt/shiftworker/setup.sh');
+    expect(setupSh).toBeDefined();
+    expect(setupSh).toContain('phone-home');
+    expect(setupSh).toContain('SIDECAR_TOKEN');
+  });
+
+  it('setup.sh calls configure-ai.py when aiProvider is set', () => {
+    const doc = parseCloudInit(generateCloudInit({
+      ...baseOpts,
+      aiProvider: 'github-copilot',
+      aiApiKey: 'gho_test',
+    }));
+    const setupSh = getWriteFileContent(doc, '/opt/shiftworker/setup.sh');
+    expect(setupSh).toContain('python3 /opt/shiftworker/configure-ai.py');
+  });
+
+  it('setup.sh calls configure-telegram.py when telegramBotToken is set', () => {
+    const doc = parseCloudInit(generateCloudInit({
+      ...baseOpts,
+      telegramBotToken: '123:ABC',
+    }));
+    const setupSh = getWriteFileContent(doc, '/opt/shiftworker/setup.sh');
+    expect(setupSh).toContain('python3 /opt/shiftworker/configure-telegram.py');
+  });
+
+  it('setup.sh does NOT contain inline python3 -c', () => {
+    const doc = parseCloudInit(generateCloudInit({
       ...baseOpts,
       aiProvider: 'github-copilot',
       aiApiKey: 'gho_test',
       telegramBotToken: '123:ABC',
-    });
-
-    // Every line after #cloud-config should either be empty or properly structured
-    // The Python scripts should be in separate write_files entries, not inline
-    expect(result).toContain('configure-ai.py');
-    expect(result).toContain('configure-telegram.py');
-    // Python code should NOT appear inside setup.sh content block
-    expect(result).not.toContain('python3 -c "');
+    }));
+    const setupSh = getWriteFileContent(doc, '/opt/shiftworker/setup.sh');
+    expect(setupSh).not.toContain('python3 -c');
   });
 
-  it('always ends with phone-home curl and runcmd', () => {
-    const result = generateCloudInit({
+  it('configure-ai.py contains the correct provider and model', () => {
+    const doc = parseCloudInit(generateCloudInit({
       ...baseOpts,
       aiProvider: 'gemini',
-      aiApiKey: 'key',
-      telegramBotToken: 'tok',
-    });
+      aiApiKey: 'test-gemini-key',
+    }));
+    const aiScript = getWriteFileContent(doc, '/opt/shiftworker/configure-ai.py');
+    expect(aiScript).toBeDefined();
+    expect(aiScript).toContain("'gemini'");
+    expect(aiScript).toContain('GEMINI_API_KEY');
+    expect(aiScript).toContain('test-gemini-key');
+    expect(aiScript).toContain('gemini/gemini-2.5-flash');
+  });
 
-    expect(result).toContain('phone-home');
-    expect(result).toContain('runcmd:');
-    expect(result).toContain('[bash, /opt/shiftworker/setup.sh]');
+  it('configure-ai.py maps each provider to correct env var', () => {
+    const providerEnvMap: Record<string, string> = {
+      'gemini': 'GEMINI_API_KEY',
+      'openai': 'OPENAI_API_KEY',
+      'anthropic': 'ANTHROPIC_API_KEY',
+      'github-copilot': 'GITHUB_TOKEN',
+    };
+
+    for (const [provider, envVar] of Object.entries(providerEnvMap)) {
+      const doc = parseCloudInit(generateCloudInit({
+        ...baseOpts,
+        aiProvider: provider,
+        aiApiKey: `key-for-${provider}`,
+      }));
+      const aiScript = getWriteFileContent(doc, '/opt/shiftworker/configure-ai.py');
+      expect(aiScript).toContain(envVar);
+      expect(aiScript).toContain(`key-for-${provider}`);
+    }
+  });
+
+  it('configure-telegram.py sets dmPolicy and groupPolicy', () => {
+    const doc = parseCloudInit(generateCloudInit({
+      ...baseOpts,
+      telegramBotToken: '123456:ABC-DEF',
+    }));
+    const tgScript = getWriteFileContent(doc, '/opt/shiftworker/configure-telegram.py');
+    expect(tgScript).toBeDefined();
+    expect(tgScript).toContain('dmPolicy');
+    expect(tgScript).toContain('groupPolicy');
+    expect(tgScript).toContain('requireMention');
+  });
+
+  it('sidecar.env contains correct tokens', () => {
+    const doc = parseCloudInit(generateCloudInit(baseOpts));
+    const env = getWriteFileContent(doc, '/etc/shiftworker/sidecar.env');
+    expect(env).toContain('SIDECAR_TOKEN=test-token');
+    expect(env).toContain('PORTAL_URL=https://shiftworker.ai');
+    expect(env).toContain('INSTANCE_ID=test-instance-id');
+  });
+
+  it('runcmd calls setup.sh', () => {
+    const doc = parseCloudInit(generateCloudInit(baseOpts));
+    expect(doc.runcmd).toEqual([['bash', '/opt/shiftworker/setup.sh']]);
   });
 });


### PR DESCRIPTION
## What

Rewrites the cloud-init test suite to actually parse the generated output as YAML using `js-yaml`. This is the safety net that would have caught #247 (inline Python breaking YAML) before it shipped.

## Tests (20 total)

**YAML validity (6 tests)** - the critical guard:
- Parses with no optional features
- Parses with AI provider only
- Parses with Telegram only  
- Parses with both AI + Telegram
- Parses with special characters in API key
- Parses for every supported AI provider (gemini, openai, anthropic, github-copilot)

**Structural checks (6 tests):**
- Required service files present in write_files
- configure-ai.py added/omitted based on aiProvider
- configure-telegram.py added/omitted based on telegramBotToken

**Content checks (8 tests):**
- setup.sh contains phone-home curl
- setup.sh calls external scripts (not inline python3 -c)
- AI config maps providers to correct env vars
- Telegram config sets dmPolicy/groupPolicy
- sidecar.env contains correct tokens
- runcmd calls setup.sh

## Why

If anyone modifies cloud-init.ts and breaks the YAML structure, these tests will catch it at CI time instead of silently deploying a VM that installs nothing.