### PR TITLE
fix: don't show false 'token expired' warning when AI is working

### DIFF
--- a/apps/web/src/app/dashboard/components/ai-model-card.tsx
+++ b/apps/web/src/app/dashboard/components/ai-model-card.tsx
@@ -18,25 +18,36 @@ export function AiModelCard({
   provider,
   apiKey,
   disabled = false,
+  assistantActive = false,
 }: {
   provider?: string | null;
   apiKey?: string | null;
   disabled?: boolean;
+  assistantActive?: boolean;
 }) {
   const configured = !!provider && !!apiKey;
-  const providerKnown = !!provider && !apiKey;
+  // Only show "expired" if the provider is set, key is missing, AND the assistant isn't actively working
+  const providerKnown = !!provider && !apiKey && !assistantActive;
+  // If provider is set and assistant is active, treat as configured (token may be on sidecar)
+  const effectivelyConfigured = configured || (!!provider && assistantActive);
   const label = provider ? PROVIDER_LABELS[provider] ?? provider : null;
 
   return (
     <div className="rounded-xl border border-slate-800 bg-slate-900 p-6">
       <h2 className="text-lg font-semibold text-white mb-1">AI Model</h2>
 
-      {configured ? (
+      {effectivelyConfigured ? (
         <>
           <p className="text-2xl font-bold text-indigo-400 mb-2">{label}</p>
-          <p className="text-sm text-slate-400 mb-4 font-mono truncate">
-            Key: {maskKey(apiKey!)}
-          </p>
+          {apiKey ? (
+            <p className="text-sm text-slate-400 mb-4 font-mono truncate">
+              Key: {maskKey(apiKey!)}
+            </p>
+          ) : (
+            <p className="text-sm text-green-400 mb-4">
+              Connected and working
+            </p>
+          )}
         </>
       ) : providerKnown ? (
         <>
@@ -56,14 +67,14 @@ export function AiModelCard({
 
       {disabled ? (
         <span className="inline-block rounded-lg bg-slate-700 px-4 py-2 text-sm text-slate-500 cursor-not-allowed">
-          {configured ? "Change" : providerKnown ? "Reconnect" : "Set up AI provider"}
+          {effectivelyConfigured ? "Change" : providerKnown ? "Reconnect" : "Set up AI provider"}
         </span>
       ) : (
         <Link
           href="/dashboard/settings?section=ai"
           className="inline-block rounded-lg bg-indigo-600 px-4 py-2 text-sm text-white hover:bg-indigo-500"
         >
-          {configured ? "Change" : providerKnown ? "Reconnect" : "Set up AI provider"}
+          {effectivelyConfigured ? "Change" : providerKnown ? "Reconnect" : "Set up AI provider"}
         </Link>
       )}
     </div>

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -111,7 +111,7 @@ async function DashboardContent({
 
           {/* Col 2: AI Model + Usage stacked */}
           <div className="space-y-6">
-            <AiModelCard provider={aiProvider} apiKey={aiApiKey} disabled={disableActions} />
+            <AiModelCard provider={aiProvider} apiKey={aiApiKey} disabled={disableActions} assistantActive={isActive} />
             <UsageCard />
           </div>
 


### PR DESCRIPTION
## Problem
Dashboard shows 'Token expired or missing. Please reconnect.' for GitHub Copilot even when the assistant is actively working and responding. The OAuth token lives on the sidecar but isn't always retrievable from the dashboard's provider_tokens table.

## Fix
Added `assistantActive` prop to `AiModelCard`. If the provider is set and the assistant is online, show 'Connected and working' instead of the false expired warning. The scary 'expired' message only shows when the assistant isn't active.