### PR TITLE
fix: onboarding to dashboard handoff loses state

### DIFF
--- a/apps/web/src/app/dashboard/components/connections-card.tsx
+++ b/apps/web/src/app/dashboard/components/connections-card.tsx
@@ -223,9 +223,9 @@ export function ConnectionsCard({
               statusLabel = "Needs setup";
             }
 
-            // For free plan, only show the connected/configured messenger
-            // Hide other messengers entirely, show "Change messenger" link instead
-            if (isFree && !connected && !configured && !(m === "telegram" && telegramBotUsername)) {
+            // For free plan, hide messengers that are neither selected, connected,
+            // configured, nor have a telegram bot ready
+            if (isFree && !connected && !configured && !isUserSelected && !(m === "telegram" && telegramBotUsername)) {
               return null;
             }
 

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -58,7 +58,7 @@ async function DashboardContent({
   }
 
   const messengers: string[] = user?.messengers ?? [];
-  let aiProvider: string | null = user?.ai_provider ?? user?.provider_preference ?? null;
+  let aiProvider: string | null = user?.ai_provider ?? null;
   let aiApiKey: string | null = user?.ai_api_key ?? null;
 
   // For GitHub Copilot, the token is in provider_tokens (OAuth flow), not users.ai_api_key
@@ -67,6 +67,18 @@ async function DashboardContent({
     const ghToken = await getProviderToken(session.userId, 'github-copilot');
     if (ghToken?.accessToken) {
       aiApiKey = ghToken.accessToken;
+    }
+  }
+
+  // Fallback: if no AI provider detected yet, check provider_tokens for any known provider
+  if (!aiProvider || !aiApiKey) {
+    for (const provider of ['github-copilot', 'gemini', 'openai', 'anthropic'] as const) {
+      const token = await getProviderToken(session.userId, provider);
+      if (token?.accessToken) {
+        aiProvider = aiProvider || provider;
+        aiApiKey = aiApiKey || token.accessToken;
+        break;
+      }
     }
   }
 

--- a/apps/web/src/app/onboarding/wizard.tsx
+++ b/apps/web/src/app/onboarding/wizard.tsx
@@ -1271,9 +1271,17 @@ export default function OnboardingWizard() {
                             <DeviceFlowPoll
                               userCode={deviceFlowCode}
                               verificationUri={deviceFlowUri!}
-                              onAuthorized={() => {
+                              onAuthorized={async () => {
                                 setAiKeyVerified(true);
                                 setDeviceFlowPolling(false);
+                                // Persist AI provider choice to the DB
+                                try {
+                                  await fetch('/api/onboarding', {
+                                    method: 'PATCH',
+                                    headers: { 'Content-Type': 'application/json' },
+                                    body: JSON.stringify({ aiProvider: 'github-copilot' }),
+                                  });
+                                } catch { /* ignore */ }
                               }}
                               onExpired={() => {
                                 setDeviceFlowCode(null);
@@ -1376,12 +1384,22 @@ export default function OnboardingWizard() {
                 </p>
                 <PrimaryBtn
                   onClick={async () => {
-                    // Mark onboarding complete
+                    // Persist all onboarding state and mark complete
                     try {
                       await fetch('/api/onboarding', {
                         method: 'PATCH',
                         headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify({ onboardingComplete: true }),
+                        body: JSON.stringify({
+                          onboardingComplete: true,
+                          timezone,
+                          plan,
+                          windowStart,
+                          messengers,
+                          skills,
+                          aiProvider,
+                          vmSize,
+                          ...(selectedSubId ? { azureSubscriptionId: selectedSubId } : {}),
+                        }),
                       });
                     } catch { /* ignore */ }
                     goTo(9);


### PR DESCRIPTION
Closes #223

## Problem
After completing onboarding, the redirect to the dashboard didn't carry over the messenger/AI provider state cleanly. Users saw 'Not configured' for things they just set up.

## Root Causes & Fixes

### 1. Incomplete state persistence on completion
The 'Continue to Dashboard' button only sent `onboardingComplete: true` without re-persisting the wizard state (AI provider, messengers, skills, timezone, etc.).

**Fix:** The final PATCH now includes all wizard state fields.

### 2. GitHub Copilot device flow didn't persist ai_provider
When the Copilot OAuth device flow succeeded during onboarding, the token was saved to the sidecar but `users.ai_provider` was never updated. The dashboard had no way to know to look for a Copilot token.

**Fix:** The `onAuthorized` callback now PATCHes `ai_provider: 'github-copilot'` to the DB.

### 3. ConnectionsCard hid user-selected messengers
On free plan, the card filtered out any messenger that wasn't already connected or configured — including ones the user had *just* selected during onboarding but hadn't connected yet.

**Fix:** User-selected messengers (from the `messengers` array in the DB) are now always displayed.

### 4. Dashboard didn't check provider_tokens broadly
The dashboard only checked `provider_tokens` for GitHub Copilot specifically. If a provider's token was stored there for any reason, it would be missed.

**Fix:** Added a fallback loop that checks `provider_tokens` for all known providers when `ai_api_key` is missing.

## Files Changed
- `apps/web/src/app/onboarding/wizard.tsx` — persist full state on completion + save ai_provider on Copilot auth
- `apps/web/src/app/dashboard/components/connections-card.tsx` — show user-selected messengers even when not yet connected
- `apps/web/src/app/dashboard/page.tsx` — broader provider_tokens fallback