### PR TITLE
fix: sidecar configure-model uses GitHub Models API for github-copilot tokens

### DIFF
--- a/apps/sidecar/dist/sidecar.cjs
+++ b/apps/sidecar/dist/sidecar.cjs
@@ -250,29 +250,34 @@ router2.post("/openclaw/configure-model", async (req, res) => {
       "gemini": "gemini/gemini-2.5-flash",
       "openai": "openai/gpt-4o",
       "anthropic": "anthropic/claude-sonnet-4",
-      "github-copilot": "github-copilot/claude-sonnet-4"
+      "github-copilot": "openai/gpt-4o"
     };
     const modelId = MODEL_MAP[provider];
     if (!modelId) {
       res.status(400).json({ error: `Unknown provider: ${provider}` });
       return;
     }
-    config.defaultModel = modelId;
-    if (apiKey && provider !== "github-copilot") {
-      const envMap = {
-        "gemini": "GEMINI_API_KEY",
-        "openai": "OPENAI_API_KEY",
-        "anthropic": "ANTHROPIC_API_KEY"
-      };
-      const envKey = envMap[provider];
+    const agents = config.agents = config.agents ?? {};
+    const defaults = agents.defaults = agents.defaults ?? {};
+    defaults.model = { primary: modelId };
+    delete config.defaultModel;
+    const ENV_MAP = {
+      "gemini": "GEMINI_API_KEY",
+      "openai": "OPENAI_API_KEY",
+      "anthropic": "ANTHROPIC_API_KEY",
+      "github-copilot": "OPENAI_API_KEY"
+    };
+    if (apiKey) {
+      const envKey = ENV_MAP[provider];
       if (envKey) {
         config.env = config.env ?? {};
         config.env[envKey] = apiKey;
       }
     }
-    if (provider === "github-copilot" && apiKey) {
+    if (provider === "github-copilot") {
       config.env = config.env ?? {};
-      config.env.GITHUB_TOKEN = apiKey;
+      config.env["OPENAI_BASE_URL"] = "https://models.inference.ai.azure.com";
+      delete config.env["GITHUB_TOKEN"];
     }
     fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
     await execAsync2(`chown ${CLAW_USER2}:${CLAW_USER2} ${configPath}`);

--- a/apps/sidecar/src/routes/openclaw.ts
+++ b/apps/sidecar/src/routes/openclaw.ts
@@ -130,11 +130,13 @@ router.post('/openclaw/configure-model', async (req: Request, res: Response) => 
     }
 
     // Map provider names to OpenClaw model IDs
+    // GitHub Copilot OAuth tokens (gho_*) work with GitHub Models API,
+    // not the copilot_internal token exchange, so route through openai provider.
     const MODEL_MAP: Record<string, string> = {
       'gemini': 'gemini/gemini-2.5-flash',
       'openai': 'openai/gpt-4o',
       'anthropic': 'anthropic/claude-sonnet-4',
-      'github-copilot': 'github-copilot/claude-sonnet-4',
+      'github-copilot': 'openai/gpt-4o',
     };
 
     const modelId = MODEL_MAP[provider];
@@ -143,27 +145,35 @@ router.post('/openclaw/configure-model', async (req: Request, res: Response) => 
       return;
     }
 
-    // Set the default model
-    config.defaultModel = modelId;
+    // Set the default model using agents.defaults.model (not legacy defaultModel)
+    const agents = config.agents = config.agents ?? {};
+    const defaults = agents.defaults = agents.defaults ?? {};
+    defaults.model = { primary: modelId };
+    // Clean up legacy defaultModel if present
+    delete config.defaultModel;
 
-    // For providers that need API keys, set env vars
-    if (apiKey && provider !== 'github-copilot') {
-      const envMap: Record<string, string> = {
-        'gemini': 'GEMINI_API_KEY',
-        'openai': 'OPENAI_API_KEY',
-        'anthropic': 'ANTHROPIC_API_KEY',
-      };
-      const envKey = envMap[provider];
+    // Map providers to their environment variable for API keys
+    const ENV_MAP: Record<string, string> = {
+      'gemini': 'GEMINI_API_KEY',
+      'openai': 'OPENAI_API_KEY',
+      'anthropic': 'ANTHROPIC_API_KEY',
+      'github-copilot': 'OPENAI_API_KEY',
+    };
+
+    if (apiKey) {
+      const envKey = ENV_MAP[provider];
       if (envKey) {
         config.env = config.env ?? {};
         config.env[envKey] = apiKey;
       }
     }
 
-    // For GitHub Copilot, set up the OAuth token if provided
-    if (provider === 'github-copilot' && apiKey) {
+    // GitHub Copilot OAuth tokens use GitHub Models API endpoint
+    if (provider === 'github-copilot') {
       config.env = config.env ?? {};
-      config.env.GITHUB_TOKEN = apiKey;
+      config.env['OPENAI_BASE_URL'] = 'https://models.inference.ai.azure.com';
+      // Clean up stale GITHUB_TOKEN if present (from older sidecar versions)
+      delete config.env['GITHUB_TOKEN'];
     }
 
     fs.writeFileSync(configPath, JSON.stringify(config, null, 2));


### PR DESCRIPTION
## Problem

The sidecar's `/openclaw/configure-model` endpoint was mapping `github-copilot` to `github-copilot/claude-sonnet-4` and setting `GITHUB_TOKEN`. This doesn't work with OAuth web flow tokens (`gho_*`) - they work with the GitHub Models API, not the copilot_internal token exchange endpoint.

This caused **401 Incorrect API key** errors when users messaged their Telegram bot, with the raw error being sent back to the user.

## Fix

- Map `github-copilot` → `openai/gpt-4o` (routed through GitHub Models API)
- Set `OPENAI_API_KEY` (not `GITHUB_TOKEN`) for the `gho_*` token
- Set `OPENAI_BASE_URL=https://models.inference.ai.azure.com`
- Use `agents.defaults.model` instead of legacy `defaultModel`
- Clean up stale `GITHUB_TOKEN` env vars from older configs

Matches the cloud-init fix in PR #250. The current test VM has already been fixed manually via Azure run-command.