### PR TITLE
Fix: GitHub Copilot device flow auth not completing

### DIFF
--- a/apps/sidecar/dist/routes/openclaw.js
+++ b/apps/sidecar/dist/routes/openclaw.js
@@ -188,6 +188,20 @@ router.get('/openclaw/github-copilot-device-status', async (_req, res) => {
     try {
         const stored = deviceFlowStore['copilot-device'];
         if (!stored) {
+            // No device flow in progress - check if auth was already completed
+            // (handles page reload after successful auth, or previous session)
+            const CLAW_USER = process.env.OPENCLAW_USER || 'claw';
+            const agentAuthPath = path.join('/home', CLAW_USER, '.openclaw', 'agents', 'main', 'agent', 'auth-profiles.json');
+            if (fs.existsSync(agentAuthPath)) {
+                try {
+                    const profiles = JSON.parse(fs.readFileSync(agentAuthPath, 'utf8'));
+                    if (profiles?.profiles?.['github-copilot:github']?.token) {
+                        res.json({ status: 'authorized', model: 'github-copilot/claude-opus-4.6' });
+                        return;
+                    }
+                }
+                catch { }
+            }
             res.json({ status: 'error', error: 'No device flow in progress. Call device-start first.' });
             return;
         }

--- a/apps/sidecar/dist/sidecar.cjs
+++ b/apps/sidecar/dist/sidecar.cjs
@@ -270,6 +270,18 @@ router2.get("/openclaw/github-copilot-device-status", async (_req, res) => {
   try {
     const stored = deviceFlowStore["copilot-device"];
     if (!stored) {
+      const CLAW_USER2 = process.env.OPENCLAW_USER || "claw";
+      const agentAuthPath = path.join("/home", CLAW_USER2, ".openclaw", "agents", "main", "agent", "auth-profiles.json");
+      if (fs.existsSync(agentAuthPath)) {
+        try {
+          const profiles = JSON.parse(fs.readFileSync(agentAuthPath, "utf8"));
+          if (profiles?.profiles?.["github-copilot:github"]?.token) {
+            res.json({ status: "authorized", model: "github-copilot/claude-opus-4.6" });
+            return;
+          }
+        } catch {
+        }
+      }
       res.json({ status: "error", error: "No device flow in progress. Call device-start first." });
       return;
     }

--- a/apps/sidecar/src/routes/openclaw.ts
+++ b/apps/sidecar/src/routes/openclaw.ts
@@ -157,6 +157,19 @@ router.get('/openclaw/github-copilot-device-status', async (_req: Request, res: 
   try {
     const stored = deviceFlowStore['copilot-device'];
     if (!stored) {
+      // No device flow in progress - check if auth was already completed
+      // (handles page reload after successful auth, or previous session)
+      const CLAW_USER = process.env.OPENCLAW_USER || 'claw';
+      const agentAuthPath = path.join('/home', CLAW_USER, '.openclaw', 'agents', 'main', 'agent', 'auth-profiles.json');
+      if (fs.existsSync(agentAuthPath)) {
+        try {
+          const profiles = JSON.parse(fs.readFileSync(agentAuthPath, 'utf8'));
+          if (profiles?.profiles?.['github-copilot:github']?.token) {
+            res.json({ status: 'authorized', model: 'github-copilot/claude-opus-4.6' });
+            return;
+          }
+        } catch {}
+      }
       res.json({ status: 'error', error: 'No device flow in progress. Call device-start first.' });
       return;
     }

--- a/apps/web/src/app/onboarding/wizard.tsx
+++ b/apps/web/src/app/onboarding/wizard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState, useCallback, useRef } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
 import {
   Sparkles, Cloud, Server, CreditCard, MessageSquare,
@@ -78,28 +78,50 @@ function DeviceFlowPoll({ userCode, verificationUri, onAuthorized, onExpired, on
   onExpired: () => void;
   onError: (msg: string) => void;
 }) {
+  const [checking, setChecking] = useState(false);
+  const [pollCount, setPollCount] = useState(0);
+  const onAuthorizedRef = useRef(onAuthorized);
+  const onExpiredRef = useRef(onExpired);
+  const onErrorRef = useRef(onError);
+  onAuthorizedRef.current = onAuthorized;
+  onExpiredRef.current = onExpired;
+  onErrorRef.current = onError;
+
+  const checkStatus = useCallback(async () => {
+    try {
+      const res = await fetch('/api/assistant/copilot-device-status');
+      const data = await res.json();
+      if (data.status === 'authorized') { onAuthorizedRef.current(); return true; }
+      if (data.status === 'expired') { onExpiredRef.current(); return true; }
+      if (data.status === 'error' && !data.error?.includes('No device flow')) {
+        onErrorRef.current(data.error || 'Unknown error'); return true;
+      }
+      return false;
+    } catch {
+      return false;
+    }
+  }, []);
+
   useEffect(() => {
     let cancelled = false;
     const poll = async () => {
       while (!cancelled) {
-        await new Promise(r => setTimeout(r, 4000));
+        await new Promise(r => setTimeout(r, 5000));
         if (cancelled) return;
-        try {
-          const res = await fetch('/api/assistant/copilot-device-status');
-          const data = await res.json();
-          if (cancelled) return;
-          if (data.status === 'authorized') { onAuthorized(); return; }
-          if (data.status === 'expired') { onExpired(); return; }
-          if (data.status === 'error') { onError(data.error || 'Unknown error'); return; }
-          // pending — continue polling
-        } catch {
-          // network error, keep polling
-        }
+        const done = await checkStatus();
+        if (done || cancelled) return;
+        setPollCount(c => c + 1);
       }
     };
     poll();
     return () => { cancelled = true; };
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [checkStatus]);
+
+  const handleManualCheck = async () => {
+    setChecking(true);
+    await checkStatus();
+    setChecking(false);
+  };
 
   return (
     <div className="space-y-3">
@@ -111,17 +133,28 @@ function DeviceFlowPoll({ userCode, verificationUri, onAuthorized, onExpired, on
           {userCode}
         </span>
       </div>
-      <a
-        href={verificationUri}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-violet-600 hover:bg-violet-500 text-sm font-medium text-white transition-colors"
-      >
-        Open GitHub <ExternalLink className="w-3 h-3" />
-      </a>
+      <div className="flex flex-wrap gap-2">
+        <a
+          href={verificationUri}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-violet-600 hover:bg-violet-500 text-sm font-medium text-white transition-colors"
+        >
+          Open GitHub <ExternalLink className="w-3 h-3" />
+        </a>
+        <button
+          type="button"
+          onClick={handleManualCheck}
+          disabled={checking}
+          className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-slate-700 hover:bg-slate-600 text-sm font-medium text-white transition-colors disabled:opacity-50"
+        >
+          {checking ? <Loader2 className="w-3 h-3 animate-spin" /> : <Check className="w-3 h-3" />}
+          I've authorized, check now
+        </button>
+      </div>
       <div className="flex items-center gap-2 text-xs text-slate-400">
         <Loader2 className="w-3 h-3 animate-spin" />
-        Waiting for authorization...
+        Checking automatically{pollCount > 0 ? ` (${pollCount} checks)` : ''}...
       </div>
     </div>
   );
@@ -279,6 +312,30 @@ export default function OnboardingWizard() {
           // Restore AI provider from user profile
           if (data.aiProvider) {
             setAiProvider(data.aiProvider as typeof aiProvider);
+          }
+          // Restore device flow state from sessionStorage
+          try {
+            const savedFlow = sessionStorage.getItem('sw_device_flow');
+            if (savedFlow && data.aiProvider === 'github-copilot') {
+              const { userCode, verificationUri } = JSON.parse(savedFlow);
+              if (userCode && verificationUri) {
+                setDeviceFlowCode(userCode);
+                setDeviceFlowUri(verificationUri);
+                setDeviceFlowPolling(true);
+              }
+            }
+          } catch {}
+          // Check if copilot auth is already complete
+          if (data.aiProvider === 'github-copilot') {
+            try {
+              const statusRes = await fetch('/api/assistant/copilot-device-status');
+              const statusData = await statusRes.json();
+              if (statusData.status === 'authorized') {
+                setAiKeyVerified(true);
+                setDeviceFlowPolling(false);
+                sessionStorage.removeItem('sw_device_flow');
+              }
+            } catch {}
           }
           setStep((currentStep) => {
             if (currentStep < 7) return 7;
@@ -1234,6 +1291,11 @@ export default function OnboardingWizard() {
                                       setDeviceFlowCode(data.userCode);
                                       setDeviceFlowUri(data.verificationUri);
                                       setDeviceFlowPolling(true);
+                                      // Persist for page reload recovery
+                                      sessionStorage.setItem('sw_device_flow', JSON.stringify({
+                                        userCode: data.userCode,
+                                        verificationUri: data.verificationUri,
+                                      }));
                                     } else {
                                       setDeviceFlowError(data.error || 'Failed to start device flow');
                                     }
@@ -1257,6 +1319,7 @@ export default function OnboardingWizard() {
                               onAuthorized={async () => {
                                 setAiKeyVerified(true);
                                 setDeviceFlowPolling(false);
+                                sessionStorage.removeItem('sw_device_flow');
                                 // Persist AI provider choice to the DB
                                 try {
                                   await fetch('/api/onboarding', {


### PR DESCRIPTION
## Problem

Device flow auth for GitHub Copilot never picks up that authorization is complete. User enters code on GitHub, but UI stays stuck on 'Waiting for authorization...'. See #280 for full root cause analysis.

## Changes

### Sidecar (`apps/sidecar/src/routes/openclaw.ts`)
- `GET /openclaw/github-copilot-device-status`: When no device flow is in progress (memory lost after restart), checks if `auth-profiles.json` already has a valid GitHub Copilot token. Returns `authorized` if found.

### Frontend (`apps/web/src/app/onboarding/wizard.tsx`)
- **sessionStorage persistence**: Device flow code + verification URI saved to `sw_device_flow` in sessionStorage. Restored on page reload.
- **Manual check button**: "I've authorized, check now" button for immediate one-shot status check. No more waiting for poll cycle.
- **Poll interval**: Changed from 4s to 5s (GitHub's minimum required interval).
- **Callback refs**: `onAuthorized`/`onExpired`/`onError` stored in refs to prevent stale closures.
- **Page load auth check**: When VM is active + provider is github-copilot, auto-checks device status to detect previously completed flows.
- **Cleanup**: sessionStorage cleared on successful auth.
- **Poll counter**: Shows number of checks to give user confidence polling is active.

Fixes #280