### PR TITLE
fix: simplify Azure auth to single-step work account flow

### DIFF
--- a/apps/web/src/app/api/auth/azure/callback/route.ts
+++ b/apps/web/src/app/api/auth/azure/callback/route.ts
@@ -18,11 +18,10 @@ function decodeJwt(token: string): Record<string, unknown> {
 }
 
 /**
- * Azure OAuth callback — handles both step 1 (tenant discovery) and step 2 (ARM token exchange).
+ * Azure OAuth callback — exchanges the authorization code for ARM tokens.
  *
- * The state cookie tells us which step we're in:
- *   - "discover:..." → Step 1: exchange code for ID token, extract tenant, redirect to step 2
- *   - "arm:<tid>:..." → Step 2: exchange code for ARM tokens, store them, done
+ * The app uses AzureADMultipleOrgs with the /organizations endpoint, so only
+ * work/school accounts can sign in. ARM scope is requested directly.
  */
 export async function GET(request: NextRequest) {
   const code = request.nextUrl.searchParams.get('code');
@@ -42,7 +41,6 @@ export async function GET(request: NextRequest) {
     } else {
       errorMsg = 'azure_error';
     }
-    // Pass the raw error code and description for debugging
     const params = new URLSearchParams({ error: errorMsg });
     if (errorDescription) params.set('error_detail', errorDescription.slice(0, 200));
     if (error !== 'access_denied') params.set('error_code', error);
@@ -53,7 +51,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.redirect(new URL('/onboarding?error=missing_code', request.url));
   }
 
