### PR TITLE
fix: move AI provider setup above messengers in onboarding wizard

### DIFF
--- a/apps/web/src/app/onboarding/wizard.tsx
+++ b/apps/web/src/app/onboarding/wizard.tsx
@@ -1196,25 +1196,8 @@ export default function OnboardingWizard() {
                 </div>
               </div>
 
-              {/* Right: messenger setup cards */}
+              {/* AI Provider setup - configure before messengers */}
               <div className="space-y-3">
-                <h3 className="text-xs font-bold uppercase tracking-wider text-slate-500 flex items-center gap-2">
-                  <MessageCircle className="w-3 h-3" />
-                  Connect Messengers
-                </h3>
-                <div className="space-y-3">
-                  {messengers.map((id) => (
-                    <MessengerSetupCard
-                      key={id}
-                      messengerId={id}
-                      isServerActive={serverActive}
-                      onReady={(platform, link) => setBotLinks((prev) => ({ ...prev, [platform]: link }))}
-                    />
-                  ))}
-                </div>
-              </div>
-              {/* AI Provider setup */}
-              <div className="space-y-3 mt-4">
                 <h3 className="text-xs font-bold uppercase tracking-wider text-slate-500 flex items-center gap-2">
                   <Key className="w-3 h-3" />
                   AI Provider
@@ -1372,6 +1355,23 @@ export default function OnboardingWizard() {
                   {!serverActive && (
                     <p className="text-xs text-slate-400">Waiting for server to start...</p>
                   )}
+                </div>
+              </div>
+              {/* Messenger setup cards - after AI provider */}
+              <div className="space-y-3">
+                <h3 className="text-xs font-bold uppercase tracking-wider text-slate-500 flex items-center gap-2">
+                  <MessageCircle className="w-3 h-3" />
+                  Connect Messengers
+                </h3>
+                <div className="space-y-3">
+                  {messengers.map((id) => (
+                    <MessengerSetupCard
+                      key={id}
+                      messengerId={id}
+                      isServerActive={serverActive}
+                      onReady={(platform, link) => setBotLinks((prev) => ({ ...prev, [platform]: link }))}
+                    />
+                  ))}
                 </div>
               </div>
             </div>


### PR DESCRIPTION
Closes #274

## Problem
In the Setup & Connect step, the messenger setup cards appear above the AI provider setup. But without an AI provider configured, the messenger bot can receive messages but has no model to respond with.

## Fix
Swapped the order so AI Provider setup comes first:
1. Server provisioning progress (left column)
2. AI Provider setup (right column, top) 
3. Messenger setup (right column, bottom)

Users naturally configure top-to-bottom, so they'll set up their AI provider before connecting a messenger.