### PR TITLE
fix: use .default ARM scope for personal Microsoft accounts

### DIFF
--- a/apps/web/src/app/api/auth/azure/callback/route.ts
+++ b/apps/web/src/app/api/auth/azure/callback/route.ts
@@ -134,7 +134,7 @@ export async function GET(request: NextRequest) {
         client_id: clientId,
         client_secret: clientSecret,
         redirect_uri: redirectUri,
-        scope: 'openid profile offline_access https://management.azure.com/user_impersonation',
+        scope: 'openid profile offline_access https://management.azure.com/.default',
       }),
     });
 

--- a/apps/web/src/app/api/auth/azure/route.ts
+++ b/apps/web/src/app/api/auth/azure/route.ts
@@ -42,7 +42,7 @@ export async function GET(request: NextRequest) {
       client_id: clientId,
       response_type: 'code',
       redirect_uri: redirectUri,
-      scope: 'openid profile offline_access https://management.azure.com/user_impersonation',
+      scope: 'openid profile offline_access https://management.azure.com/.default',
       state: statePayload,
       prompt: 'consent',
       // login_hint could be added here if we stored the email from step 1


### PR DESCRIPTION
## Problem
Azure sign-in fails with `invalid_scope` for personal Microsoft accounts:

> The scope 'openid profile offline_access https://management.azure.com/user_impersonation' does not exist.

## Root cause
Our app registration uses `signInAudience: AzureADandPersonalMicrosoftAccount` (converged app). The v2.0 endpoint doesn't support named permissions like `user_impersonation` for converged apps - you have to use `.default` instead.

## Fix
Change `https://management.azure.com/user_impersonation` → `https://management.azure.com/.default` in both the authorize redirect and token exchange. This matches what `token-store.ts` already uses for refresh tokens.