-  // CSRF check — log details to help debug cookie-loss issues on mobile
+  // CSRF check
   if (!state || !storedState || state !== storedState) {
     console.error('Azure CSRF check failed:', {
       hasState: !!state,
@@ -69,139 +67,86 @@ export async function GET(request: NextRequest) {
   const clientSecret = process.env.AZURE_CLIENT_SECRET!.trim();
   const redirectUri = process.env.AZURE_REDIRECT_URI!.trim();
 
-  // Parse the state to determine which step we're in
-  const isDiscovery = state.startsWith('discover:');
-  const isArm = state.startsWith('arm:');
+  // Exchange code for ARM tokens via v2.0 endpoint
+  // Use /organizations which routes to the user's actual tenant
+  const tokenRes = await fetch('https://login.microsoftonline.com/organizations/oauth2/v2.0/token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      grant_type: 'authorization_code',
+      code,
+      client_id: clientId,
+      client_secret: clientSecret,
+      redirect_uri: redirectUri,
+      scope: 'openid profile offline_access https://management.azure.com/.default',
+    }),
+  });
 
-  if (isDiscovery) {
-    // ─── Step 1 callback: Exchange code for ID token, extract tenant ID ───
-    const tokenRes = await fetch('https://login.microsoftonline.com/common/oauth2/v2.0/token', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-      body: new URLSearchParams({
-        grant_type: 'authorization_code',
-        code,
-        client_id: clientId,
-        client_secret: clientSecret,
-        redirect_uri: redirectUri,
-        scope: 'openid profile',
-      }),
-    });
+  if (!tokenRes.ok) {
+    const errorBody = await tokenRes.text().catch(() => 'no body');
+    console.error(`Azure ARM token exchange failed: ${tokenRes.status}`, errorBody);
 
-    if (!tokenRes.ok) {
-      const errorBody = await tokenRes.text().catch(() => 'no body');
-      console.error(`Azure tenant discovery token exchange failed: ${tokenRes.status}`, errorBody);
-      return NextResponse.redirect(new URL('/onboarding?error=token_exchange', request.url));
+    if (errorBody.includes('AADSTS') || errorBody.includes('personal')) {
+      return NextResponse.redirect(new URL('/onboarding?error=azure_personal_account', request.url));
     }
+    return NextResponse.redirect(new URL('/onboarding?error=token_exchange', request.url));
+  }
 
-    const tokenData = await tokenRes.json();
-    const idToken = tokenData.id_token;
-    if (!idToken) {
-      console.error('Azure tenant discovery: no id_token in response');
-      return NextResponse.redirect(new URL('/onboarding?error=no_id_token', request.url));
-    }
+  const tokenData = await tokenRes.json();
 
+  // Extract tenant ID from the ID token for future token refreshes
+  const idToken = tokenData.id_token;
+  let tenantId = 'organizations';
+  if (idToken) {
     const claims = decodeJwt(idToken);
-    const tenantId = claims.tid as string;
-
-    if (!tenantId) {
-      console.error('Azure tenant discovery: no tid claim in ID token', claims);
-      return NextResponse.redirect(new URL('/onboarding?error=no_tenant', request.url));
+    if (claims.tid) {
+      tenantId = claims.tid as string;
     }
-
-    console.log(`Azure tenant discovered: ${tenantId} for user ${claims.preferred_username || claims.email || 'unknown'}`);
-
-    // Redirect to step 2: ARM consent through the user's specific tenant.
-    // Clear the discovery state cookie first.
-    const response = NextResponse.redirect(
-      new URL(`/api/auth/azure?step=arm&tenant=${tenantId}`, request.url),
-    );
-    response.cookies.delete('azure_oauth_state');
-    return response;
   }
 
-  if (isArm) {
-    // ─── Step 2 callback: Exchange code for ARM tokens (v1.0 endpoint) ───
-    // Extract tenant ID from state: "arm:<tid>:<random>"
-    const tenantId = state.split(':')[1];
-
-    // Use v1.0 token endpoint to match the v1.0 authorize request.
-    // v1.0 uses `resource` instead of `scope`.
-    const tokenRes = await fetch(`https://login.microsoftonline.com/${tenantId}/oauth2/token`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-      body: new URLSearchParams({
-        grant_type: 'authorization_code',
-        code,
-        client_id: clientId,
-        client_secret: clientSecret,
-        redirect_uri: redirectUri,
-        resource: 'https://management.azure.com/',
-      }),
-    });
-
-    if (!tokenRes.ok) {
-      const errorBody = await tokenRes.text().catch(() => 'no body');
-      console.error(`Azure ARM token exchange failed: ${tokenRes.status}`, errorBody);
-
-      // If ARM token fails, it might be a personal account that truly can't get ARM tokens.
-      // Provide a helpful error.
-      if (errorBody.includes('AADSTS') || errorBody.includes('personal')) {
-        return NextResponse.redirect(new URL('/onboarding?error=azure_personal_account', request.url));
-      }
-      return NextResponse.redirect(new URL('/onboarding?error=token_exchange', request.url));
-    }
-
-    const tokenData = await tokenRes.json();
-
-    // Get current user from session
-    const session = await getSession();
-    if (!session) {
-      return NextResponse.redirect(new URL('/auth/signin', request.url));
-    }
-
-    // Store ARM-scoped tokens
-    const expiresAt = tokenData.expires_in
-      ? new Date(Date.now() + tokenData.expires_in * 1000)
-      : null;
-
-    await saveProviderToken(
-      session.userId,
-      'azure',
-      tokenData.access_token,
-      tokenData.refresh_token,
-      expiresAt,
-    );
-
-    // Store the tenant ID for future token refreshes
-    await saveProviderToken(
-      session.userId,
-      'azure_tenant',
-      tenantId,
-      null,
-      null,
-    );
-
-    // Verify the account works by listing subscriptions
-    try {
-      const subs = await listSubscriptions(tokenData.access_token);
-      const active = subs.find((s) => s.state === 'Enabled');
-      if (active) {
-        console.log(`Azure connected: subscription ${active.id} (${active.displayName}) tenant ${tenantId}`);
-      } else {
-        console.warn('Azure connected but no active subscription found');
-      }
-    } catch (e) {
-      console.error('Azure subscription check failed (non-fatal):', e);
-    }
-
-    // Clear the state cookie and redirect to success
-    const response = NextResponse.redirect(new URL('/onboarding?connected=azure', request.url));
-    response.cookies.delete('azure_oauth_state');
-    return response;
+  // Get current user from session
+  const session = await getSession();
+  if (!session) {
+    return NextResponse.redirect(new URL('/auth/signin', request.url));
   }
 
-  // Unknown state format
-  console.error('Azure callback: unrecognized state format', state);
-  return NextResponse.redirect(new URL('/onboarding?error=invalid_state', request.url));
+  // Store ARM-scoped tokens
+  const expiresAt = tokenData.expires_in
+    ? new Date(Date.now() + tokenData.expires_in * 1000)
+    : null;
+
+  await saveProviderToken(
+    session.userId,
+    'azure',
+    tokenData.access_token,
+    tokenData.refresh_token,
+    expiresAt,
+  );
+
+  // Store the tenant ID for future token refreshes
+  await saveProviderToken(
+    session.userId,
+    'azure_tenant',
+    tenantId,
+    null,
+    null,
+  );
+
+  // Verify the account works by listing subscriptions
+  try {
+    const subs = await listSubscriptions(tokenData.access_token);
+    const active = subs.find((s) => s.state === 'Enabled');
+    if (active) {
+      console.log(`Azure connected: subscription ${active.id} (${active.displayName}) tenant ${tenantId}`);
+    } else {
+      console.warn('Azure connected but no active subscription found');
+    }
+  } catch (e) {
+    console.error('Azure subscription check failed (non-fatal):', e);
+  }
+
+  // Clear the state cookie and redirect to success
+  const response = NextResponse.redirect(new URL('/onboarding?connected=azure', request.url));
+  response.cookies.delete('azure_oauth_state');
+  return response;
 }

--- a/apps/web/src/app/api/auth/azure/route.ts
+++ b/apps/web/src/app/api/auth/azure/route.ts
@@ -2,23 +2,15 @@ import { NextRequest, NextResponse } from 'next/server';
 import crypto from 'crypto';
 
 /**
- * Azure OAuth — Step 1 (tenant discovery) or Step 2 (ARM consent).
+ * Azure OAuth — Single-step ARM consent.
  *
- * Problem: Personal Microsoft accounts (@outlook.com, @hotmail.com, etc.) cannot
- * get ARM tokens through the /common endpoint because Microsoft treats them as
- * consumer accounts. But every personal account that has an Azure subscription
- * also has a work/school identity inside an auto-created Azure AD tenant.
+ * The app registration is set to AzureADMultipleOrgs (work/school accounts only)
+ * which allows requesting ARM scopes directly via the v2.0 endpoint. Users must
+ * sign in with a work/school account (e.g. admin@shiftworker.ai), not a personal
+ * Microsoft account (@outlook.com, @hotmail.com).
  *
- * Solution — two-step sign-in:
- *   Step 1: Redirect to /common with just openid+profile scope (works for ALL
- *           account types). The callback extracts the tenant ID from the ID token.
- *   Step 2: Redirect again through /{{tenant-id}} with ARM scope. Going through
- *           the user's specific tenant makes Microsoft recognize their work/school
- *           identity and issue ARM tokens, even for personal accounts.
- *
- * Query params:
- *   ?step=arm&tenant=<tid>  — Skip to step 2 (ARM consent) with a known tenant.
- *   (none)                  — Start at step 1 (tenant discovery).
+ * Personal Microsoft accounts cannot get ARM tokens regardless of the OAuth
+ * endpoint version (v1.0 or v2.0) when going through the MSA tenant.
  */
 export async function GET(request: NextRequest) {
   const clientId = process.env.AZURE_CLIENT_ID?.trim();
@@ -28,55 +20,19 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'Azure OAuth not configured' }, { status: 500 });
   }
 
