### PR TITLE
fix: use v1.0 OAuth endpoint for ARM access (converged app compat)

### DIFF
--- a/apps/web/src/app/api/auth/azure/callback/route.ts
+++ b/apps/web/src/app/api/auth/azure/callback/route.ts
@@ -121,11 +121,13 @@ export async function GET(request: NextRequest) {
   }
 
   if (isArm) {
-    // ─── Step 2 callback: Exchange code for ARM tokens ───
+    // ─── Step 2 callback: Exchange code for ARM tokens (v1.0 endpoint) ───
     // Extract tenant ID from state: "arm:<tid>:<random>"
     const tenantId = state.split(':')[1];
 
-    const tokenRes = await fetch(`https://login.microsoftonline.com/${tenantId}/oauth2/v2.0/token`, {
+    // Use v1.0 token endpoint to match the v1.0 authorize request.
+    // v1.0 uses `resource` instead of `scope`.
+    const tokenRes = await fetch(`https://login.microsoftonline.com/${tenantId}/oauth2/token`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
       body: new URLSearchParams({
@@ -134,7 +136,7 @@ export async function GET(request: NextRequest) {
         client_id: clientId,
         client_secret: clientSecret,
         redirect_uri: redirectUri,
-        scope: 'openid profile offline_access https://management.azure.com/.default',
+        resource: 'https://management.azure.com/',
       }),
     });
 

--- a/apps/web/src/app/api/auth/azure/route.ts
+++ b/apps/web/src/app/api/auth/azure/route.ts
@@ -37,19 +37,23 @@ export async function GET(request: NextRequest) {
     : `discover:${crypto.randomBytes(16).toString('hex')}`;
 
   if (step === 'arm' && tenantHint) {
-    // ─── Step 2: ARM consent through the user's specific tenant ───
+    // ─── Step 2: ARM consent through the user's specific tenant (v1.0 endpoint) ───
+    //
+    // We use the v1.0 OAuth endpoint here because the v2.0 endpoint does not
+    // support Azure Resource Manager scopes for converged apps
+    // (signInAudience: AzureADandPersonalMicrosoftAccount). The v1.0 endpoint
+    // uses `resource` instead of `scope` and works regardless of app audience.
     const params = new URLSearchParams({
       client_id: clientId,
       response_type: 'code',
       redirect_uri: redirectUri,
-      scope: 'openid profile offline_access https://management.azure.com/.default',
+      resource: 'https://management.azure.com/',
       state: statePayload,
       prompt: 'consent',
-      // login_hint could be added here if we stored the email from step 1
     });
 
     const response = NextResponse.redirect(
-      `https://login.microsoftonline.com/${tenantHint}/oauth2/v2.0/authorize?${params.toString()}`,
+      `https://login.microsoftonline.com/${tenantHint}/oauth2/authorize?${params.toString()}`,
     );
     response.cookies.set('azure_oauth_state', statePayload, {
       httpOnly: true,

--- a/apps/web/src/lib/providers/token-store.ts
+++ b/apps/web/src/lib/providers/token-store.ts
@@ -85,13 +85,13 @@ export async function refreshProviderToken(userId: string, provider: string) {
   if (provider === 'azure') {
     const tenantData = await getProviderToken(userId, 'azure_tenant');
     const tenantId = tenantData?.accessToken ?? 'organizations'; // accessToken field stores the tenant ID
-    refreshUrl = `https://login.microsoftonline.com/${tenantId}/oauth2/v2.0/token`;
+    refreshUrl = `https://login.microsoftonline.com/${tenantId}/oauth2/token`;
     refreshBody = {
       grant_type: 'refresh_token',
       refresh_token: existing.refreshToken,
       client_id: process.env.AZURE_CLIENT_ID!.trim(),
       client_secret: process.env.AZURE_CLIENT_SECRET!.trim(),
-      scope: 'https://management.azure.com/.default offline_access',
+      resource: 'https://management.azure.com/',
     };
   } else {
     const config = getRefreshConfig(provider, existing.refreshToken);
@@ -118,13 +118,13 @@ function getRefreshConfig(provider: string, refreshToken: string): { url: string
   switch (provider) {
     case 'azure':
       return {
-        url: 'https://login.microsoftonline.com/common/oauth2/v2.0/token',
+        url: 'https://login.microsoftonline.com/common/oauth2/token',
         body: {
           grant_type: 'refresh_token',
           refresh_token: refreshToken,
           client_id: process.env.AZURE_CLIENT_ID!.trim(),
           client_secret: process.env.AZURE_CLIENT_SECRET!.trim(),
-          scope: 'https://management.azure.com/.default offline_access',
+          resource: 'https://management.azure.com/',
         },
       };
     case 'digitalocean':


### PR DESCRIPTION
## Problem
Azure sign-in fails with `invalid_scope` for converged apps. Both `user_impersonation` and `.default` ARM scopes are rejected by the v2.0 authorize endpoint when the app's `signInAudience` is `AzureADandPersonalMicrosoftAccount`.

## Root cause
The v2.0 OAuth endpoint doesn't support first-party resource scopes (like ARM) for converged apps. This is a Microsoft limitation.

## Fix
Switch step 2 (ARM consent + token exchange) and token refresh to use the *v1.0* OAuth endpoint, which uses `resource=https://management.azure.com/` instead of `scope`. The v1.0 endpoint works regardless of app audience setting.

- Step 1 (tenant discovery) stays on v2.0 with just openid+profile - works fine for converged apps
- Step 2 (ARM) now uses v1.0 authorize + v1.0 token endpoint
- Token refresh also updated to v1.0 for consistency

Also reverted the app registration back to `AzureADandPersonalMicrosoftAccount` so personal Microsoft accounts can still sign in at step 1.