### PR TITLE
fix: catch MissingSubscriptionRegistration in any provisioning step

### DIFF
--- a/apps/web/src/lib/vm/provisioning-steps.ts
+++ b/apps/web/src/lib/vm/provisioning-steps.ts
@@ -121,6 +121,31 @@ export async function advanceProvisioning(assistant: Assistant): Promise<Assista
   const token = await getUserToken(assistant.user_id);
   const rgName = `${RG_PREFIX}${assistant.id.split('-')[0]}`;
 
+  try {
+    return await executeStep(assistant, step, pd, token, rgName);
+  } catch (err) {
+    // If any step fails due to missing resource provider registration,
+    // fall back to the register_providers step to fix it automatically.
+    const errMsg = err instanceof Error ? err.message : String(err);
+    if (errMsg.includes('MissingSubscriptionRegistration') && step !== 'register_providers') {
+      console.warn(`[provisioning] ${step} failed with MissingSubscriptionRegistration, falling back to register_providers`);
+      return await updateAssistant(assistant.id, {
+        provisioning_step: 'register_providers' as ProvisioningStep,
+        provisioning_data: pd as any,
+      });
+    }
+    throw err;
+  }
+}
+
+async function executeStep(
+  assistant: Assistant,
+  step: ProvisioningStep,
+  pd: Record<string, any>,
+  token: string,
+  rgName: string,
+): Promise<Assistant> {
+
   switch (step) {
     case 'validate': {
       // If a subscription was pre-selected during onboarding, use it directly


### PR DESCRIPTION
## Problem
The existing stuck assistant was created before the `register_providers` step was added (PR #294). It's on the `create_nsg` step which keeps failing with `MissingSubscriptionRegistration` because it never went through `register_providers`.

## Fix
Wrapped the step execution in a try/catch. If any step fails with `MissingSubscriptionRegistration`, it automatically falls back to the `register_providers` step. This self-heals stuck assistants and is a safety net for any step that hits unregistered providers.