### PR TITLE
fix: use agents.defaults.model instead of defaultModel in cloud-init

### DIFF
--- a/apps/web/src/lib/providers/__tests__/cloud-init.test.ts
+++ b/apps/web/src/lib/providers/__tests__/cloud-init.test.ts
@@ -196,6 +196,20 @@ describe('cloud-init', () => {
     expect(aiScript).toContain('gemini/gemini-2.5-flash');
   });
 
+  it('configure-ai.py sets model under agents.defaults.model (not defaultModel)', () => {
+    const doc = parseCloudInit(generateCloudInit({
+      ...baseOpts,
+      aiProvider: 'github-copilot',
+      aiApiKey: 'gho_test',
+    }));
+    const aiScript = getWriteFileContent(doc, '/opt/shiftworker/configure-ai.py');
+    expect(aiScript).toBeDefined();
+    // Must use agents.defaults.model path, not root-level defaultModel
+    expect(aiScript).toContain("agents");
+    expect(aiScript).toContain("defaults");
+    expect(aiScript).not.toContain("config['defaultModel']");
+  });
+
   it('configure-ai.py maps each provider to correct env var', () => {
     const providerEnvMap: Record<string, string> = {
       'gemini': 'GEMINI_API_KEY',

--- a/apps/web/src/lib/providers/cloud-init.ts
+++ b/apps/web/src/lib/providers/cloud-init.ts
@@ -49,7 +49,9 @@ export function generateCloudInit(opts: CloudInitOptions): string {
       provider = '${opts.aiProvider}'
       model_id = MODEL_MAP.get(provider, '')
       if model_id:
-          config['defaultModel'] = model_id
+          agents = config.setdefault('agents', {})
+          defaults = agents.setdefault('defaults', {})
+          defaults['model'] = model_id
       ENV_MAP = {
           'gemini': 'GEMINI_API_KEY',
           'openai': 'OPENAI_API_KEY',


### PR DESCRIPTION
## Problem

The AI config script wrote `defaultModel` as a root-level key in `openclaw.json`. OpenClaw 2026.4.2 treats this as an unrecognized key and rejects the entire config:

```
Config invalid
File: ~/.openclaw/openclaw.json
Problem:
  - <root>: Unrecognized key: "defaultModel"
```

This blocked **every** `openclaw` CLI command on the VM, including `openclaw channels add` for Telegram setup. Result: AI model worked (set via env var) but Telegram was completely non-functional.

## Fix

Changed the Python config script to use the correct path: `config['agents']['defaults']['model'] = model_id` per the OpenClaw config docs.

## Testing

- 206 tests pass
- New test verifies configure-ai.py uses `agents.defaults` path, not `config['defaultModel']`