### PR TITLE
fix: surface Azure OAuth error details for debugging

### DIFF
--- a/apps/web/src/app/api/auth/azure/callback/route.ts
+++ b/apps/web/src/app/api/auth/azure/callback/route.ts
@@ -34,18 +34,34 @@ export async function GET(request: NextRequest) {
   // Handle OAuth errors from Microsoft
   if (error) {
     console.error(`Azure OAuth error: ${error} - ${errorDescription}`);
-    const errorMsg = error === 'access_denied'
-      ? 'azure_denied'
-      : 'azure_error';
-    return NextResponse.redirect(new URL(`/onboarding?error=${errorMsg}`, request.url));
+    let errorMsg: string;
+    if (error === 'access_denied') {
+      errorMsg = 'azure_denied';
+    } else if (error === 'consent_required' || error === 'interaction_required') {
+      errorMsg = 'azure_consent_required';
+    } else {
+      errorMsg = 'azure_error';
+    }
+    // Pass the raw error code and description for debugging
+    const params = new URLSearchParams({ error: errorMsg });
+    if (errorDescription) params.set('error_detail', errorDescription.slice(0, 200));
+    if (error !== 'access_denied') params.set('error_code', error);
+    return NextResponse.redirect(new URL(`/onboarding?${params.toString()}`, request.url));
   }
 
   if (!code) {
     return NextResponse.redirect(new URL('/onboarding?error=missing_code', request.url));
   }
 
-  // CSRF check
+  // CSRF check — log details to help debug cookie-loss issues on mobile
   if (!state || !storedState || state !== storedState) {
+    console.error('Azure CSRF check failed:', {
+      hasState: !!state,
+      hasStoredState: !!storedState,
+      statePrefix: state?.split(':')[0],
+      storedStatePrefix: storedState?.split(':')[0],
+      match: state === storedState,
+    });
     return NextResponse.redirect(new URL('/onboarding?error=invalid_state', request.url));
   }
 

--- a/apps/web/src/app/onboarding/wizard.tsx
+++ b/apps/web/src/app/onboarding/wizard.tsx
@@ -239,10 +239,13 @@ export default function OnboardingWizard() {
     const errorParam = searchParams.get('error');
 
     if (errorParam) {
+      const errorDetail = searchParams.get('error_detail');
+      const errorCode = searchParams.get('error_code');
       const errorMessages: Record<string, string> = {
         azure_no_subscription: 'Could not connect to Azure. Make sure you have an active Azure subscription with your Microsoft account.',
         azure_denied: 'Azure sign-in was denied. Please try again and accept the permissions.',
-        azure_error: 'Azure sign-in failed. Please try again.',
+        azure_error: `Azure sign-in failed${errorCode ? ` (${errorCode})` : ''}. ${errorDetail || 'Please try again.'}`,
+        azure_consent_required: 'Azure requires additional consent. Please try again and accept all permissions when prompted.',
         azure_personal_account: 'Your Microsoft account could not get Azure management access. Make sure you have an active Azure subscription.',
         token_exchange: 'Sign-in failed. Please try again.',
         missing_code: 'Sign-in was incomplete. Please try again.',


### PR DESCRIPTION
## Problem
Azure sign-in shows a generic 'Azure sign-in failed. Please try again.' with no details about what actually went wrong, making it impossible to debug.

## Changes
- **Callback**: Pass the actual Microsoft error code and description through to the onboarding UI via query params (`error_code`, `error_detail`)
- **Callback**: Handle `consent_required` and `interaction_required` errors specifically with a more helpful message
- **Callback**: Add detailed logging for CSRF state mismatches (common on mobile Safari)
- **Wizard**: Display the actual error code/description so we can see what Microsoft is returning

## Also done (outside this PR)
- Added Azure Service Management API `user_impersonation` permission to the app registration (was missing - could cause consent failures)