### PR TITLE
fix: write auth profiles to per-agent dir for OpenClaw

### DIFF
--- a/apps/sidecar/dist/routes/openclaw.js
+++ b/apps/sidecar/dist/routes/openclaw.js
@@ -230,15 +230,27 @@ router.get('/openclaw/github-copilot-device-status', async (_req, res) => {
             const token = data.access_token;
             // Store token in OpenClaw auth profile store
             const CLAW_USER = process.env.OPENCLAW_USER || 'claw';
+            // Write auth profiles to BOTH the global state dir and the per-agent dir.
+            // OpenClaw resolves auth from the per-agent path: ~/.openclaw/agents/main/agent/auth-profiles.json
+            const agentDir = path.join('/home', CLAW_USER, '.openclaw', 'agents', 'main', 'agent');
             const stateDir = path.join('/home', CLAW_USER, '.openclaw', 'state');
-            const authProfilesPath = path.join(stateDir, 'auth-profiles.json');
-            if (!fs.existsSync(stateDir)) {
-                fs.mkdirSync(stateDir, { recursive: true });
+            const agentAuthPath = path.join(agentDir, 'auth-profiles.json');
+            const stateAuthPath = path.join(stateDir, 'auth-profiles.json');
+            for (const dir of [agentDir, stateDir]) {
+                if (!fs.existsSync(dir)) {
+                    fs.mkdirSync(dir, { recursive: true });
+                }
             }
             let profiles = { profiles: {} };
-            if (fs.existsSync(authProfilesPath)) {
+            if (fs.existsSync(agentAuthPath)) {
                 try {
-                    profiles = JSON.parse(fs.readFileSync(authProfilesPath, 'utf8'));
+                    profiles = JSON.parse(fs.readFileSync(agentAuthPath, 'utf8'));
+                }
+                catch { }
+            }
+            else if (fs.existsSync(stateAuthPath)) {
+                try {
+                    profiles = JSON.parse(fs.readFileSync(stateAuthPath, 'utf8'));
                 }
                 catch { }
             }
@@ -248,7 +260,14 @@ router.get('/openclaw/github-copilot-device-status', async (_req, res) => {
                 provider: 'github-copilot',
                 token: token,
             };
-            fs.writeFileSync(authProfilesPath, JSON.stringify(profiles, null, 2));
+            // Write to both locations
+            for (const authPath of [agentAuthPath, stateAuthPath]) {
+                fs.writeFileSync(authPath, JSON.stringify(profiles, null, 2));
+            }
+            try {
+                await execAsync(`chown -R ${CLAW_USER}:${CLAW_USER} ${agentDir}`);
+            }
+            catch { }
             try {
                 await execAsync(`chown -R ${CLAW_USER}:${CLAW_USER} ${stateDir}`);
             }

--- a/apps/sidecar/dist/sidecar.cjs
+++ b/apps/sidecar/dist/sidecar.cjs
@@ -311,15 +311,24 @@ router2.get("/openclaw/github-copilot-device-status", async (_req, res) => {
       delete deviceFlowStore["copilot-device"];
       const token = data.access_token;
       const CLAW_USER2 = process.env.OPENCLAW_USER || "claw";
+      const agentDir = path.join("/home", CLAW_USER2, ".openclaw", "agents", "main", "agent");
       const stateDir = path.join("/home", CLAW_USER2, ".openclaw", "state");
-      const authProfilesPath = path.join(stateDir, "auth-profiles.json");
-      if (!fs.existsSync(stateDir)) {
-        fs.mkdirSync(stateDir, { recursive: true });
+      const agentAuthPath = path.join(agentDir, "auth-profiles.json");
+      const stateAuthPath = path.join(stateDir, "auth-profiles.json");
+      for (const dir of [agentDir, stateDir]) {
+        if (!fs.existsSync(dir)) {
+          fs.mkdirSync(dir, { recursive: true });
+        }
       }
       let profiles = { profiles: {} };
-      if (fs.existsSync(authProfilesPath)) {
+      if (fs.existsSync(agentAuthPath)) {
         try {
-          profiles = JSON.parse(fs.readFileSync(authProfilesPath, "utf8"));
+          profiles = JSON.parse(fs.readFileSync(agentAuthPath, "utf8"));
+        } catch {
+        }
+      } else if (fs.existsSync(stateAuthPath)) {
+        try {
+          profiles = JSON.parse(fs.readFileSync(stateAuthPath, "utf8"));
         } catch {
         }
       }
@@ -329,7 +338,13 @@ router2.get("/openclaw/github-copilot-device-status", async (_req, res) => {
         provider: "github-copilot",
         token
       };
-      fs.writeFileSync(authProfilesPath, JSON.stringify(profiles, null, 2));
+      for (const authPath of [agentAuthPath, stateAuthPath]) {
+        fs.writeFileSync(authPath, JSON.stringify(profiles, null, 2));
+      }
+      try {
+        await execAsync2(`chown -R ${CLAW_USER2}:${CLAW_USER2} ${agentDir}`);
+      } catch {
+      }
       try {
         await execAsync2(`chown -R ${CLAW_USER2}:${CLAW_USER2} ${stateDir}`);
       } catch {

--- a/apps/sidecar/src/routes/openclaw.ts
+++ b/apps/sidecar/src/routes/openclaw.ts
@@ -208,16 +208,25 @@ router.get('/openclaw/github-copilot-device-status', async (_req: Request, res: 
 
       // Store token in OpenClaw auth profile store
       const CLAW_USER = process.env.OPENCLAW_USER || 'claw';
-      const stateDir = path.join('/home', CLAW_USER, '.openclaw', 'state');
-      const authProfilesPath = path.join(stateDir, 'auth-profiles.json');
 
-      if (!fs.existsSync(stateDir)) {
-        fs.mkdirSync(stateDir, { recursive: true });
+      // Write auth profiles to BOTH the global state dir and the per-agent dir.
+      // OpenClaw resolves auth from the per-agent path: ~/.openclaw/agents/main/agent/auth-profiles.json
+      const agentDir = path.join('/home', CLAW_USER, '.openclaw', 'agents', 'main', 'agent');
+      const stateDir = path.join('/home', CLAW_USER, '.openclaw', 'state');
+      const agentAuthPath = path.join(agentDir, 'auth-profiles.json');
+      const stateAuthPath = path.join(stateDir, 'auth-profiles.json');
+
+      for (const dir of [agentDir, stateDir]) {
+        if (!fs.existsSync(dir)) {
+          fs.mkdirSync(dir, { recursive: true });
+        }
       }
 
       let profiles: any = { profiles: {} };
-      if (fs.existsSync(authProfilesPath)) {
-        try { profiles = JSON.parse(fs.readFileSync(authProfilesPath, 'utf8')); } catch {}
+      if (fs.existsSync(agentAuthPath)) {
+        try { profiles = JSON.parse(fs.readFileSync(agentAuthPath, 'utf8')); } catch {}
+      } else if (fs.existsSync(stateAuthPath)) {
+        try { profiles = JSON.parse(fs.readFileSync(stateAuthPath, 'utf8')); } catch {}
       }
       profiles.profiles = profiles.profiles ?? {};
       profiles.profiles['github-copilot:github'] = {
@@ -225,7 +234,11 @@ router.get('/openclaw/github-copilot-device-status', async (_req: Request, res: 
         provider: 'github-copilot',
         token: token,
       };
-      fs.writeFileSync(authProfilesPath, JSON.stringify(profiles, null, 2));
+      // Write to both locations
+      for (const authPath of [agentAuthPath, stateAuthPath]) {
+        fs.writeFileSync(authPath, JSON.stringify(profiles, null, 2));
+      }
+      try { await execAsync(`chown -R ${CLAW_USER}:${CLAW_USER} ${agentDir}`); } catch {}
       try { await execAsync(`chown -R ${CLAW_USER}:${CLAW_USER} ${stateDir}`); } catch {}
 
       // Update openclaw.json config


### PR DESCRIPTION
OpenClaw resolves auth from `~/.openclaw/agents/main/agent/auth-profiles.json`, not `~/.openclaw/state/auth-profiles.json`. This caused 'No API key found for provider github-copilot' errors after the device flow completed. Now writes to both locations.