### PR TITLE
fix: filter ARM64 VM sizes from Azure provisioning

### DIFF
--- a/apps/web/src/app/api/azure/vm-sizes/route.ts
+++ b/apps/web/src/app/api/azure/vm-sizes/route.ts
@@ -123,6 +123,10 @@ export async function GET(req: NextRequest) {
 
       if (vCPUs < 1 || vCPUs > 8 || memoryGB < 1 || memoryGB > 32) continue;
 
+      // Filter out ARM64-only SKUs — our default image is x64
+      const cpuArch = caps.get('CpuArchitectureType') || 'x64';
+      if (cpuArch.toLowerCase() === 'arm64') continue;
+
       // Check quota availability
       const familyKey = (sku.family || caps.get('VMDeploymentTypes') || '').toLowerCase();
       // Try common family patterns for quota lookup

--- a/apps/web/src/lib/vm/provisioning-steps.ts
+++ b/apps/web/src/lib/vm/provisioning-steps.ts
@@ -391,6 +391,18 @@ export async function advanceProvisioning(assistant: Assistant): Promise<Assista
       const nicId = `/subscriptions/${subscriptionId}/resourceGroups/${rgName}/providers/Microsoft.Network/networkInterfaces/${vmName}-nic`;
       const vmPath = `${base}/Microsoft.Compute/virtualMachines/${vmName}?api-version=${COMPUTE_API}`;
 
+      // Safety check: reject known ARM64-only size families (our image is x64)
+      const ARM64_PREFIXES = ['Standard_B2ps', 'Standard_B4ps', 'Standard_B8ps', 'Standard_B16ps',
+        'Standard_B2pts', 'Standard_B4pts', 'Standard_B8pts', 'Standard_B16pts',
+        'Standard_Dpls', 'Standard_Dpds', 'Standard_Dplds', 'Standard_Epls', 'Standard_Epds'];
+      const resolvedSize = vmSize ?? 'Standard_D2als_v7';
+      if (ARM64_PREFIXES.some(p => resolvedSize.startsWith(p))) {
+        console.warn(`[provisioning] ARM64 VM size ${resolvedSize} is incompatible with x64 image, falling back to Standard_B2s`);
+        return await updateAssistant(assistant.id, {
+          provisioning_data: { ...pd, vmSize: 'Standard_B2s' } as any,
+        });
+      }
+
       // Check if already exists
       const state = await checkProvisioningState(token, vmPath);
       if (state === 'Succeeded') {


### PR DESCRIPTION
## Problem
Users can select ARM64-only VM sizes (like `Standard_B4ps_v2`) during onboarding, but our default Ubuntu image is x64. This causes the `create_vm` provisioning step to fail with:

> Cannot create a VM of size 'Standard_B4ps_v2' because this VM size only supports a CPU Architecture of 'Arm64', but an image or disk with CPU Architecture 'x64' was given.

The dashboard shows 'Provisioning step failed. Retrying automatically.' in an infinite loop (bug #204).

## Fix
1. **VM size picker** (`/api/azure/vm-sizes`): Filters out SKUs where `CpuArchitectureType` is `Arm64`
2. **Provisioning safety net** (`provisioning-steps.ts`): If an ARM64 size somehow reaches `create_vm`, it auto-falls back to `Standard_B2s` instead of failing forever

## Testing
- Confirmed Julie's account was stuck with `Standard_B4ps_v2` - patched to `Standard_B2s` in DB
- ARM filter uses Azure SKU capability `CpuArchitectureType` which is present on all VM SKUs

Partially addresses #204

Partially addresses #204