### PR TITLE
fix: show messengers when user selection is empty + AI model reconnect state

### DIFF
--- a/apps/web/src/app/dashboard/components/ai-model-card.tsx
+++ b/apps/web/src/app/dashboard/components/ai-model-card.tsx
@@ -24,6 +24,7 @@ export function AiModelCard({
   disabled?: boolean;
 }) {
   const configured = !!provider && !!apiKey;
+  const providerKnown = !!provider && !apiKey;
   const label = provider ? PROVIDER_LABELS[provider] ?? provider : null;
 
   return (
@@ -37,6 +38,13 @@ export function AiModelCard({
             Key: {maskKey(apiKey!)}
           </p>
         </>
+      ) : providerKnown ? (
+        <>
+          <p className="text-2xl font-bold text-indigo-400 mb-2">{label}</p>
+          <p className="text-sm text-amber-400 mb-4">
+            Token expired or missing. Please reconnect.
+          </p>
+        </>
       ) : (
         <>
           <p className="text-sm text-slate-400 mb-4">
@@ -48,14 +56,14 @@ export function AiModelCard({
 
       {disabled ? (
         <span className="inline-block rounded-lg bg-slate-700 px-4 py-2 text-sm text-slate-500 cursor-not-allowed">
-          {configured ? "Change" : "Set up AI provider"}
+          {configured ? "Change" : providerKnown ? "Reconnect" : "Set up AI provider"}
         </span>
       ) : (
         <Link
           href="/dashboard/settings"
           className="inline-block rounded-lg bg-indigo-600 px-4 py-2 text-sm text-white hover:bg-indigo-500"
         >
-          {configured ? "Change" : "Set up AI provider"}
+          {configured ? "Change" : providerKnown ? "Reconnect" : "Set up AI provider"}
         </Link>
       )}
     </div>

--- a/apps/web/src/app/dashboard/components/connections-card.tsx
+++ b/apps/web/src/app/dashboard/components/connections-card.tsx
@@ -224,8 +224,11 @@ export function ConnectionsCard({
             }
 
             // For free plan, hide messengers that are neither selected, connected,
-            // configured, nor have a telegram bot ready
-            if (isFree && !connected && !configured && !isUserSelected && !(m === "telegram" && telegramBotUsername)) {
+            // configured, nor have a telegram bot ready.
+            // Exception: if NO messengers are selected at all (empty array from
+            // broken onboarding), show everything so the user can connect.
+            const hasAnySelected = messengers.length > 0;
+            if (isFree && hasAnySelected && !connected && !configured && !isUserSelected && !(m === "telegram" && telegramBotUsername)) {
               return null;
             }
 


### PR DESCRIPTION
Closes #262

## Problem
1. **Connections card empty** - Free plan users with an empty `messengers` array see zero messenger rows. The free-plan filter hides all messengers that aren't user-selected, connected, or configured. If onboarding didn't save the selection (pre-#259), users are stuck.

2. **AI Model shows 'Not configured'** - When `ai_provider` is set but the token is missing/expired (e.g. GitHub Copilot OAuth token wasn't persisted), the card shows generic 'Not configured' with no indication that a provider was previously set up.

## Fix
1. **Connections card**: When `messengers` array is empty, bypass the free-plan filter and show all available messengers with Connect buttons
2. **AI Model card**: New intermediate state - shows the provider name with an amber 'Token expired or missing. Please reconnect.' message and a 'Reconnect' button

## Before/After
- Before: Empty connections card, generic 'Not configured' AI model
- After: Telegram + WhatsApp shown with Connect buttons, AI model shows 'GitHub Copilot' with reconnect prompt