### PR TITLE
Fix mobile layout overflow and add usage tracking

### DIFF
--- a/apps/sidecar/dist/sidecar.cjs
+++ b/apps/sidecar/dist/sidecar.cjs
@@ -140,7 +140,7 @@ var execAsync2 = (0, import_util2.promisify)(import_child_process2.exec);
 var router2 = (0, import_express2.Router)();
 var deviceFlowStore = {};
 async function getOpenclawStatus() {
-  let running = false;
+  let running2 = false;
   let version = "unknown";
   let uptime = "unknown";
   try {
@@ -150,22 +150,22 @@ async function getOpenclawStatus() {
   }
   try {
     await execAsync2("systemctl is-active openclaw");
-    running = true;
+    running2 = true;
   } catch {
     try {
       await execAsync2("pgrep -f openclaw");
-      running = true;
+      running2 = true;
     } catch {
     }
   }
-  if (running) {
+  if (running2) {
     try {
       const { stdout } = await execAsync2("systemctl show openclaw --property=ActiveEnterTimestamp --value");
       uptime = stdout.trim() || "unknown";
     } catch {
     }
   }
-  return { running, version, uptime };
+  return { running: running2, version, uptime };
 }
 router2.get("/openclaw/status", async (_req, res) => {
   const status = await getOpenclawStatus();
@@ -1249,6 +1249,99 @@ router6.get("/messaging/whatsapp/qr", async (_req, res) => {
 });
 var messaging_default = router6;
 
+// src/services/usage-tracker.ts
+var import_child_process5 = require("child_process");
+var import_fs3 = require("fs");
+var import_promises3 = require("fs/promises");
+var import_path4 = require("path");
+var DEFAULT_LOG_DIRS = [
+  (0, import_path4.join)(process.env.HOME || "/home/claw", ".openclaw/agents/main/agent/logs"),
+  "/home/claw/.openclaw/agents/main/agent/logs"
+];
+var SIDECAR_PORT = parseInt(process.env.PORT || "8787", 10);
+var SIDECAR_TOKEN = process.env.SIDECAR_TOKEN || "";
+var MESSAGE_PATTERNS = [
+  /\[inbound\]/i,
+  /\[outbound\]/i,
+  /\bmessage\s+(sent|received|delivered)\b/i,
+  /\bhandleInbound\b/i,
+  /\bhandleOutbound\b/i,
+  /\b(telegram|whatsapp|discord|slack|signal)\b.*\b(send|recv|message)\b/i
+];
+async function findLogFile() {
+  const explicit = process.env.OPENCLAW_LOG_PATH;
+  if (explicit) {
+    if ((0, import_fs3.existsSync)(explicit)) return explicit;
+    console.warn(`[usage-tracker] OPENCLAW_LOG_PATH=${explicit} not found`);
+  }
+  for (const dir of DEFAULT_LOG_DIRS) {
+    if (!(0, import_fs3.existsSync)(dir)) continue;
+    try {
+      const files = await (0, import_promises3.readdir)(dir);
+      if (files.includes("agent.log")) return (0, import_path4.join)(dir, "agent.log");
+      const logFile = files.find((f) => f.endsWith(".log"));
+      if (logFile) return (0, import_path4.join)(dir, logFile);
+    } catch {
+    }
+  }
+  return null;
+}
+async function incrementUsage(messages = 1) {
+  try {
+    const url = `http://127.0.0.1:${SIDECAR_PORT}/usage/increment`;
+    const headers = { "Content-Type": "application/json" };
+    if (SIDECAR_TOKEN) {
+      headers["Authorization"] = `Bearer ${SIDECAR_TOKEN}`;
+    }
+    await fetch(url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ messages })
+    });
+  } catch (err) {
+    console.warn("[usage-tracker] increment failed:", err.message);
+  }
+}
+function isMessageLine(line) {
+  return MESSAGE_PATTERNS.some((pat) => pat.test(line));
+}
+var running = false;
+async function startUsageTracker() {
+  if (running) return;
+  const logFile = await findLogFile();
+  if (!logFile) {
+    console.warn("[usage-tracker] No OpenClaw log file found. Usage tracking disabled.");
+    console.warn("[usage-tracker] Set OPENCLAW_LOG_PATH to enable.");
+    return;
+  }
+  console.log(`[usage-tracker] Tailing ${logFile}`);
+  running = true;
+  const tail = (0, import_child_process5.spawn)("tail", ["-F", "-n", "0", logFile], {
+    stdio: ["ignore", "pipe", "ignore"]
+  });
+  let buffer = "";
+  tail.stdout.on("data", (chunk) => {
+    buffer += chunk.toString();
+    const lines = buffer.split("\n");
+    buffer = lines.pop() || "";
+    for (const line of lines) {
+      if (line.trim() && isMessageLine(line)) {
+        incrementUsage(1);
+      }
+    }
+  });
+  tail.on("exit", (code) => {
+    console.warn(`[usage-tracker] tail exited with code ${code}, restarting in 5s...`);
+    running = false;
+    setTimeout(() => startUsageTracker(), 5e3);
+  });
+  tail.on("error", (err) => {
+    console.warn("[usage-tracker] tail error:", err.message);
+    running = false;
+    setTimeout(() => startUsageTracker(), 5e3);
+  });
+}
+
 // src/index.ts
 var app = (0, import_express7.default)();
 var PORT = parseInt(process.env.PORT || "8787", 10);
@@ -1262,5 +1355,8 @@ app.use(messaging_default);
 app.use(usage_default);
 app.listen(PORT, "0.0.0.0", () => {
   console.log(`[sidecar] listening on port ${PORT}`);
+  startUsageTracker().catch((err) => {
+    console.warn("[sidecar] usage tracker failed to start:", err.message);
+  });
 });
 var index_default = app;

--- a/apps/sidecar/src/index.ts
+++ b/apps/sidecar/src/index.ts
@@ -6,6 +6,7 @@ import heartbeatRouter from './routes/heartbeat';
 import skillsRouter from './routes/skills';
 import messagingRouter from './routes/messaging';
 import usageRouter from './routes/usage';
+import { startUsageTracker } from './services/usage-tracker';
 
 const app = express();
 const PORT = parseInt(process.env.PORT || '8787', 10);
@@ -25,6 +26,9 @@ app.use(usageRouter);
 
 app.listen(PORT, '0.0.0.0', () => {
   console.log(`[sidecar] listening on port ${PORT}`);
+  startUsageTracker().catch((err) => {
+    console.warn('[sidecar] usage tracker failed to start:', err.message);
+  });
 });
 
 export default app;

--- a/apps/sidecar/src/services/usage-tracker.ts
+++ b/apps/sidecar/src/services/usage-tracker.ts
@@ -1,0 +1,113 @@
+import { spawn } from 'child_process';
+import { existsSync } from 'fs';
+import { readdir } from 'fs/promises';
+import { join } from 'path';
+
+const DEFAULT_LOG_DIRS = [
+  join(process.env.HOME || '/home/claw', '.openclaw/agents/main/agent/logs'),
+  '/home/claw/.openclaw/agents/main/agent/logs',
+];
+
+const SIDECAR_PORT = parseInt(process.env.PORT || '8787', 10);
+const SIDECAR_TOKEN = process.env.SIDECAR_TOKEN || '';
+
+// Match log lines indicating message activity (inbound or outbound)
+// Typical OpenClaw log patterns for messages:
+const MESSAGE_PATTERNS = [
+  /\[inbound\]/i,
+  /\[outbound\]/i,
+  /\bmessage\s+(sent|received|delivered)\b/i,
+  /\bhandleInbound\b/i,
+  /\bhandleOutbound\b/i,
+  /\b(telegram|whatsapp|discord|slack|signal)\b.*\b(send|recv|message)\b/i,
+];
+
+async function findLogFile(): Promise<string | null> {
+  const explicit = process.env.OPENCLAW_LOG_PATH;
+  if (explicit) {
+    if (existsSync(explicit)) return explicit;
+    console.warn(`[usage-tracker] OPENCLAW_LOG_PATH=${explicit} not found`);
+  }
+
+  for (const dir of DEFAULT_LOG_DIRS) {
+    if (!existsSync(dir)) continue;
+    try {
+      const files = await readdir(dir);
+      // Prefer agent.log, then any .log file
+      if (files.includes('agent.log')) return join(dir, 'agent.log');
+      const logFile = files.find((f) => f.endsWith('.log'));
+      if (logFile) return join(dir, logFile);
+    } catch {
+      // skip
+    }
+  }
+  return null;
+}
+
+async function incrementUsage(messages = 1): Promise<void> {
+  try {
+    const url = `http://127.0.0.1:${SIDECAR_PORT}/usage/increment`;
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    if (SIDECAR_TOKEN) {
+      headers['Authorization'] = `Bearer ${SIDECAR_TOKEN}`;
+    }
+    await fetch(url, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ messages }),
+    });
+  } catch (err) {
+    // Non-fatal: usage tracking is best-effort
+    console.warn('[usage-tracker] increment failed:', (err as Error).message);
+  }
+}
+
+function isMessageLine(line: string): boolean {
+  return MESSAGE_PATTERNS.some((pat) => pat.test(line));
+}
+
+let running = false;
+
+export async function startUsageTracker(): Promise<void> {
+  if (running) return;
+
+  const logFile = await findLogFile();
+  if (!logFile) {
+    console.warn('[usage-tracker] No OpenClaw log file found. Usage tracking disabled.');
+    console.warn('[usage-tracker] Set OPENCLAW_LOG_PATH to enable.');
+    return;
+  }
+
+  console.log(`[usage-tracker] Tailing ${logFile}`);
+  running = true;
+
+  const tail = spawn('tail', ['-F', '-n', '0', logFile], {
+    stdio: ['ignore', 'pipe', 'ignore'],
+  });
+
+  let buffer = '';
+
+  tail.stdout.on('data', (chunk: Buffer) => {
+    buffer += chunk.toString();
+    const lines = buffer.split('\n');
+    buffer = lines.pop() || ''; // keep incomplete line in buffer
+
+    for (const line of lines) {
+      if (line.trim() && isMessageLine(line)) {
+        incrementUsage(1);
+      }
+    }
+  });
+
+  tail.on('exit', (code) => {
+    console.warn(`[usage-tracker] tail exited with code ${code}, restarting in 5s...`);
+    running = false;
+    setTimeout(() => startUsageTracker(), 5000);
+  });
+
+  tail.on('error', (err) => {
+    console.warn('[usage-tracker] tail error:', err.message);
+    running = false;
+    setTimeout(() => startUsageTracker(), 5000);
+  });
+}

