### PR TITLE
fix: remove systemd watchdog from sidecar service

### DIFF
--- a/apps/web/src/lib/providers/cloud-init.ts
+++ b/apps/web/src/lib/providers/cloud-init.ts
@@ -115,8 +115,6 @@ write_files:
       ExecStart=/usr/bin/node dist/sidecar.cjs
       Restart=always
       RestartSec=5
-      WatchdogSec=120
-      WatchdogSignal=SIGKILL
       [Install]
       WantedBy=multi-user.target
   - path: /opt/shiftworker/patch-config.py


### PR DESCRIPTION
The sidecar was getting SIGKILL'd every 2 minutes by the systemd watchdog (WatchdogSec=120), wiping in-memory state including device flow codes. This caused the 'No device flow in progress' error during onboarding.