### PR TITLE
fix: use GitHub Models API for github-copilot OAuth tokens

### DIFF
--- a/apps/web/src/lib/providers/__tests__/cloud-init.test.ts
+++ b/apps/web/src/lib/providers/__tests__/cloud-init.test.ts
@@ -215,7 +215,7 @@ describe('cloud-init', () => {
       'gemini': 'GEMINI_API_KEY',
       'openai': 'OPENAI_API_KEY',
       'anthropic': 'ANTHROPIC_API_KEY',
-      'github-copilot': 'GITHUB_TOKEN',
+      'github-copilot': 'OPENAI_API_KEY',
     };
 
     for (const [provider, envVar] of Object.entries(providerEnvMap)) {

--- a/apps/web/src/lib/providers/cloud-init.ts
+++ b/apps/web/src/lib/providers/cloud-init.ts
@@ -44,7 +44,7 @@ export function generateCloudInit(opts: CloudInitOptions): string {
           'gemini': 'gemini/gemini-2.5-flash',
           'openai': 'openai/gpt-4o',
           'anthropic': 'anthropic/claude-sonnet-4',
-          'github-copilot': 'github-copilot/claude-sonnet-4',
+          'github-copilot': 'openai/gpt-4o',
       }
       provider = '${opts.aiProvider}'
       model_id = MODEL_MAP.get(provider, '')
@@ -56,12 +56,14 @@ export function generateCloudInit(opts: CloudInitOptions): string {
           'gemini': 'GEMINI_API_KEY',
           'openai': 'OPENAI_API_KEY',
           'anthropic': 'ANTHROPIC_API_KEY',
-          'github-copilot': 'GITHUB_TOKEN',
+          'github-copilot': 'OPENAI_API_KEY',
       }
       env_key = ENV_MAP.get(provider, '')
       api_key = '${escapedApiKey}'
       if env_key and api_key:
           config.setdefault('env', {})[env_key] = api_key
+      if provider == 'github-copilot':
+          config.setdefault('env', {})['OPENAI_BASE_URL'] = 'https://models.inference.ai.azure.com'
       with open(config_path, 'w') as f:
           json.dump(config, f, indent=2)
       pw = pwd.getpwnam(user)


### PR DESCRIPTION
## Problem

The bot was returning errors on every message: `Copilot token exchange failed: HTTP 404`.

OpenClaw's `github-copilot` provider uses `copilot_internal/v2/token` for token exchange, which only works with tokens from the GitHub Device Flow (`openclaw models auth login-github-copilot`). Our OAuth web flow produces `gho_*` tokens that work with the GitHub Models API but not with the Copilot internal API.

## Fix

When `aiProvider` is `github-copilot`, configure the VM to use the GitHub Models API instead:

| Before | After |
|--------|-------|
| `github-copilot/claude-sonnet-4` | `openai/gpt-4o` |
| `GITHUB_TOKEN=gho_...` | `OPENAI_API_KEY=gho_...` |
| (copilot_internal API) | `OPENAI_BASE_URL=https://models.inference.ai.azure.com` |

This routes through the standard OpenAI provider to GitHub's Models API, which accepts OAuth web flow tokens.

## Testing

- 206 tests pass
- Updated env var mapping test for github-copilot provider