-  const step = request.nextUrl.searchParams.get('step');
-  const tenantHint = request.nextUrl.searchParams.get('tenant');
+  const statePayload = `arm:common:${crypto.randomBytes(16).toString('hex')}`;
 
-  // Anti-CSRF state token — encode the step so the callback knows what to do
-  const statePayload = step === 'arm' && tenantHint
-    ? `arm:${tenantHint}:${crypto.randomBytes(16).toString('hex')}`
-    : `discover:${crypto.randomBytes(16).toString('hex')}`;
-
-  if (step === 'arm' && tenantHint) {
-    // ─── Step 2: ARM consent through the user's specific tenant (v1.0 endpoint) ───
-    //
-    // We use the v1.0 OAuth endpoint here because the v2.0 endpoint does not
-    // support Azure Resource Manager scopes for converged apps
-    // (signInAudience: AzureADandPersonalMicrosoftAccount). The v1.0 endpoint
-    // uses `resource` instead of `scope` and works regardless of app audience.
-    const params = new URLSearchParams({
-      client_id: clientId,
-      response_type: 'code',
-      redirect_uri: redirectUri,
-      resource: 'https://management.azure.com/',
-      state: statePayload,
-      prompt: 'consent',
-    });
-
-    const response = NextResponse.redirect(
-      `https://login.microsoftonline.com/${tenantHint}/oauth2/authorize?${params.toString()}`,
-    );
-    response.cookies.set('azure_oauth_state', statePayload, {
-      httpOnly: true,
-      secure: process.env.NODE_ENV === 'production',
-      sameSite: 'lax',
-      maxAge: 600,
-      path: '/',
-    });
-    return response;
-  }
-
-  // ─── Step 1: Tenant discovery via /common (works for all account types) ───
   const params = new URLSearchParams({
     client_id: clientId,
     response_type: 'code',
     redirect_uri: redirectUri,
-    scope: 'openid profile',
+    scope: 'openid profile offline_access https://management.azure.com/.default',
     state: statePayload,
     prompt: 'select_account',
   });
 
   const response = NextResponse.redirect(
-    `https://login.microsoftonline.com/common/oauth2/v2.0/authorize?${params.toString()}`,
+    `https://login.microsoftonline.com/organizations/oauth2/v2.0/authorize?${params.toString()}`,
   );
   response.cookies.set('azure_oauth_state', statePayload, {
     httpOnly: true,

--- a/apps/web/src/app/onboarding/wizard.tsx
+++ b/apps/web/src/app/onboarding/wizard.tsx
@@ -244,9 +244,9 @@ export default function OnboardingWizard() {
       const errorMessages: Record<string, string> = {
         azure_no_subscription: 'Could not connect to Azure. Make sure you have an active Azure subscription with your Microsoft account.',
         azure_denied: 'Azure sign-in was denied. Please try again and accept the permissions.',
-        azure_error: `Azure sign-in failed${errorCode ? ` (${errorCode})` : ''}. ${errorDetail || 'Please try again.'}`,
+        azure_error: `Azure sign-in failed${errorCode ? ` (${errorCode})` : ''}. ${errorDetail || 'Please sign in with a work or school account (not a personal @outlook.com account).'}`,
         azure_consent_required: 'Azure requires additional consent. Please try again and accept all permissions when prompted.',
-        azure_personal_account: 'Your Microsoft account could not get Azure management access. Make sure you have an active Azure subscription.',
+        azure_personal_account: 'Azure requires a work or school account. Personal Microsoft accounts (@outlook.com, @hotmail.com) cannot manage Azure resources. Please sign in with your organization account.',
         token_exchange: 'Sign-in failed. Please try again.',
         missing_code: 'Sign-in was incomplete. Please try again.',
         invalid_state: 'Sign-in verification failed. Please try again.',

--- a/apps/web/src/lib/providers/token-store.ts
+++ b/apps/web/src/lib/providers/token-store.ts
@@ -85,13 +85,13 @@ export async function refreshProviderToken(userId: string, provider: string) {
   if (provider === 'azure') {
     const tenantData = await getProviderToken(userId, 'azure_tenant');
     const tenantId = tenantData?.accessToken ?? 'organizations'; // accessToken field stores the tenant ID
-    refreshUrl = `https://login.microsoftonline.com/${tenantId}/oauth2/token`;
+    refreshUrl = `https://login.microsoftonline.com/${tenantId}/oauth2/v2.0/token`;
     refreshBody = {
       grant_type: 'refresh_token',
       refresh_token: existing.refreshToken,
       client_id: process.env.AZURE_CLIENT_ID!.trim(),
       client_secret: process.env.AZURE_CLIENT_SECRET!.trim(),
-      resource: 'https://management.azure.com/',
+      scope: 'https://management.azure.com/.default offline_access',
     };
   } else {
     const config = getRefreshConfig(provider, existing.refreshToken);
@@ -118,13 +118,13 @@ function getRefreshConfig(provider: string, refreshToken: string): { url: string
   switch (provider) {
     case 'azure':
       return {
-        url: 'https://login.microsoftonline.com/common/oauth2/token',
+        url: 'https://login.microsoftonline.com/organizations/oauth2/v2.0/token',
         body: {
           grant_type: 'refresh_token',
           refresh_token: refreshToken,
           client_id: process.env.AZURE_CLIENT_ID!.trim(),
           client_secret: process.env.AZURE_CLIENT_SECRET!.trim(),
-          resource: 'https://management.azure.com/',
+          scope: 'https://management.azure.com/.default offline_access',
         },
       };
     case 'digitalocean':


### PR DESCRIPTION
## Problem
Personal Microsoft accounts cannot get ARM tokens through ANY OAuth flow:
- v2.0 + converged app → `invalid_scope` (ARM scopes not supported)
- v1.0 + converged app → `AADSTS90027` (v1.0 not supported on MSA tenant)
- v2.0 + multi-org app → works, but rejects personal accounts at sign-in

The two-step tenant discovery approach was an attempt to work around this, but it fundamentally can't work because ARM doesn't support personal accounts.

## Fix
Simplified the entire flow:
- Changed app registration to `AzureADMultipleOrgs` (work/school only)
- Single OAuth redirect through `/organizations` endpoint with ARM scope
- Removed the two-step discover/consent dance (91 lines deleted)
- Users sign in with a work/school account (e.g. admin@shiftworker.ai)
- Updated error messages to guide users toward work accounts
- Token refresh updated to v2.0 with `.default` scope