### PR TITLE
fix: restore AI provider selection when resuming onboarding

### DIFF
--- a/apps/web/src/app/api/assistant/status/route.ts
+++ b/apps/web/src/app/api/assistant/status/route.ts
@@ -12,17 +12,24 @@ export async function GET() {
     }
 
     const supabase: any = createClient();
-    const { data: assistant, error } = await supabase
-      .from('assistants')
-      .select()
-      .eq('user_id', session.userId)
-      .neq('status', 'destroyed')
-      .order('created_at', { ascending: false })
-      .limit(1)
-      .single();
+    const [{ data: assistant, error }, { data: userProfile }] = await Promise.all([
+      supabase
+        .from('assistants')
+        .select()
+        .eq('user_id', session.userId)
+        .neq('status', 'destroyed')
+        .order('created_at', { ascending: false })
+        .limit(1)
+        .single(),
+      supabase
+        .from('users')
+        .select('ai_provider, provider_preference')
+        .eq('id', session.userId)
+        .single(),
+    ]);
 
     if (error || !assistant) {
-      return NextResponse.json({ assistant: null });
+      return NextResponse.json({ assistant: null, aiProvider: userProfile?.ai_provider ?? userProfile?.provider_preference ?? null });
     }
 
     const needsProvisioning =
@@ -50,11 +57,12 @@ export async function GET() {
         } catch { /* best effort */ }
         return NextResponse.json({
           assistant: { ...assistant, _provisioningError: 'Provisioning step failed. Retrying automatically.' },
+          aiProvider: userProfile?.ai_provider ?? userProfile?.provider_preference ?? null,
         });
       }
     }
 
-    return NextResponse.json({ assistant });
+    return NextResponse.json({ assistant, aiProvider: userProfile?.ai_provider ?? userProfile?.provider_preference ?? null });
   } catch (err) {
     return handleApiError(err, 'assistant/status');
   }

--- a/apps/web/src/app/onboarding/wizard.tsx
+++ b/apps/web/src/app/onboarding/wizard.tsx
@@ -257,12 +257,19 @@ export default function OnboardingWizard() {
           setServerActive(true);
           setSetupDone(true);
           setSetupStatus((prev) => [...prev, 'Server is online']);
+          // Restore AI provider from user profile
+          if (data.aiProvider) {
+            setAiProvider(data.aiProvider as typeof aiProvider);
+          }
           setStep((currentStep) => {
             if (currentStep < 7) return 7;
             return currentStep; // Don't jump backward
           });
         } else if (assistant.status === 'provisioning') {
           // VM is provisioning - jump to Setup & Connect and start polling
+          if (data.aiProvider) {
+            setAiProvider(data.aiProvider as typeof aiProvider);
+          }
           setStep((currentStep) => {
             if (currentStep < 7) {
               setServerActive(false);


### PR DESCRIPTION
When the wizard resumes (page reload, returning from OAuth redirect, etc.) and an assistant is already active, it jumped to step 7 but `aiProvider` was empty. This caused the generic API key input to show instead of the GitHub Copilot device flow UI.

Fix: include the user's `ai_provider` in the assistant/status API response and restore it when resuming.