### PR TITLE
fix: validate Telegram bots exist before attaching to assistant

### DIFF
--- a/apps/web/src/lib/messaging/__tests__/telegram-bot-factory.test.ts
+++ b/apps/web/src/lib/messaging/__tests__/telegram-bot-factory.test.ts
@@ -33,6 +33,18 @@ process.env.TELEGRAM_API_ID = '12345';
 process.env.TELEGRAM_API_HASH = 'testhash';
 process.env.TELEGRAM_SESSION_STRING = 'testsession';
 
+// Mock global fetch for verifyBotToken
+const originalFetch = global.fetch;
+global.fetch = vi.fn().mockImplementation((url: string) => {
+  if (typeof url === 'string' && url.includes('api.telegram.org')) {
+    return Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({ ok: true, result: { username: 'sw_test_bot' } }),
+    });
+  }
+  return originalFetch(url);
+}) as any;
+
 import { createTelegramBot } from '../telegram-bot-factory';
 
 describe('telegram-bot-factory', () => {

--- a/apps/web/src/lib/messaging/setup.ts
+++ b/apps/web/src/lib/messaging/setup.ts
@@ -1,4 +1,4 @@
-import { createTelegramBot, deleteTelegramBot } from './telegram-bot-factory';
+import { createTelegramBot, deleteTelegramBot, verifyBotToken } from './telegram-bot-factory';
 import { createClient } from '../supabase/server';
 
 export interface MessagingSetupResult {
@@ -73,24 +73,40 @@ export async function setupTelegramForAssistant(
 
   // Check if bot already exists for this assistant
   if (assistant.telegram_bot_username && assistant.telegram_bot_token) {
-    // Re-configure sidecar with existing bot (in case of restart)
-    try {
-      await callSidecar(
-        assistant.ip_address,
-        assistant.sidecar_token,
-        'telegram',
-        { botToken: assistant.telegram_bot_token },
-      );
-    } catch {
-      // Best-effort reconfiguration
-    }
+    // Verify the bot still exists on Telegram before reusing
+    const verified = await verifyBotToken(assistant.telegram_bot_token);
+    if (!verified) {
+      // Bot token is stale/invalid - clear it and create a new one
+      console.warn(`Stale Telegram bot @${assistant.telegram_bot_username} - clearing and recreating`);
+      await (supabase as any)
+        .from('assistants')
+        .update({
+          telegram_bot_username: null,
+          telegram_bot_token: null,
+          updated_at: new Date().toISOString(),
+        })
+        .eq('id', assistantId);
+      // Fall through to create a new bot below
+    } else {
+      // Bot is valid - re-configure sidecar with existing bot (in case of restart)
+      try {
+        await callSidecar(
+          assistant.ip_address,
+          assistant.sidecar_token,
+          'telegram',
+          { botToken: assistant.telegram_bot_token },
+        );
+      } catch {
+        // Best-effort reconfiguration
+      }
 
-    return {
-      platform: 'telegram',
-      status: 'configured',
-      botUsername: assistant.telegram_bot_username,
-      botLink: `https://t.me/${assistant.telegram_bot_username}`,
-    };
+      return {
+        platform: 'telegram',
+        status: 'configured',
+        botUsername: verified,
+        botLink: `https://t.me/${verified}`,
+      };
+    }
   }
 
   try {
@@ -102,33 +118,48 @@ export async function setupTelegramForAssistant(
       .single();
 
     if (userRow?.telegram_bot_token) {
-      // Use the pre-created bot — configure sidecar and copy to assistant
-      try {
-        await callSidecar(
-          assistant.ip_address,
-          assistant.sidecar_token,
-          'telegram',
-          { botToken: userRow.telegram_bot_token },
-        );
-      } catch {
-        // Best-effort sidecar config
+      // Verify the pre-created bot still exists
+      const verifiedUser = await verifyBotToken(userRow.telegram_bot_token);
+      if (!verifiedUser) {
+        // Stale bot - clear from users table and fall through to create new
+        console.warn(`Stale pre-created Telegram bot @${userRow.telegram_bot_username} - clearing`);
+        await (supabase as any)
+          .from('users')
+          .update({
+            telegram_bot_username: null,
+            telegram_bot_token: null,
+          })
+          .eq('id', userId);
+        // Fall through to BotFather creation below
+      } else {
+        // Use the verified pre-created bot
+        try {
+          await callSidecar(
+            assistant.ip_address,
+            assistant.sidecar_token,
+            'telegram',
+            { botToken: userRow.telegram_bot_token },
+          );
+        } catch {
+          // Best-effort sidecar config
+        }
+
+        await (supabase as any)
+          .from('assistants')
+          .update({
+            telegram_bot_username: verifiedUser,
+            telegram_bot_token: userRow.telegram_bot_token,
+            updated_at: new Date().toISOString(),
+          })
+          .eq('id', assistantId);
+
+        return {
+          platform: 'telegram',
+          status: 'configured',
+          botUsername: verifiedUser,
+          botLink: `https://t.me/${verifiedUser}`,
+        };
       }
-
-      await (supabase as any)
-        .from('assistants')
-        .update({
-          telegram_bot_username: userRow.telegram_bot_username,
-          telegram_bot_token: userRow.telegram_bot_token,
-          updated_at: new Date().toISOString(),
-        })
-        .eq('id', assistantId);
-
-      return {
-        platform: 'telegram',
-        status: 'configured',
-        botUsername: userRow.telegram_bot_username,
-        botLink: `https://t.me/${userRow.telegram_bot_username}`,
-      };
     }
 
     // Check if BotFather automation is configured

--- a/apps/web/src/lib/messaging/telegram-bot-factory.ts
+++ b/apps/web/src/lib/messaging/telegram-bot-factory.ts
@@ -125,8 +125,14 @@ export async function createTelegramBot(
   const result = await attemptBotCreation(tg, botFather, botUsername, botName);
 
   if (result.token) {
-    await configureBotSettings(tg, botFather, botUsername);
-    return { botUsername, botToken: result.token, botDisplayName: botName };
+    // Verify the bot actually exists on Telegram before returning
+    const verifiedUsername = await verifyBotToken(result.token);
+    if (!verifiedUsername) {
+      console.error(`Bot @${botUsername} token received but getMe failed - bot may not exist`);
+      throw new Error('telegram_bot_creation_failed');
+    }
+    await configureBotSettings(tg, botFather, verifiedUsername);
+    return { botUsername: verifiedUsername, botToken: result.token, botDisplayName: botName };
   }
 
   // Username taken - try to recover the existing bot's token
@@ -142,9 +148,14 @@ export async function createTelegramBot(
     const fallbackResult = await attemptBotCreation(tg, botFather, fallbackUsername, botName);
 
     if (fallbackResult.token) {
-      await configureBotSettings(tg, botFather, fallbackUsername);
+      const verifiedFallback = await verifyBotToken(fallbackResult.token);
+      if (!verifiedFallback) {
+        console.error(`Fallback bot @${fallbackUsername} token received but getMe failed`);
+        throw new Error('telegram_bot_creation_failed');
+      }
+      await configureBotSettings(tg, botFather, verifiedFallback);
       return {
-        botUsername: fallbackUsername,
+        botUsername: verifiedFallback,
         botToken: fallbackResult.token,
         botDisplayName: botName,
       };
@@ -221,4 +232,24 @@ export async function deleteTelegramBot(botUsername: string): Promise<void> {
 
 function sleep(ms: number): Promise<void> {
   return new Promise((r) => setTimeout(r, ms));
+}
+
+/**
+ * Verify a bot token is valid by calling Telegram's getMe API.
+ * Returns the bot username if valid, null if the bot doesn't exist.
+ */
+export async function verifyBotToken(token: string): Promise<string | null> {
+  try {
+    const res = await fetch(`https://api.telegram.org/bot${token}/getMe`, {
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!res.ok) return null;
+    const data = await res.json();
+    if (data.ok && data.result?.username) {
+      return data.result.username;
+    }
+    return null;
+  } catch {
+    return null;
+  }
 }


### PR DESCRIPTION
## Problem
ShiftWorker can attach a stale/non-existent Telegram bot to an assistant. The bot username gets saved in the DB even when BotFather creation fails silently, and then users get a 't.me/bot_name' link that says 'this user doesn't seem to exist'.

## Fix
Added `verifyBotToken()` - calls Telegram's `getMe` API to confirm a bot token is valid and the bot actually exists.

Validation in three places:
1. **After BotFather creation** - verify the bot exists before saving the token
2. **Reusing stored assistant bot** - verify before reconfiguring sidecar; clear stale bots
3. **Reusing pre-created user bot** - verify before copying to assistant; clear stale bots

When a stale bot is detected, it's cleared from the DB so the next setup attempt creates a fresh bot instead of reusing the broken one.