--- a/apps/web/src/app/dashboard/components/ai-model-card.tsx
+++ b/apps/web/src/app/dashboard/components/ai-model-card.tsx
@@ -34,7 +34,7 @@ export function AiModelCard({
       {configured ? (
         <>
           <p className="text-2xl font-bold text-indigo-400 mb-2">{label}</p>
-          <p className="text-sm text-slate-400 mb-4 font-mono">
+          <p className="text-sm text-slate-400 mb-4 font-mono truncate">
             Key: {maskKey(apiKey!)}
           </p>
         </>

--- a/apps/web/src/app/dashboard/components/connections-card.tsx
+++ b/apps/web/src/app/dashboard/components/connections-card.tsx
@@ -241,7 +241,7 @@ export function ConnectionsCard({
             return (
               <div key={m}>
                 <div
-                  className={`flex items-center justify-between py-2 ${locked ? "opacity-60" : ""}`}
+                  className={`flex flex-wrap items-center justify-between gap-2 py-2 ${locked ? "opacity-60" : ""}`}
                 >
                   <div className="flex items-center gap-2.5">
                     {(() => { const Icon = config.icon; return <Icon className={`w-5 h-5 ${config.color}`} />; })()}
@@ -253,7 +253,7 @@ export function ConnectionsCard({
 
                   {/* Connected: show Open + Disconnect */}
                   {connected && (
-                    <div className="flex items-center gap-2">
+                    <div className="flex flex-wrap items-center gap-2">
                       {(telegramLink || botLink) && (
                         <a
                           href={telegramLink || botLink!}
@@ -268,7 +268,7 @@ export function ConnectionsCard({
                         type="button"
                         disabled={disconnecting === m || disabled}
                         onClick={() => handleDisconnect(m)}
-                        className="rounded-md bg-red-900/50 px-3 py-1.5 text-xs text-red-400 hover:bg-red-900/80 disabled:opacity-50"
+                        className="whitespace-nowrap rounded-md bg-red-900/50 px-3 py-1.5 text-xs text-red-400 hover:bg-red-900/80 disabled:opacity-50"
                       >
                         {disconnecting === m ? "Disconnecting…" : "Disconnect"}
                       </button>


### PR DESCRIPTION
## Changes

### Issue 1: Mobile layout overflow
- **connections-card.tsx**: Added `flex-wrap gap-2` to button containers and main row layout so buttons wrap on small screens instead of overflowing/clipping
- **ai-model-card.tsx**: Added `truncate` to API key display to prevent overflow

### Issue 2: Usage tracking not working
- **New file `apps/sidecar/src/services/usage-tracker.ts`**: Tails the OpenClaw gateway log file, detects inbound/outbound message events, and calls the existing `/usage/increment` endpoint
- **index.ts**: Wired up the tracker to start on sidecar boot
- Log path configurable via `OPENCLAW_LOG_PATH` env var (defaults to `~/.openclaw/agents/main/agent/logs/agent.log`)