### PR TITLE
fix: remove authProfile from model config object

### DIFF
--- a/apps/sidecar/dist/routes/openclaw.js
+++ b/apps/sidecar/dist/routes/openclaw.js
@@ -264,7 +264,7 @@ router.get('/openclaw/github-copilot-device-status', async (_req, res) => {
             }
             const agents = config.agents = config.agents ?? {};
             const defaults = agents.defaults = agents.defaults ?? {};
-            defaults.model = { primary: 'github-copilot/gpt-4o', authProfile: 'github-copilot:github' };
+            defaults.model = { primary: 'github-copilot/gpt-4o' };
             delete config.defaultModel;
             // Remove stale env vars since we're using auth profiles
             if (config.env) {

--- a/apps/sidecar/dist/sidecar.cjs
+++ b/apps/sidecar/dist/sidecar.cjs
@@ -344,7 +344,7 @@ router2.get("/openclaw/github-copilot-device-status", async (_req, res) => {
       }
       const agents = config.agents = config.agents ?? {};
       const defaults = agents.defaults = agents.defaults ?? {};
-      defaults.model = { primary: "github-copilot/gpt-4o", authProfile: "github-copilot:github" };
+      defaults.model = { primary: "github-copilot/gpt-4o" };
       delete config.defaultModel;
       if (config.env) {
         delete config.env["OPENAI_API_KEY"];

--- a/apps/sidecar/src/routes/openclaw.ts
+++ b/apps/sidecar/src/routes/openclaw.ts
@@ -237,7 +237,7 @@ router.get('/openclaw/github-copilot-device-status', async (_req: Request, res: 
 
       const agents = config.agents = config.agents ?? {};
       const defaults = agents.defaults = agents.defaults ?? {};
-      defaults.model = { primary: 'github-copilot/gpt-4o', authProfile: 'github-copilot:github' };
+      defaults.model = { primary: 'github-copilot/gpt-4o' };
       delete config.defaultModel;
 
       // Remove stale env vars since we're using auth profiles


### PR DESCRIPTION
OpenClaw rejects unknown keys inside `agents.defaults.model`. The `authProfile` field caused config validation errors, preventing the gateway from starting after device flow auth. OpenClaw resolves auth profiles automatically by provider name.